### PR TITLE
Completing buffer module, for #112

### DIFF
--- a/src/iotjs_handlewrap.cpp
+++ b/src/iotjs_handlewrap.cpp
@@ -20,22 +20,15 @@
 namespace iotjs {
 
 
-HandleWrap::HandleWrap(JObject& jnative, JObject& jholder, uv_handle_t* handle)
-    : JObjectWrap(jnative)
-    , __handle(handle)
-    , _jholder(NULL) {
-  if (!jholder.IsNull() && !jholder.IsUndefined()) {
-    JRawValueType raw_value = jholder.raw_value();
-    _jholder = new JObject(&raw_value, false);
-  }
+HandleWrap::HandleWrap(JObject& jobject, JObject& jholder, uv_handle_t* handle)
+    : JObjectWrap(jobject, jholder)
+    , __handle(handle) {
   __handle->data = this;
 }
 
 
 HandleWrap::~HandleWrap() {
-  if (_jholder != NULL) {
-    delete _jholder;
-  }
+  Close(NULL);
 }
 
 
@@ -43,26 +36,6 @@ HandleWrap* HandleWrap::FromHandle(uv_handle_t* handle) {
   HandleWrap* wrap = reinterpret_cast<HandleWrap*>(handle->data);
   IOTJS_ASSERT(wrap != NULL);
   return wrap;
-}
-
-
-JObject& HandleWrap::jnative() {
-  return jobject();
-}
-
-
-JObject& HandleWrap::jholder() {
-  IOTJS_ASSERT(_jholder != NULL);
-  return *_jholder;
-}
-
-
-void HandleWrap::set_jholder(JObject& jholder) {
-  IOTJS_ASSERT(_jholder == NULL);
-  IOTJS_ASSERT(jholder.IsObject());
-
-  JRawValueType raw_value = jholder.raw_value();
-  _jholder = new JObject(&raw_value, false);
 }
 
 

--- a/src/iotjs_handlewrap.h
+++ b/src/iotjs_handlewrap.h
@@ -31,20 +31,13 @@ namespace iotjs {
 // If the object is freed by GC, then this wrapper instance will be also freed.
 class HandleWrap : public JObjectWrap {
  public:
-  HandleWrap(JObject& jnative, /* Native object */
-             JObject& jholder, /* Object hodling the native object */
+  HandleWrap(JObject& jobject, /* Object that connect with the uv handle*/
+             JObject& jholder, /* Object holding the object */
              uv_handle_t* handle);
 
   virtual ~HandleWrap();
 
   static HandleWrap* FromHandle(uv_handle_t* handle);
-
-  // Native object.
-  JObject& jnative();
-
-  // Javascript object that holds the native object.
-  JObject& jholder();
-  void set_jholder(JObject& jholder);
 
   typedef void (*OnCloseHandler)(uv_handle_t*);
 
@@ -52,7 +45,6 @@ class HandleWrap : public JObjectWrap {
 
  protected:
   uv_handle_t* __handle;
-  JObject* _jholder;
 };
 
 

--- a/src/iotjs_module_buffer.h
+++ b/src/iotjs_module_buffer.h
@@ -30,20 +30,25 @@ JObject* InitBuffer();
 JObject CreateBuffer(size_t len);
 
 
-class Buffer : public JObjectWrap {
+class BufferWrap : public JObjectWrap {
  public:
-  Buffer(JObject& jbuffer, size_t length);
+  BufferWrap(JObject& jbuffer, JObject& jbuiltin, size_t length);
 
-  virtual ~Buffer();
+  virtual ~BufferWrap();
 
-  static Buffer* FromJBuffer(JObject& jbuffer);
+  static BufferWrap* FromJBufferBuiltin(JObject& jbuiltin);
+  static BufferWrap* FromJBuffer(JObject& jbuffer);
 
+  JObject& jbuiltin();
   JObject& jbuffer();
+
   char* buffer();
   size_t length();
 
+  int Compare(const BufferWrap& other) const;
+
   size_t Copy(char* src, size_t len);
-  size_t Copy(char* src, size_t len, size_t src_from , size_t dst_from);
+  size_t Copy(char* src, size_t src_from, size_t src_to, size_t dst_from);
 
  protected:
   char* _buffer;

--- a/src/iotjs_module_fs.cpp
+++ b/src/iotjs_module_fs.cpp
@@ -177,7 +177,7 @@ JHANDLER_FUNCTION(Read, handler) {
   int position = handler.GetArg(4)->GetInt32();
 
   JObject* jbuffer = handler.GetArg(1);
-  Buffer* buffer_wrap = Buffer::FromJBuffer(*jbuffer);
+  BufferWrap* buffer_wrap = BufferWrap::FromJBuffer(*jbuffer);
   char* buffer = buffer_wrap->buffer();
   int buffer_length = buffer_wrap->length();
 
@@ -218,7 +218,7 @@ JHANDLER_FUNCTION(Write, handler) {
   int position = handler.GetArg(4)->GetInt32();
 
   JObject* jbuffer = handler.GetArg(1);
-  Buffer* buffer_wrap = Buffer::FromJBuffer(*jbuffer);
+  BufferWrap* buffer_wrap = BufferWrap::FromJBuffer(*jbuffer);
   char* buffer = buffer_wrap->buffer();
   int buffer_length = buffer_wrap->length();
 

--- a/src/iotjs_module_tcp.cpp
+++ b/src/iotjs_module_tcp.cpp
@@ -102,7 +102,7 @@ JHANDLER_FUNCTION(TCP, handler) {
   JObject* jholder = handler.GetArg(0);
 
   TcpWrap* tcp_wrap = new TcpWrap(env, *jtcp, *jholder);
-  IOTJS_ASSERT(tcp_wrap->jnative().IsObject());
+  IOTJS_ASSERT(tcp_wrap->jobject().IsObject());
   IOTJS_ASSERT(jtcp->GetNative() != 0);
 
   return true;
@@ -344,7 +344,7 @@ JHANDLER_FUNCTION(Write, handler) {
   IOTJS_ASSERT(tcp_wrap != NULL);
 
   JObject* jbuffer = handler.GetArg(0);
-  Buffer* buffer_wrap = Buffer::FromJBuffer(*jbuffer);
+  BufferWrap* buffer_wrap = BufferWrap::FromJBuffer(*jbuffer);
   char* buffer = buffer_wrap->buffer();
   int len = buffer_wrap->length();
 
@@ -411,7 +411,7 @@ void OnRead(uv_stream_t* handle, ssize_t nread, const uv_buf_t* buf) {
   }
 
   JObject jbuffer(CreateBuffer(static_cast<size_t>(nread)));
-  Buffer* buffer_wrap = Buffer::FromJBuffer(jbuffer);
+  BufferWrap* buffer_wrap = BufferWrap::FromJBuffer(jbuffer);
 
   buffer_wrap->Copy(buf->base, nread);
 

--- a/src/iotjs_module_timer.cpp
+++ b/src/iotjs_module_timer.cpp
@@ -68,9 +68,9 @@ class TimerWrap : public HandleWrap {
 
   void OnTimeout() {
     if (_jcallback != NULL) {
-      IOTJS_ASSERT(jnative().IsObject());
+      IOTJS_ASSERT(jobject().IsObject());
       IOTJS_ASSERT(_jcallback->IsFunction());
-      MakeCallback(*_jcallback, jnative(), JArgList::Empty());
+      MakeCallback(*_jcallback, jobject(), JArgList::Empty());
     }
   }
 
@@ -84,7 +84,7 @@ class TimerWrap : public HandleWrap {
 
 static void timerHandleTimeout(uv_timer_t* handle) {
   TimerWrap* timer_wrap = TimerWrap::FromHandle(handle);
-  IOTJS_ASSERT(timer_wrap->jnative().IsObject());
+  IOTJS_ASSERT(timer_wrap->jobject().IsObject());
   if (timer_wrap) {
     timer_wrap->OnTimeout();
   }
@@ -104,7 +104,7 @@ JHANDLER_FUNCTION(Start, handler) {
 
   TimerWrap* timer_wrap = reinterpret_cast<TimerWrap*>(jtimer->GetNative());
   IOTJS_ASSERT(timer_wrap != NULL);
-  IOTJS_ASSERT(timer_wrap->jnative().IsObject());
+  IOTJS_ASSERT(timer_wrap->jobject().IsObject());
 
   timer_wrap->set_timeout(timeout);
   timer_wrap->set_repeat(repeat);
@@ -146,7 +146,7 @@ JHANDLER_FUNCTION(Timer, handler) {
   JObject* jtimer = handler.GetThis();
 
   TimerWrap* timer_wrap = new TimerWrap(env, *jtimer);
-  IOTJS_ASSERT(timer_wrap->jnative().IsObject());
+  IOTJS_ASSERT(timer_wrap->jobject().IsObject());
   IOTJS_ASSERT(jtimer->GetNative() != 0);;
 
   return true;

--- a/src/iotjs_objectwrap.cpp
+++ b/src/iotjs_objectwrap.cpp
@@ -28,7 +28,8 @@ JFREE_HANDLER_FUNCTION(FreeObjectWrap, wrapper) {
 
 
 JObjectWrap::JObjectWrap(JObject& jobject)
-    : _jobject(NULL) {
+    : _jobject(NULL)
+    , _jholder(NULL) {
   IOTJS_ASSERT(jobject.IsObject());
 
   // This wrapper hold pointer to the javascript object but never increase
@@ -41,16 +42,45 @@ JObjectWrap::JObjectWrap(JObject& jobject)
 }
 
 
+JObjectWrap::JObjectWrap(JObject& jobject, JObject& jholder)
+    : JObjectWrap(jobject) {
+  IOTJS_ASSERT(jholder.IsObject() || jholder.IsNull() || jholder.IsUndefined());
+
+  if (jholder.IsObject()) {
+    set_jholder(jholder);
+  }
+}
+
+
 JObjectWrap::~JObjectWrap() {
   IOTJS_ASSERT(_jobject != NULL);
   IOTJS_ASSERT(_jobject->IsObject());
   delete _jobject;
+
+  if (_jholder != NULL) {
+    delete _jholder;
+  }
 }
 
 
 JObject& JObjectWrap::jobject() {
-  IOTJS_ASSERT(_jobject);
+  IOTJS_ASSERT(_jobject != NULL);
   return *_jobject;
+}
+
+
+JObject& JObjectWrap::jholder() {
+  IOTJS_ASSERT(_jholder != NULL);
+  return *_jholder;
+}
+
+
+void JObjectWrap::set_jholder(JObject& jholder) {
+  IOTJS_ASSERT(_jholder == NULL);
+  IOTJS_ASSERT(jholder.IsObject());
+
+  JRawValueType raw_value = jholder.raw_value();
+  _jholder = new JObject(&raw_value, false);
 }
 
 

--- a/src/iotjs_objectwrap.h
+++ b/src/iotjs_objectwrap.h
@@ -27,14 +27,18 @@ namespace iotjs {
 // If the object is freed by GC, then this wrapper instance will be also freed.
 class JObjectWrap {
  public:
-  JObjectWrap(JObject& object);
+  explicit JObjectWrap(JObject& jobject);
+  explicit JObjectWrap(JObject& jobject, JObject& jholder);
 
   virtual ~JObjectWrap();
 
   JObject& jobject();
+  JObject& jholder();
+  void set_jholder(JObject& jholder);
 
  protected:
   JObject* _jobject;
+  JObject* _jholder;
 };
 
 

--- a/test/run_pass/test_buffer.js
+++ b/test/run_pass/test_buffer.js
@@ -13,10 +13,24 @@
  * limitations under the License.
  */
 
+/*
+  @STDOUT=testabcdefgh
+*/
+
+
 var assert = require('assert');
 
 var buff1 = new Buffer("test");
 assert.equal(buff1.toString(), "test");
+assert.equal(buff1.toString(0, 0), "");
+assert.equal(buff1.toString(0, 1), "t");
+assert.equal(buff1.toString(0, 2), "te");
+assert.equal(buff1.toString(0, 3), "tes");
+assert.equal(buff1.toString(0, 4), "test");
+assert.equal(buff1.toString(1, 4), "est");
+assert.equal(buff1.toString(2, 4), "st");
+assert.equal(buff1.toString(3, 4), "t");
+assert.equal(buff1.toString(4, 4), "");
 assert.equal(buff1.length, 4);
 
 var buff2 = new Buffer(10);
@@ -31,3 +45,52 @@ assert.equal(buff2.length ,10);
 var buff3 = Buffer.concat([buff1, buff2]);
 assert.equal(buff3.toString(), "testabcdefgh");
 assert.equal(buff3.length ,14);
+
+var buff4 = new Buffer(10);
+var buff5 = new Buffer('a1b2c3');
+buff5.copy(buff4);
+assert.equal(buff4.toString(), 'a1b2c3');
+buff5.copy(buff4, 4, 2);
+assert.equal(buff4.toString(), 'a1b2b2c3');
+
+
+var buff6 = buff3.slice(1);
+assert.equal(buff6.toString(), 'estabcdefgh');
+assert.equal(buff6.length, 13);
+
+var buff7 = buff6.slice(3, 5);
+assert.equal(buff7.toString(), 'ab');
+assert.equal(buff7.length, 2);
+
+var buff8 = new Buffer(buff5);
+assert.equal(buff8.toString(), 'a1b2c3');
+assert.equal(buff8.equals(buff5), true);
+assert.equal(buff8.equals(buff6), false);
+
+var buff9 = new Buffer('abcabcabcd');
+var buff10 = buff9.slice(0, 3);
+var buff11 = buff9.slice(3, 6);
+var buff12 = buff9.slice(6);
+assert.equal(buff10.equals(buff11), true);
+assert.equal(buff11.equals(buff10), true);
+assert.equal(buff11.equals(buff12), false);
+assert.equal(buff10.compare(buff11), 0);
+assert.equal(buff11.compare(buff10), 0);
+assert.equal(buff11.compare(buff12), -1);
+assert.equal(buff12.compare(buff11), 1);
+
+assert.equal(buff9.slice(-2).toString(), 'cd');
+assert.equal(buff9.slice(-3, -2).toString(), 'b');
+assert.equal(buff9.slice(0, -2).toString(), 'abcabcab');
+
+
+assert.equal(Buffer.isBuffer(buff9), true);
+assert.equal(Buffer.isBuffer(1), false);
+assert.equal(Buffer.isBuffer({}), false);
+assert.equal(Buffer.isBuffer('1'), false);
+assert.equal(Buffer.isBuffer([1]), false);
+assert.equal(Buffer.isBuffer([buff1]), false);
+assert.equal(Buffer.isBuffer({obj:buff1}), false);
+
+
+console.log(buff3.toString());


### PR DESCRIPTION
Completing buffer module, for #112

* Refactoring JObjectWrap, moving jholder from JHandlerWrap.
* Renaming confusing member name 'jnative' to 'jobject'.
* Completing buffer module.
 * Buffer.isBuffer()
 * Buffer.prototype.equals()
 * Buffer.prototype.compare()
 * Buffer.prototype.copy()
 * Buffer.prototype.slice()
 * Buffer.prototype.toString()
* Revisit buffer tester.

IoT.js-DCO-1.0-Signed-off-by: Ilyong Cho ily.cho@samsung.com