### PR TITLE
Timer test callback function fix.

### DIFF
--- a/test/test_timer.js
+++ b/test/test_timer.js
@@ -16,18 +16,20 @@
 var Timer = process.binding(process.binding.timer);
 
 var timerobj = new Timer();
-timerobj.start(500, 0, function() {
+var cbone = function() {
   console.log("JS Timer fired");
-});
+};
+timerobj.start(500, 0, cbone);
 console.log("JS Timer timeout in 500 msec...");
 
 var repeat_cnt = 1;
 var timerobj2 = new Timer();
-timerobj2.start(400,100, function() {
+var cbrepeat = function() {
   console.log("Js Timer repeat #" + repeat_cnt);
   if (repeat_cnt >= 5) {
     timerobj2.stop();
   }
   repeat_cnt++;
-});
+};
+timerobj2.start(400, 100, cbrepeat);
 console.log("JS Timer repeat in 400 msec, 100 msec interval, 5 times...");


### PR DESCRIPTION
As current timer test code callback function is not referenced by any global objects,
it is GCed in some machines, like 32bits. To avoid this, reference callback functions to
global variables.

IoT.js-DCO-1.0-Signed-off-by: SaeHie Park saehie.park@samsung.com
