### PR TITLE
Close not a half opened socket after receive EOF from the other side.

### DIFF
--- a/src/js/stream_readable.js
+++ b/src/js/stream_readable.js
@@ -33,9 +33,6 @@ function ReadableState(options) {
   // true if in flowing mode.
   this.flowing = false;
 
-  // become `true` when forcely finished.
-  this.finished = false;
-
   // become `true` when the stream meet EOF.
   this.ended = false;
 
@@ -125,10 +122,6 @@ Readable.prototype.error = function(error) {
 Readable.prototype.push = function(chunk, encoding) {
   var state = this._readableState;
 
-  if (state.finished) {
-    return;
-  }
-
   if (!util.isString(chunk) &&
       !util.isBuffer(chunk) &&
       !util.isNull(chunk)) {
@@ -151,20 +144,6 @@ Readable.prototype.push = function(chunk, encoding) {
     }
   }
 };
-
-
-Readable.prototype.finishRead = function() {
-  var state = this._readableState;
-
-  // set finished
-  if (state.finished) {
-    return;
-  }
-  state.finished = true;
-  state.ended = true;
-
-  emitEnd(this);
-}
 
 
 function readBuffer(stream, n) {

--- a/src/js/stream_writable.js
+++ b/src/js/stream_writable.js
@@ -182,6 +182,7 @@ function doWrite(stream, chunk, callback) {
 }
 
 
+// No more data to write. if this stream is being finishing, emit 'finish'.
 function onEmptyBuffer(stream) {
   var state = stream._writableState;
   if (state.ending) {
@@ -190,14 +191,20 @@ function onEmptyBuffer(stream) {
 }
 
 
+// Writable.prototype.end() was called. register callback for 'finish' event.
+// After finish writing out buffered data, 'finish' event will be fired.
 function endWritable(stream, callback) {
   var state = stream._writableState;
   state.ending = true;
   if (callback) {
     stream.once('finish', callback);
   }
+  // write out buffered data.
+  writeBuffered(stream);
 }
 
+
+// Emit 'finish' event to notify this stream is finished.
 function emitFinish(stream) {
   var state = stream._writableState;
   if (!state.ended) {
@@ -205,6 +212,7 @@ function emitFinish(stream) {
     stream.emit('finish')
   }
 }
+
 
 module.exports = Writable;
 

--- a/test/run_pass/test_net.js
+++ b/test/run_pass/test_net.js
@@ -18,8 +18,9 @@ var assert = require('assert');
 
 
 var server = net.createServer();
+var port = 1235;
 
-server.listen(1234, 5);
+server.listen(port, 5);
 
 server.on('connection', function(socket) {
   socket.on('data', function(data) {
@@ -34,13 +35,16 @@ server.on('connection', function(socket) {
 var socket = new net.Socket();
 var msg = "";
 
-socket.connect(1234, "127.0.0.1");
-socket.end("Hello IoT.js");
+socket.connect(port, "127.0.0.1");
+socket.write("Hello IoT.js");
 
 socket.on('data', function(data) {
   msg += data;
 });
 
+socket.on('end', function() {
+  socket.end();
+});
 
 process.on('exit', function(code) {
   assert.equal(code, 0);


### PR DESCRIPTION
Add 'allowHalfOpen' attribute for socket.
Close not allowed half open socket when its readable stream gets EOF - means the other side socket shutdown its writable stream. because the socket is not allowed half open and its readable stream is ended, it also close its writable stream resulting closing connection.
