### PR TITLE
Define Module list in one place

### DIFF
--- a/src/iotjs_module.cpp
+++ b/src/iotjs_module.cpp
@@ -33,29 +33,21 @@ static Module _modules[MODULE_COUNT];
   _modules[MODULE_ ## upper].module = NULL; \
   _modules[MODULE_ ## upper].fn_register = Init ## Camel;
 
+void InitModuleList() {
+  MAP_MODULE_LIST(INIT_MODULE_LIST)
+}
+#undef INIT_MODULE_LIST
+
 
 #define CLENUP_MODULE_LIST(upper, Camel, lower) \
   if (_modules[MODULE_ ## upper].module) \
     delete _modules[MODULE_ ## upper].module; \
   _modules[MODULE_ ## upper].module = NULL;
 
-
-#define MAP_MODULE_LIST(F) \
-  F(BUFFER, Buffer, buffer) \
-  F(CONSOLE, Console, console) \
-  F(FS, Fs, fs) \
-  F(PROCESS, Process, process) \
-  F(TIMER, Timer, timer)
-
-
-void InitModuleList() {
-  MAP_MODULE_LIST(INIT_MODULE_LIST)
-}
-
-
 void CleanupModuleList() {
   MAP_MODULE_LIST(CLENUP_MODULE_LIST)
 }
+#undef CLENUP_MODULE_LIST
 
 
 Module* GetBuiltinModule(ModuleKind kind) {

--- a/src/iotjs_module.h
+++ b/src/iotjs_module.h
@@ -23,14 +23,23 @@ namespace iotjs {
 
 typedef JObject* (*register_func)();
 
+// List of builtin modules
+#define MAP_MODULE_LIST(F) \
+  F(BUFFER, Buffer, buffer) \
+  F(CONSOLE, Console, console) \
+  F(FS, Fs, fs) \
+  F(PROCESS, Process, process) \
+  F(TIMER, Timer, timer)
+
+
+#define ENUMDEF_MODULE_LIST(upper, Camel, lower) \
+  MODULE_ ## upper,
+
 enum ModuleKind {
-  MODULE_BUFFER,
-  MODULE_CONSOLE,
-  MODULE_FS,
-  MODULE_PROCESS,
-  MODULE_TIMER,
-  MODULE_COUNT,
+  MAP_MODULE_LIST(ENUMDEF_MODULE_LIST)
+  MODULE_COUNT
 };
+#undef ENUMDEF_MODULE_LIST
 
 
 struct Module {

--- a/src/iotjs_module_process.cpp
+++ b/src/iotjs_module_process.cpp
@@ -121,11 +121,12 @@ JObject* InitProcess() {
 
     // Binding module id.
     JObject jbinding = process->GetProperty("binding");
-    jbinding.SetProperty("buffer", JVal::Int(MODULE_BUFFER));
-    jbinding.SetProperty("console", JVal::Int(MODULE_CONSOLE));
-    jbinding.SetProperty("fs", JVal::Int(MODULE_FS));
-    jbinding.SetProperty("process", JVal::Int(MODULE_PROCESS));
-    jbinding.SetProperty("timer", JVal::Int(MODULE_TIMER));
+
+#define ENUMDEF_MODULE_LIST(upper, Camel, lower) \
+    jbinding.SetProperty(# lower, JVal::Int(MODULE_ ## upper));
+
+    MAP_MODULE_LIST(ENUMDEF_MODULE_LIST)
+#undef ENUMDEF_MODULE_LIST
 
     module->module = process;
   }


### PR DESCRIPTION
Define Modules list in one iotjs_module.h file with macro  which was separately listed in
iotjs_module.cpp, iotjs_module.h, iotjs_module_process.cpp

IoT.js-DCO-1.0-Signed-off-by: SaeHie Park saehie.park@samsung.com
