### PR TITLE
Add gpio control and related codes.

### DIFF
--- a/cmake/config/arm-nuttx.cmake
+++ b/cmake/config/arm-nuttx.cmake
@@ -26,6 +26,7 @@ CMAKE_FORCE_CXX_COMPILER(${EXTERNAL_CMAKE_CXX_COMPILER} GNU)
 
 set(NO_PTHREAD YES)
 set(BUILD_TO_LIB YES)
+set(DEVICE_DEPENDS "nuttx-stm32f4disco")
 
 set(FLAGS_COMMON -mcpu=cortex-m4
                  -mthumb

--- a/cmake/config/i686-linux.cmake
+++ b/cmake/config/i686-linux.cmake
@@ -17,6 +17,8 @@ include(CMakeForceCompiler)
 set(CMAKE_SYSTEM_NAME Linux)
 set(CMAKE_SYSTEM_PROCESSOR x86)
 
+set(DEVICE_DEPENDS "linux-x86")
+
 set(FLAGS_COMMON -D__LINUX__
                  -D__i686__
                  -fno-builtin)

--- a/cmake/config/x86_64-linux.cmake
+++ b/cmake/config/x86_64-linux.cmake
@@ -17,6 +17,8 @@ include(CMakeForceCompiler)
 set(CMAKE_SYSTEM_NAME Linux)
 set(CMAKE_SYSTEM_PROCESSOR x86_64)
 
+set(DEVICE_DEPENDS "linux-x86")
+
 set(FLAGS_COMMON -D__LINUX__
                  -D__x86_64__
                  -fno-builtin)

--- a/cmake/iotjs.cmake
+++ b/cmake/iotjs.cmake
@@ -14,7 +14,8 @@
 
 cmake_minimum_required(VERSION 2.8)
 
-file(GLOB LIB_IOTJS_SRC ${SRC_ROOT}/*.cpp)
+file(GLOB LIB_IOTJS_SRC ${SRC_ROOT}/*.cpp
+                        ${SRC_ROOT}/device/${DEVICE_DEPENDS}/*.cpp)
 
 set(LIB_IOTJS_CFLAGS ${CFLAGS})
 set(LIB_IOTJS_INCDIR ${TARGET_INC}

--- a/src/device/linux-x86/gpioctl_linux_x86.cpp
+++ b/src/device/linux-x86/gpioctl_linux_x86.cpp
@@ -13,26 +13,25 @@
  * limitations under the License.
  */
 
-#ifndef IOTJS_MODULE_PROCESS_H
-#define IOTJS_MODULE_PROCESS_H
+#if defined(__LINUX__)
 
-#include "iotjs_binding.h"
+#include "iotjs_def.h"
+#include "iotjs_objectwrap.h"
+#include "iotjs_module_gpioctl.h"
 
 
 namespace iotjs {
 
-void UncaughtException(JObject& jexception);
+/*
+ * Use default dummy for linux-x86
+ */
 
-void ProcessEmitExit(int code);
+GpioControl* GpioControl::Create(JObject& jgpioctl)
+{
+  return new GpioControl(jgpioctl);
+}
 
-bool ProcessNextTick();
-
-JObject MakeCallback(JObject& function, JObject& this_, JArgList& args);
-
-JObject* InitProcess();
-
-void SetProcessIotjs(JObject* process);
 
 } // namespace iotjs
 
-#endif /* IOTJS_MODULE_PROCESS_H */
+#endif // __NUTTX__

--- a/src/device/nuttx-stm32f4disco/gpioctl_nuttx_stm32f4disco.cpp
+++ b/src/device/nuttx-stm32f4disco/gpioctl_nuttx_stm32f4disco.cpp
@@ -1,0 +1,111 @@
+/* Copyright 2015 Samsung Electronics Co., Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#if defined(__NUTTX__)
+
+#include "iotjs_def.h"
+#include "iotjs_objectwrap.h"
+#include "iotjs_module_gpioctl.h"
+
+#include <unistd.h>
+#include <fcntl.h>
+#include <nuttx/gpio.h>
+#include <sys/ioctl.h>
+
+
+namespace iotjs {
+
+
+class GpioControlInst : public GpioControl {
+public:
+  explicit GpioControlInst(JObject& jgpioctl);
+  virtual int Initialize(void);
+  virtual void Release(void);
+  virtual int PinMode(uint32_t portpin);
+  virtual int WritePin(uint32_t portpin, uint8_t data);
+  virtual int ReadPin(uint32_t portpin, uint8_t* pdata);
+};
+
+//-----------------------------------------------------------------------------
+
+GpioControl* GpioControl::Create(JObject& jgpioctl)
+{
+  return new GpioControlInst(jgpioctl);
+}
+
+
+GpioControlInst::GpioControlInst(JObject& jgpioctl)
+    : GpioControl(jgpioctl) {
+}
+
+
+int GpioControlInst::Initialize(void) {
+  if (_fd > 0 )
+    return IOTJS_GPIO_INUSE;
+
+  const char* devfilepath = "/dev/gpio";
+  _fd = open(devfilepath, O_RDWR);
+  DDDLOG("gpio> %s : fd(%d)", devfilepath, _fd);
+  return _fd;
+}
+
+void GpioControlInst::Release(void) {
+  if (_fd > 0) {
+    close(_fd);
+  }
+  _fd = 0;
+}
+
+
+int GpioControlInst::PinMode(uint32_t portpin) {
+  if (_fd > 0) {
+    struct gpioioctl_config_s cdata;
+    cdata.port = portpin;
+    return ioctl(_fd, GPIOIOCTL_CONFIG, (long unsigned int)&cdata);
+  }
+  return IOTJS_GPIO_NOTINITED;
+}
+
+
+int GpioControlInst::WritePin(uint32_t portpin, uint8_t data) {
+  if (_fd > 0) {
+    struct gpioioctl_write_s wdata;
+    wdata.port = portpin;
+    wdata.data = data;
+    return ioctl(_fd, GPIOIOCTL_WRITE, (long unsigned int)&wdata);
+  }
+  return IOTJS_GPIO_NOTINITED;
+}
+
+
+int GpioControlInst::ReadPin(uint32_t portpin, uint8_t* pdata) {
+  if (_fd > 0) {
+    struct gpioioctl_write_s wdata;
+    int ret;
+    wdata.port = portpin;
+    wdata.port = *pdata = 0;
+    ret = ioctl(_fd, GPIOIOCTL_READ, (long unsigned int)&wdata);
+    if (ret >= 0) {
+      *pdata = wdata.data;
+    }
+    return ret;
+  }
+  return IOTJS_GPIO_NOTINITED;
+}
+
+
+} // namespace iotjs
+
+#endif // __NUTTX__

--- a/src/iotjs.cpp
+++ b/src/iotjs.cpp
@@ -129,6 +129,8 @@ int Start(char* src) {
 
   JObject* process = InitModules();
 
+  SetProcessIotjs(process);
+
   // FIXME: this should be moved to seperate function
   {
     JObject argv;

--- a/src/iotjs_def.h
+++ b/src/iotjs_def.h
@@ -21,8 +21,10 @@
 #ifndef IOTJS_MAX_READ_BUFFER_SIZE
  #ifdef __NUTTX__
   #define IOTJS_MAX_READ_BUFFER_SIZE 1024
+  #define IOTJS_MAX_PATH_SIZE 120
  #else
   #define IOTJS_MAX_READ_BUFFER_SIZE 65535
+  #define IOTJS_MAX_PATH_SIZE PATH_MAX
  #endif
 #endif
 

--- a/src/iotjs_module.cpp
+++ b/src/iotjs_module.cpp
@@ -25,6 +25,7 @@
 #include "iotjs_module_stream.h"
 #include "iotjs_module_tcp.h"
 #include "iotjs_module_timer.h"
+#include "iotjs_module_gpioctl.h"
 
 
 namespace iotjs {

--- a/src/iotjs_module.h
+++ b/src/iotjs_module.h
@@ -34,7 +34,8 @@ typedef JObject* (*register_func)();
   F(PROCESS, Process, process) \
   F(STREAM, Stream, stream) \
   F(TCP, Tcp, tcp) \
-  F(TIMER, Timer, timer)
+  F(TIMER, Timer, timer) \
+  F(GPIOCTL, GpioCtl, gpioctl)
 
 
 #define ENUMDEF_MODULE_LIST(upper, Camel, lower) \

--- a/src/iotjs_module_gpioctl.cpp
+++ b/src/iotjs_module_gpioctl.cpp
@@ -1,0 +1,187 @@
+/* Copyright 2015 Samsung Electronics Co., Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "iotjs_def.h"
+#include "iotjs_objectwrap.h"
+#include "iotjs_module_gpioctl.h"
+
+
+namespace iotjs {
+
+
+//-----------------------------------------------------------------------------
+
+GpioControl::GpioControl(JObject& jgpioctl)
+    : JObjectWrap(jgpioctl)
+    , _fd(0) {
+}
+
+
+GpioControl::~GpioControl() {
+  IOTJS_ASSERT(_fd <= 0);
+}
+
+
+GpioControl* GpioControl::FromJGpioCtl(JObject& jgpioctl) {
+  GpioControl* gpioctrl = reinterpret_cast<GpioControl*>(jgpioctl.GetNative());
+  IOTJS_ASSERT(gpioctrl != NULL);
+  return gpioctrl;
+}
+
+
+int GpioControl::Initialize(void) {
+  if (_fd > 0 )
+    return IOTJS_GPIO_INUSE;
+
+  DDDLOG("gpio initalize dummy");
+  _fd = 1;
+  return _fd;
+}
+
+
+void GpioControl::Release(void) {
+  DDDLOG("gpio release dummy");
+  _fd = 0;
+}
+
+
+int GpioControl::PinMode(uint32_t portpin) {
+  DDDLOG("gpio pin mode 0x%08x", portpin);
+  return 0;
+}
+
+
+int GpioControl::WritePin(uint32_t portpin, uint8_t data) {
+  DDDLOG("gpio write 0x%08x: 0x%02x", portpin, data);
+  return 0;
+}
+
+
+int GpioControl::ReadPin(uint32_t portpin, uint8_t* pdata) {
+  DDDLOG("gpio read 0x%08x", portpin);
+  return 0;
+}
+
+
+//-----------------------------------------------------------------------------
+
+JHANDLER_FUNCTION(Initialize, handler) {
+  JObject* jgpioctl = handler.GetThis();
+  GpioControl* gpioctrl = GpioControl::FromJGpioCtl(*jgpioctl);
+
+  int err = gpioctrl->Initialize();
+  DDDLOG("gpio initialize %d", err);
+
+  JObject ret(err);
+  handler.Return(ret);
+  return true;
+}
+
+
+JHANDLER_FUNCTION(Release, handler) {
+  JObject* jgpioctl = handler.GetThis();
+  GpioControl* gpioctrl = GpioControl::FromJGpioCtl(*jgpioctl);
+
+  gpioctrl->Release();
+
+  JObject ret(0);
+  handler.Return(ret);
+  return true;
+}
+
+
+JHANDLER_FUNCTION(PinMode, handler) {
+  IOTJS_ASSERT(handler.GetArgLength() == 1);
+  IOTJS_ASSERT(handler.GetArg(0)->IsNumber());
+  JObject* jgpioctl = handler.GetThis();
+  GpioControl* gpioctrl = GpioControl::FromJGpioCtl(*jgpioctl);
+
+  uint32_t portpin = handler.GetArg(0)->GetInt32();
+  int err = gpioctrl->PinMode(portpin);
+
+  JObject ret(err);
+  handler.Return(ret);
+  return true;
+}
+
+
+JHANDLER_FUNCTION(WritePin, handler) {
+  IOTJS_ASSERT(handler.GetArgLength() == 2);
+  IOTJS_ASSERT(handler.GetArg(0)->IsNumber());
+  IOTJS_ASSERT(handler.GetArg(1)->IsNumber());
+  JObject* jgpioctl = handler.GetThis();
+  GpioControl* gpioctrl = GpioControl::FromJGpioCtl(*jgpioctl);
+
+  uint32_t portpin = handler.GetArg(0)->GetInt64();
+  uint8_t data = (uint8_t)handler.GetArg(1)->GetInt32();
+  int err = gpioctrl->WritePin(portpin, data);
+
+  JObject ret(err);
+  handler.Return(ret);
+  return true;
+}
+
+
+JHANDLER_FUNCTION(ReadPin, handler) {
+  IOTJS_ASSERT(handler.GetArgLength() == 1);
+  IOTJS_ASSERT(handler.GetArg(0)->IsNumber());
+  JObject* jgpioctl = handler.GetThis();
+  GpioControl* gpioctrl = GpioControl::FromJGpioCtl(*jgpioctl);
+
+  uint32_t portpin = handler.GetArg(0)->GetInt64();
+  uint8_t data = 0;
+  int err = gpioctrl->ReadPin(portpin, &data);
+
+  JObject ret(err < 0 ? err : data);
+  handler.Return(ret);
+  return true;
+}
+
+
+#define SET_CONSTANT(object, name, constant) \
+  do { \
+    JObject value(constant); \
+    object->SetProperty(name, value); \
+  } while (0)
+
+
+JObject* InitGpioCtl() {
+  Module* module = GetBuiltinModule(MODULE_GPIOCTL);
+  JObject* jgpioctl = module->module;
+
+  if (jgpioctl == NULL) {
+    jgpioctl = new JObject();
+
+    jgpioctl->SetMethod("initialize", Initialize);
+    jgpioctl->SetMethod("release", Release);
+    jgpioctl->SetMethod("pinmode", PinMode);
+    jgpioctl->SetMethod("writepin", WritePin);
+    jgpioctl->SetMethod("readpin", ReadPin);
+
+    SET_CONSTANT(jgpioctl, "NOTINITIALIZED", IOTJS_GPIO_NOTINITED);
+    SET_CONSTANT(jgpioctl, "INUSE", IOTJS_GPIO_INUSE);
+
+    GpioControl* gpioctrl = GpioControl::Create(*jgpioctl);
+    IOTJS_ASSERT(gpioctrl ==
+                 reinterpret_cast<GpioControl*>(jgpioctl->GetNative()));
+
+    module->module = jgpioctl;
+  }
+
+  return jgpioctl;
+}
+
+
+} // namespace iotjs

--- a/src/iotjs_module_gpioctl.h
+++ b/src/iotjs_module_gpioctl.h
@@ -13,26 +13,41 @@
  * limitations under the License.
  */
 
-#ifndef IOTJS_MODULE_PROCESS_H
-#define IOTJS_MODULE_PROCESS_H
+#ifndef IOTJS_MODULE_GPIOCTL_H
+#define IOTJS_MODULE_GPIOCTL_H
 
 #include "iotjs_binding.h"
 
 
 namespace iotjs {
 
-void UncaughtException(JObject& jexception);
+enum {
+  IOTJS_GPIO_NOTINITED = -1,
+  IOTJS_GPIO_INUSE  = -2,
+};
 
-void ProcessEmitExit(int code);
 
-bool ProcessNextTick();
+class GpioControl : public JObjectWrap {
+public:
+  explicit GpioControl(JObject& jgpioctl);
+  virtual ~GpioControl();
 
-JObject MakeCallback(JObject& function, JObject& this_, JArgList& args);
+  static GpioControl* Create(JObject& jgpioctl);
+  static GpioControl* FromJGpioCtl(JObject& jgpioctl);
 
-JObject* InitProcess();
+  virtual int Initialize(void);
+  virtual void Release(void);
+  virtual int PinMode(uint32_t portpin);
+  virtual int WritePin(uint32_t portpin, uint8_t data);
+  virtual int ReadPin(uint32_t portpin, uint8_t* pdata);
 
-void SetProcessIotjs(JObject* process);
+protected:
+  int _fd;
+};
+
+
+JObject* InitGpioCtl();
 
 } // namespace iotjs
 
-#endif /* IOTJS_MODULE_PROCESS_H */
+#endif /* IOTJS_MODULE_GPIOCTL_H */

--- a/src/iotjs_module_process.cpp
+++ b/src/iotjs_module_process.cpp
@@ -206,7 +206,7 @@ JHANDLER_FUNCTION(ReadSource, handler){
 JHANDLER_FUNCTION(Cwd, handler){
   IOTJS_ASSERT(handler.GetArgLength() == 0);
 
-  char path[120];
+  char path[IOTJS_MAX_PATH_SIZE];
   size_t size_path = sizeof(path);
   int err = uv_cwd(path, &size_path);
   if (err) {
@@ -292,6 +292,12 @@ JObject* InitProcess() {
   }
 
   return process;
+}
+
+void SetProcessIotjs(JObject* process) {
+  // IoT.js specific
+  JObject iotjs;
+  process->SetProperty("iotjs", iotjs);
 }
 
 

--- a/src/js/gpio.js
+++ b/src/js/gpio.js
@@ -1,0 +1,93 @@
+/* Copyright 2015 Samsung Electronics Co., Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+var gpioctl  = process.binding(process.binding.gpioctl)
+  , util     = require('util')
+  , dev_open = false;
+
+
+function GPIO() {
+
+}
+
+
+GPIO.initialize = function(callback) {
+  var err = gpioctl.initialize();
+  if (err >= 0) {
+    dev_open = true;
+  }
+  if (util.isFunction(callback)) {
+    process.nextTick(function() {
+      callback(err);
+    });
+  }
+  else {
+    return err;
+  }
+};
+
+
+GPIO.release = function() {
+  if (dev_open) {
+    gpioctl.release();
+    dev_open = false;
+  }
+};
+
+
+GPIO.pinmode = function(portpin, callback) {
+  var err = gpioctl.pinmode(portpin);
+
+  if (util.isFunction(callback)) {
+    process.nextTick(function() {
+      callback(err);
+    });
+  }
+  else {
+    return err;
+  }
+};
+
+
+GPIO.write = function(portpin, val, callback) {
+  var err = gpioctl.writepin(portpin, val);
+
+  if (util.isFunction(callback)) {
+    process.nextTick(function() {
+      callback(err);
+    });
+  }
+  else {
+    return err;
+  }
+};
+
+
+GPIO.read = function(portpin, callback) {
+  var err = gpioctl.readpin(portpin);
+  var value = err;
+
+  if (util.isFunction(callback)) {
+    process.nextTick(function() {
+      callback(err, value);
+    });
+  }
+  else {
+    return err;
+  }
+};
+
+
+module.exports = GPIO;

--- a/test/run_pass/test_gpio.js
+++ b/test/run_pass/test_gpio.js
@@ -1,0 +1,54 @@
+/* Copyright 2015 Samsung Electronics Co., Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+  @TIMEOUT=10
+*/
+
+var assert = require('assert');
+var gpio = require('gpio');
+
+var gpioSequence = '';
+
+gpio.initialize(function(err) {
+  assert(err>=0, "failed to initailize");
+  gpioSequence += 'I';
+});
+
+gpio.pinmode(0x11, function(err) {
+  assert(err>=0, "failed to pinmode");
+  gpioSequence += 'A';
+});
+
+gpio.pinmode(0x22, function(err) {
+  assert(err>=0, "failed to pinmode");
+  gpioSequence += 'B';
+});
+
+gpio.write(0x01, 0xff, function(err) {
+  assert(err>=0, "failed to write");
+  gpioSequence += 'C';
+});
+
+gpio.read(0x02, function(err, value) {
+  assert(err>=0, "failed to read");
+  gpioSequence += 'D';
+});
+
+gpio.release();
+
+process.on('exit', function(code) {
+  assert.equal(gpioSequence, 'IABCD');
+});


### PR DESCRIPTION
IoT.js-DCO-1.0-Signed-off-by: SaeHie Park saehie.park@samsung.com

Continue of #105. 
What has changed in this PR
* add GpioControl interface for basic GPIO control
* implement GpioControl for NuttX on STM32F4Discovery
* add gpio.js builtin calling GpioControl
* add src/device folder for platform dependent codes, like gpio