### PR TITLE
HandleWrap class and jerryscript object free callback to sync object lifecycle

### DIFF
--- a/src/iotjs_binding.cpp
+++ b/src/iotjs_binding.cpp
@@ -179,6 +179,11 @@ uintptr_t JObject::GetNative() {
   return ptr;
 }
 
+void JObject::SetFreeCallback(jerry_object_free_callback_t freecb) {
+  assert(IsObject());
+  jerry_api_set_object_free_callback(_obj_val.v_object, freecb);
+}
+
 JObject JObject::Call(JObject* this_, JObject** args, uint16_t argv) {
   assert(IsFunction());
 

--- a/src/iotjs_binding.h
+++ b/src/iotjs_binding.h
@@ -100,6 +100,7 @@ class JObject {
   void SetProperty(const char* name, JObject* val);
   JObject GetProperty(const char* name);
   void SetNative(uintptr_t ptr);
+  void SetFreeCallback(jerry_object_free_callback_t freecb);
   JObject Call(JObject* this_, JObject** args, uint16_t argv);
   uintptr_t GetNative();
 

--- a/src/iotjs_handlerwrap.cpp
+++ b/src/iotjs_handlerwrap.cpp
@@ -1,0 +1,38 @@
+/* Copyright 2015 Samsung Electronics Co., Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "iotjs_handlewrap.h"
+
+
+namespace iotjs {
+
+static void ObjectFreeCallback(const uintptr_t native_p) {
+  // native_p is always non-null value
+  HandleWrap* wrap = reinterpret_cast<HandleWrap*>(native_p);
+  delete wrap;
+}
+
+HandleWrap::HandleWrap(JObject* othis, uv_handle_t* handle)
+    : __handle(handle) {
+  __handle->data = this;
+  othis->SetNative((uintptr_t)this);
+  othis->SetFreeCallback(ObjectFreeCallback);
+}
+
+HandleWrap::~HandleWrap() {
+  __handle->data = NULL;
+}
+
+} // namespace iotjs

--- a/src/iotjs_handlewrap.h
+++ b/src/iotjs_handlewrap.h
@@ -1,0 +1,37 @@
+/* Copyright 2015 Samsung Electronics Co., Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef IOTJS_HANDLEWRAP_H
+#define IOTJS_HANDLEWRAP_H
+
+#include "uv.h"
+
+#include "iotjs_binding.h"
+
+
+namespace iotjs {
+
+class HandleWrap {
+ public:
+  HandleWrap(JObject* othis, uv_handle_t* handle);
+  virtual ~HandleWrap();
+
+ private:
+  uv_handle_t* __handle;
+};
+
+} // namespace iotjs
+
+#endif /* IOTJS_HANDLEWRAP_H */


### PR DESCRIPTION
New HandleWrap class for wrapping handle of libuv.
Use object free callback of jerry to sync object lifecycle that was created in native.
Apply to TimerWrap class.

IoT.js-DCO-1.0-Signed-off-by: SaeHie Park saehie.park@samsung.com
