### PR TITLE
Improve target flags handling

### DIFF
--- a/cmake/config/arm-nuttx.cmake
+++ b/cmake/config/arm-nuttx.cmake
@@ -27,21 +27,26 @@ CMAKE_FORCE_CXX_COMPILER(${EXTERNAL_CMAKE_CXX_COMPILER} GNU)
 set(NO_PTHREAD YES)
 set(BUILD_TO_LIB YES)
 
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -D__NUTTX__")
+set(FLAGS_COMMON -mcpu=cortex-m4
+                 -mthumb
+                 -march=armv7e-m
+                 -mfpu=fpv4-sp-d16
+                 -mfloat-abi=hard
+                 -D__NUTTX__
+                 -Os
+                 -fno-strict-aliasing
+                 -fno-strength-reduce
+                 -fomit-frame-pointer)
+
+foreach(FLAG ${FLAGS_COMMON})
+  set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} ${FLAG}")
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${FLAG}")
+endforeach()
 
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fpermissive")
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fno-exceptions")
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fno-builtin")
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fno-rtti")
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -mcpu=cortex-m4")
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -mthumb")
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -march=armv7e-m")
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -mfpu=fpv4-sp-d16")
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -mfloat-abi=hard")
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Os")
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fno-strict-aliasing")
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fno-strength-reduce")
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fomit-frame-pointer")
 
 set(TARGET_INC ${TARGET_INC} "${NUTTX_HOME}/include")
 set(TARGET_INC ${TARGET_INC} "${NUTTX_HOME}/include/cxx")

--- a/cmake/config/i686-linux.cmake
+++ b/cmake/config/i686-linux.cmake
@@ -17,9 +17,14 @@ include(CMakeForceCompiler)
 set(CMAKE_SYSTEM_NAME Linux)
 set(CMAKE_SYSTEM_PROCESSOR x86)
 
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -D__LINUX__")
+set(FLAGS_COMMON -D__LINUX__
+                 -fno-builtin)
+
+foreach(FLAG ${FLAGS_COMMON})
+  set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} ${FLAG}")
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${FLAG}")
+endforeach()
 
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fpermissive")
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fno-exceptions")
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fno-builtin")
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fno-rtti")

--- a/cmake/config/x86_64-darwin.cmake
+++ b/cmake/config/x86_64-darwin.cmake
@@ -17,9 +17,14 @@ include(CMakeForceCompiler)
 set(CMAKE_SYSTEM_NAME Darwin)
 set(CMAKE_SYSTEM_PROCESSOR x86_64)
 
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -D__DARWIN__")
+set(FLAGS_COMMON -D__DARWIN__
+                 -fno-builtin)
+
+foreach(FLAG ${FLAGS_COMMON})
+  set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} ${FLAG}")
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${FLAG}")
+endforeach()
 
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fpermissive")
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fno-exceptions")
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fno-builtin")
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fno-rtti")

--- a/cmake/config/x86_64-linux.cmake
+++ b/cmake/config/x86_64-linux.cmake
@@ -17,9 +17,14 @@ include(CMakeForceCompiler)
 set(CMAKE_SYSTEM_NAME Linux)
 set(CMAKE_SYSTEM_PROCESSOR x86_64)
 
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -D__LINUX__")
+set(FLAGS_COMMON -D__LINUX__
+                 -fno-builtin)
+
+foreach(FLAG ${FLAGS_COMMON})
+  set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} ${FLAG}")
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${FLAG}")
+endforeach()
 
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fpermissive")
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fno-exceptions")
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fno-builtin")
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fno-rtti")


### PR DESCRIPTION
Set both the CMAKE_C_FLAGS and CMAKE_CXX_FLAGS in the toolchain config
files.

IoT.js-DCO-1.0-Signed-off-by: Peter Gal pgal.u-szeged@partner.samsung.com
