### PR TITLE
Disable JObject assignment operation

### DIFF
--- a/cmake/config.cmake
+++ b/cmake/config.cmake
@@ -18,7 +18,7 @@ set(CC ${CMAKE_C_COMPILER})
 set(CXX ${CMAKE_CXX_COMPILER})
 
 set(CFLAGS ${CMAKE_CXX_FLAGS})
-#set(CFLAGS "${CFLAGS} -flto")
+set(CFLAGS "${CFLAGS} -std=c++11")
 if (NOT(${NO_PTHREAD}))
     set(CFLAGS "${CFLAGS} -pthread -Wall")
 endif()

--- a/src/iotjs_binding.h
+++ b/src/iotjs_binding.h
@@ -145,6 +145,9 @@ class JObject {
  private:
   JRawValueType _obj_val;
   bool _unref_at_close;
+
+  // disable assignment.
+  JObject& operator=(const JObject& rhs) = delete;
 };
 
 


### PR DESCRIPTION
To prevent reassignment of JObject instance.
For instance, below example create JObject instance `a` and reassign other value to `a` this may cause reference count problem. 

```
JObject a(...);
a = b.GetProperty(...);
```

By this patch will forbid such assignment.
