### PR TITLE
Change character type to uint8_t

### DIFF
--- a/src/iotjs.cpp
+++ b/src/iotjs.cpp
@@ -42,7 +42,7 @@ static bool InitJerry() {
 
   InitJerryMagicStringEx();
 
-  if (!jerry_parse("", 0)) {
+  if (!jerry_parse(JSCT(""), 0)) {
     DLOG("jerry_parse() failed");
     return false;
   }
@@ -134,9 +134,9 @@ int Start(char* src) {
   // FIXME: this should be moved to seperate function
   {
     JObject argv;
-    JObject user_filename(src);
-    argv.SetProperty("1", user_filename);
-    process->SetProperty("argv", argv);
+    JObject user_filename(JSCT(src));
+    argv.SetProperty(JSCT("1"), user_filename);
+    process->SetProperty(JSCT("argv"), argv);
   }
 
   if (!StartIoTjs(process)) {

--- a/src/iotjs_binding.cpp
+++ b/src/iotjs_binding.cpp
@@ -95,7 +95,7 @@ JObject::JObject(double v) {
 }
 
 
-JObject::JObject(const char* v) {
+JObject::JObject(const jschar* v) {
   _obj_val.type = JERRY_API_DATA_TYPE_STRING;
   _obj_val.v_string = jerry_api_create_string(v);
   _unref_at_close = true;
@@ -148,43 +148,44 @@ JObject JObject::Global() {
 }
 
 
-JObject JObject::Error(const char* message) {
+JObject JObject::Error(const jschar* message) {
   return JObject(jerry_api_create_error(JERRY_API_ERROR_COMMON, message));
 }
 
 
-JObject JObject::EvalError(const char* message) {
+JObject JObject::EvalError(const jschar* message) {
   return JObject(jerry_api_create_error(JERRY_API_ERROR_EVAL, message));
 }
 
 
-JObject JObject::RangeError(const char* message) {
+JObject JObject::RangeError(const jschar* message) {
   return JObject(jerry_api_create_error(JERRY_API_ERROR_RANGE, message));
 }
 
 
-JObject JObject::ReferenceError(const char* message) {
+JObject JObject::ReferenceError(const jschar* message) {
   return JObject(jerry_api_create_error(JERRY_API_ERROR_REFERENCE, message));
 }
 
 
-JObject JObject::SyntaxError(const char* message) {
+JObject JObject::SyntaxError(const jschar* message) {
   return JObject(jerry_api_create_error(JERRY_API_ERROR_SYNTAX, message));
 }
 
 
-JObject JObject::TypeError(const char* message) {
+JObject JObject::TypeError(const jschar* message) {
   return JObject(jerry_api_create_error(JERRY_API_ERROR_TYPE, message));
 }
 
 
-JObject JObject::URIError(const char* message) {
+JObject JObject::URIError(const jschar* message) {
   return JObject(jerry_api_create_error(JERRY_API_ERROR_URI, message));
 }
 
 
-JResult JObject::Eval(const char* source, bool direct_mode, bool strict_mode) {
-  size_t source_len = strlen(source);
+JResult JObject::Eval(const jschar* source, bool direct_mode,
+                      bool strict_mode) {
+  size_t source_len = jstrlen(source);
   JRawValueType res;
   jerry_completion_code_t ret = jerry_api_eval(source,
                                                source_len,
@@ -203,14 +204,14 @@ JResult JObject::Eval(const char* source, bool direct_mode, bool strict_mode) {
 }
 
 
-void JObject::SetMethod(const char* name, JHandlerType handler) {
+void JObject::SetMethod(const jschar* name, JHandlerType handler) {
   IOTJS_ASSERT(IsObject());
   JObject method(jerry_api_create_external_function(handler));
   SetProperty(name, method);
 }
 
 
-void JObject::SetProperty(const char* name, JObject& val) {
+void JObject::SetProperty(const jschar* name, JObject& val) {
   IOTJS_ASSERT(IsObject());
   JRawValueType v = val.raw_value();
   bool is_ok  = jerry_api_set_object_field_value(_obj_val.v_object, name, &v);
@@ -218,14 +219,14 @@ void JObject::SetProperty(const char* name, JObject& val) {
 }
 
 
-void JObject::SetProperty(const char* name, JRawValueType val) {
+void JObject::SetProperty(const jschar* name, JRawValueType val) {
   IOTJS_ASSERT(IsObject());
   bool is_ok  = jerry_api_set_object_field_value(_obj_val.v_object, name, &val);
   IOTJS_ASSERT(is_ok);
 }
 
 
-JObject JObject::GetProperty(const char* name) {
+JObject JObject::GetProperty(const jschar* name) {
   IOTJS_ASSERT(IsObject());
   JRawValueType res;
   bool is_ok = jerry_api_get_object_field_value(_obj_val.v_object, name, &res);
@@ -363,27 +364,28 @@ double JObject::GetNumber() {
 }
 
 
-char* JObject::GetCString() {
+jschar* JObject::GetByteString() {
   IOTJS_ASSERT(IsString());
 
-  size_t size = -GetCStringLength();
-  char* buffer = AllocBuffer(size);
+  size_t size = -GetByteStringLength();
+  octet* buffer = AllocBuffer(size);
+  jschar* jsbuffer = reinterpret_cast<jschar*>(buffer);
   size_t check = jerry_api_string_to_char_buffer(_obj_val.v_string,
-                                                 buffer,
+                                                 jsbuffer,
                                                  size);
   IOTJS_ASSERT(check == size);
   return buffer;
 }
 
 
-void JObject::ReleaseCString(char* str) {
-  ReleaseBuffer(str);
+void JObject::ReleaseByteString(jschar* str) {
+  ReleaseBuffer(reinterpret_cast<octet*>(str));
 }
 
 
-size_t JObject::GetCStringLength() {
+size_t JObject::GetByteStringLength() {
   IOTJS_ASSERT(IsString());
-  return jerry_api_string_to_char_buffer (_obj_val.v_string, NULL, 0);
+  return jerry_api_string_to_char_buffer(_obj_val.v_string, NULL, 0);
 }
 
 

--- a/src/iotjs_binding.h
+++ b/src/iotjs_binding.h
@@ -27,6 +27,7 @@ typedef jerry_external_handler_t JHandlerType;
 typedef jerry_object_free_callback_t JFreeHandlerType;
 typedef jerry_api_object_t JRawObjectType;
 typedef jerry_api_value_t JRawValueType;
+typedef jerry_api_length_t JRawLengthType;
 
 
 
@@ -61,7 +62,7 @@ class JObject {
   explicit JObject(double v);
 
   // Creates a javascirpt number object.
-  explicit JObject(const char* v);
+  explicit JObject(const jschar* v);
 
   // Creates a object from `JRawObjectType*`.
   // If second argument set true, then ref count for the object will be
@@ -87,18 +88,18 @@ class JObject {
   static JObject Global();
 
   // Create a javascript error object.
-  static JObject Error(const char* message = NULL);
-  static JObject EvalError(const char* message = NULL);
-  static JObject RangeError(const char* message = NULL);
-  static JObject ReferenceError(const char* message = NULL);
-  static JObject SyntaxError(const char* message = NULL);
-  static JObject TypeError(const char* message = NULL);
-  static JObject URIError(const char* message = NULL);
+  static JObject Error(const jschar* message = NULL);
+  static JObject EvalError(const jschar* message = NULL);
+  static JObject RangeError(const jschar* message = NULL);
+  static JObject ReferenceError(const jschar* message = NULL);
+  static JObject SyntaxError(const jschar* message = NULL);
+  static JObject TypeError(const jschar* message = NULL);
+  static JObject URIError(const jschar* message = NULL);
 
 
   // Evaluate javascript source file.
   // `souce` shoud be a null-terminated c string.
-  static JResult Eval(const char* source,
+  static JResult Eval(const jschar* source,
                       bool direct_mode = true,
                       bool strict_mode = false);
 
@@ -124,12 +125,12 @@ class JObject {
   bool IsFunction();
 
   // Sets native handler method for the javascript object.
-  void SetMethod(const char* name, JHandlerType handler);
+  void SetMethod(const jschar* name, JHandlerType handler);
 
   // Sets & gets property for the javascript object.
-  void SetProperty(const char* name, JObject& val);
-  void SetProperty(const char* name, JRawValueType val);
-  JObject GetProperty(const char* name);
+  void SetProperty(const jschar* name, JObject& val);
+  void SetProperty(const jschar* name, JRawValueType val);
+  JObject GetProperty(const jschar* name);
 
   // Sets & gets native data for the javascript object.
   void SetNative(uintptr_t ptr, JFreeHandlerType free_handler);
@@ -148,15 +149,15 @@ class JObject {
   double GetNumber();
 
   // Returns pontiner to null terminated string contents of string object.
-  // Returned pointer should be released using `ReleaseCString()` when it become
-  // unnecessary.
-  char* GetCString();
+  // Returned pointer should be released using `ReleaseByteString()` when
+  // it become unnecessary.
+  jschar* GetByteString();
 
-  // Release memory retrieved from `GetCString()`.
-  static void ReleaseCString(char* str);
+  // Release memory retrieved from `GetByteString()`.
+  static void ReleaseByteString(jschar* str);
 
   // Returns length of null teminated string contents of string object.
-  size_t GetCStringLength();
+  size_t GetByteStringLength();
 
   // Calls javascript function.
   JResult Call(JObject& this_, JArgList& arg);
@@ -170,6 +171,8 @@ class JObject {
 
   // disable assignment.
   JObject& operator=(const JObject& rhs) = delete;
+  // disable char* constructor
+  JObject(const char* v) = delete;
 };
 
 
@@ -277,7 +280,7 @@ class JHandlerInfo {
                       const JRawValueType *this_p, \
                       JRawValueType *ret_val_p, \
                       const JRawValueType args_p [], \
-                      const uint16_t args_cnt) { \
+                      const JRawLengthType args_cnt) { \
     JHandlerInfo info(function_obj_p, this_p, ret_val_p, args_p, args_cnt); \
     return ___ ## handler ## _wrap(info); \
   } \

--- a/src/iotjs_def.h
+++ b/src/iotjs_def.h
@@ -44,6 +44,7 @@
 #include "iotjs_debuglog.h"
 #include "iotjs_module.h"
 #include "iotjs_module_process.h"
+#include "iotjs_types.h"
 #include "iotjs_util.h"
 
 #include <uv.h>

--- a/src/iotjs_exception.h
+++ b/src/iotjs_exception.h
@@ -23,7 +23,7 @@
 namespace iotjs {
 
 
-JObject CreateUVException(int errorno, const char* syscall);
+JObject CreateUVException(int errorno, const jschar* syscall);
 
 
 } // namespace iotjs

--- a/src/iotjs_module_buffer.h
+++ b/src/iotjs_module_buffer.h
@@ -42,16 +42,16 @@ class BufferWrap : public JObjectWrap {
   JObject& jbuiltin();
   JObject& jbuffer();
 
-  char* buffer();
+  octet* buffer();
   size_t length();
 
   int Compare(const BufferWrap& other) const;
 
-  size_t Copy(char* src, size_t len);
-  size_t Copy(char* src, size_t src_from, size_t src_to, size_t dst_from);
+  size_t Copy(octet* src, size_t len);
+  size_t Copy(octet* src, size_t src_from, size_t src_to, size_t dst_from);
 
  protected:
-  char* _buffer;
+  octet* _buffer;
   size_t _length;
 };
 

--- a/src/iotjs_module_console.cpp
+++ b/src/iotjs_module_console.cpp
@@ -25,9 +25,9 @@ namespace iotjs {
 static bool Print(JHandlerInfo& handler, FILE* out_fd) {
   if (handler.GetArgLength() > 0) {
     if (handler.GetArg(0)->IsString()) {
-      char* str = handler.GetArg(0)->GetCString();
-      fprintf(out_fd, "%s\n", str);
-      JObject::ReleaseCString(str);
+      jschar* str = handler.GetArg(0)->GetByteString();
+      fprintf(out_fd, "%s\n", (const char*)str);
+      JObject::ReleaseByteString(str);
 
       return true;
     }
@@ -52,10 +52,10 @@ JObject* InitConsole() {
 
   if (console == NULL) {
     console = new JObject();
-    console->SetMethod("log", Log);
-    console->SetMethod("info", Log);
-    console->SetMethod("error", Error);
-    console->SetMethod("warn", Error);
+    console->SetMethod(JSCT("log"), Log);
+    console->SetMethod(JSCT("info"), Log);
+    console->SetMethod(JSCT("error"), Error);
+    console->SetMethod(JSCT("warn"), Error);
 
     module->module = console;
   }

--- a/src/iotjs_module_constants.cpp
+++ b/src/iotjs_module_constants.cpp
@@ -26,7 +26,7 @@ namespace iotjs {
 #define SET_CONSTANT(object, constant) \
   do { \
     JObject value(constant); \
-    object->SetProperty(#constant, value); \
+    object->SetProperty(JSCT(#constant), value); \
   } while (0)
 
 

--- a/src/iotjs_module_gpioctl.cpp
+++ b/src/iotjs_module_gpioctl.cpp
@@ -164,14 +164,14 @@ JObject* InitGpioCtl() {
   if (jgpioctl == NULL) {
     jgpioctl = new JObject();
 
-    jgpioctl->SetMethod("initialize", Initialize);
-    jgpioctl->SetMethod("release", Release);
-    jgpioctl->SetMethod("pinmode", PinMode);
-    jgpioctl->SetMethod("writepin", WritePin);
-    jgpioctl->SetMethod("readpin", ReadPin);
+    jgpioctl->SetMethod(JSCT("initialize"), Initialize);
+    jgpioctl->SetMethod(JSCT("release"), Release);
+    jgpioctl->SetMethod(JSCT("pinmode"), PinMode);
+    jgpioctl->SetMethod(JSCT("writepin"), WritePin);
+    jgpioctl->SetMethod(JSCT("readpin"), ReadPin);
 
-    SET_CONSTANT(jgpioctl, "NOTINITIALIZED", IOTJS_GPIO_NOTINITED);
-    SET_CONSTANT(jgpioctl, "INUSE", IOTJS_GPIO_INUSE);
+    SET_CONSTANT(jgpioctl, JSCT("NOTINITIALIZED"), IOTJS_GPIO_NOTINITED);
+    SET_CONSTANT(jgpioctl, JSCT("INUSE"), IOTJS_GPIO_INUSE);
 
     GpioControl* gpioctrl = GpioControl::Create(*jgpioctl);
     IOTJS_ASSERT(gpioctrl ==

--- a/src/iotjs_module_stream.cpp
+++ b/src/iotjs_module_stream.cpp
@@ -39,7 +39,7 @@ JObject* InitStream() {
 
   if (stream == NULL) {
     stream = new JObject();
-    stream->SetMethod("doWrite", DoWrite);
+    stream->SetMethod(JSCT("doWrite"), DoWrite);
 
     module->module = stream;
   }

--- a/src/iotjs_module_tcp.cpp
+++ b/src/iotjs_module_tcp.cpp
@@ -124,7 +124,7 @@ static void AfterClose(uv_handle_t* handle) {
   IOTJS_ASSERT(jsocket.IsObject());
 
   // internal close callback.
-  JObject jonclose = jsocket.GetProperty("_onclose");
+  JObject jonclose = jsocket.GetProperty(JSCT("_onclose"));
   IOTJS_ASSERT(jonclose.IsFunction());
 
   MakeCallback(jonclose, jsocket, JArgList::Empty());
@@ -155,11 +155,11 @@ JHANDLER_FUNCTION(Bind, handler) {
   IOTJS_ASSERT(handler.GetArg(0)->IsString());
   IOTJS_ASSERT(handler.GetArg(1)->IsNumber());
 
-  LocalString address(handler.GetArg(0)->GetCString());
+  LocalString address(handler.GetArg(0)->GetByteString());
   int port = handler.GetArg(1)->GetInt32();
 
   sockaddr_in addr;
-  int err = uv_ip4_addr(address, port, &addr);
+  int err = uv_ip4_addr(address.charbuff(), port, &addr);
 
   if (err == 0) {
     TcpWrap* wrap = TcpWrap::FromJObject(handler.GetThis());
@@ -211,12 +211,12 @@ JHANDLER_FUNCTION(Connect, handler) {
   IOTJS_ASSERT(handler.GetArg(1)->IsNumber());
   IOTJS_ASSERT(handler.GetArg(2)->IsFunction());
 
-  LocalString address(handler.GetArg(0)->GetCString());
+  LocalString address(handler.GetArg(0)->GetByteString());
   int port = handler.GetArg(1)->GetInt32();
   JObject jcallback = *handler.GetArg(2);
 
   sockaddr_in addr;
-  int err = uv_ip4_addr(address, port, &addr);
+  int err = uv_ip4_addr(address.charbuff(), port, &addr);
 
   if (err == 0) {
     // Get tcp wrapper from javascript socket object.
@@ -259,7 +259,7 @@ static void OnConnection(uv_stream_t* handle, int status) {
   IOTJS_ASSERT(jserver.IsObject());
 
   // `onconnection` callback.
-  JObject jonconnection = jserver.GetProperty("_onconnection");
+  JObject jonconnection = jserver.GetProperty(JSCT("_onconnection"));
   IOTJS_ASSERT(jonconnection.IsFunction());
 
   // The callback takes two parameter
@@ -270,7 +270,7 @@ static void OnConnection(uv_stream_t* handle, int status) {
 
   if (status == 0) {
     // Create client socket handle wrapper.
-    JObject jfunc_create_tcp = jserver.GetProperty("_createTCP");
+    JObject jfunc_create_tcp = jserver.GetProperty(JSCT("_createTCP"));
     IOTJS_ASSERT(jfunc_create_tcp.IsFunction());
 
     JObject jclient_tcp = jfunc_create_tcp.CallOk(jserver, JArgList::Empty());
@@ -345,11 +345,11 @@ JHANDLER_FUNCTION(Write, handler) {
 
   JObject* jbuffer = handler.GetArg(0);
   BufferWrap* buffer_wrap = BufferWrap::FromJBuffer(*jbuffer);
-  char* buffer = buffer_wrap->buffer();
+  jschar* buffer = buffer_wrap->buffer();
   int len = buffer_wrap->length();
 
   uv_buf_t buf;
-  buf.base = buffer;
+  buf.base = reinterpret_cast<char*>(buffer);
   buf.len = len;
 
   WriteReqWrap* req_wrap = new WriteReqWrap(*handler.GetArg(1));
@@ -377,7 +377,7 @@ void OnAlloc(uv_handle_t* handle, size_t suggested_size, uv_buf_t* buf) {
     suggested_size = IOTJS_MAX_READ_BUFFER_SIZE;
   }
 
-  buf->base = AllocBuffer(suggested_size);
+  buf->base = reinterpret_cast<char*>(AllocBuffer(suggested_size));
   buf->len = suggested_size;
 }
 
@@ -390,7 +390,7 @@ void OnRead(uv_stream_t* handle, ssize_t nread, const uv_buf_t* buf) {
   IOTJS_ASSERT(jsocket.IsObject());
 
   // Socket.prototype._onread = function(nread, isEOF, buffer)
-  JObject jonread = jsocket.GetProperty("_onread");
+  JObject jonread = jsocket.GetProperty(JSCT("_onread"));
   IOTJS_ASSERT(jonread.IsFunction());
 
   JArgList jargs(3);
@@ -399,7 +399,7 @@ void OnRead(uv_stream_t* handle, ssize_t nread, const uv_buf_t* buf) {
 
   if (nread <= 0) {
     if (buf->base != NULL) {
-      ReleaseBuffer(buf->base);
+      ReleaseBuffer(OCTET(buf->base));
     }
     if (nread < 0) {
       if (nread == UV__EOF) {
@@ -413,12 +413,12 @@ void OnRead(uv_stream_t* handle, ssize_t nread, const uv_buf_t* buf) {
   JObject jbuffer(CreateBuffer(static_cast<size_t>(nread)));
   BufferWrap* buffer_wrap = BufferWrap::FromJBuffer(jbuffer);
 
-  buffer_wrap->Copy(buf->base, nread);
+  buffer_wrap->Copy(OCTET(buf->base), nread);
 
   jargs.Add(jbuffer);
   MakeCallback(jonread, jsocket, jargs);
 
-  ReleaseBuffer(buf->base);
+  ReleaseBuffer(OCTET(buf->base));
 }
 
 
@@ -509,17 +509,17 @@ JObject* InitTcp() {
     tcp = new JObject(TCP);
 
     JObject prototype;
-    tcp->SetProperty("prototype", prototype);
+    tcp->SetProperty(JSCT("prototype"), prototype);
 
-    prototype.SetMethod("open", Open);
-    prototype.SetMethod("close", Close);
-    prototype.SetMethod("connect", Connect);
-    prototype.SetMethod("bind", Bind);
-    prototype.SetMethod("listen", Listen);
-    prototype.SetMethod("write", Write);
-    prototype.SetMethod("readStart", ReadStart);
-    prototype.SetMethod("shutdown", Shutdown);
-    prototype.SetMethod("_setHolder", SetHolder);
+    prototype.SetMethod(JSCT("open"), Open);
+    prototype.SetMethod(JSCT("close"), Close);
+    prototype.SetMethod(JSCT("connect"), Connect);
+    prototype.SetMethod(JSCT("bind"), Bind);
+    prototype.SetMethod(JSCT("listen"), Listen);
+    prototype.SetMethod(JSCT("write"), Write);
+    prototype.SetMethod(JSCT("readStart"), ReadStart);
+    prototype.SetMethod(JSCT("shutdown"), Shutdown);
+    prototype.SetMethod(JSCT("_setHolder"), SetHolder);
 
     module->module = tcp;
   }

--- a/src/iotjs_module_timer.cpp
+++ b/src/iotjs_module_timer.cpp
@@ -161,9 +161,9 @@ JObject* InitTimer() {
     timer = new JObject(Timer);
 
     JObject prototype;
-    timer->SetProperty("prototype", prototype);
-    prototype.SetMethod("start", Start);
-    prototype.SetMethod("stop", Stop);
+    timer->SetProperty(JSCT("prototype"), prototype);
+    prototype.SetMethod(JSCT("start"), Start);
+    prototype.SetMethod(JSCT("stop"), Stop);
 
     module->module = timer;
   }

--- a/src/iotjs_types.h
+++ b/src/iotjs_types.h
@@ -13,24 +13,19 @@
  * limitations under the License.
  */
 
-#include "iotjs_exception.h"
 
-#include <stdio.h>
-
-#include "uv.h"
+#ifndef IOTJS_TYPES_H
+#define IOTJS_TYPES_H
 
 
-namespace iotjs {
+typedef uint8_t jschar;  /* follow jerry_api_char_t type which is uint8_t */
+
+#define JSCT(a) reinterpret_cast<const jschar*>((const char*)a)
 
 
-JObject CreateUVException(int errorno, const jschar* syscall) {
-    static char msg[256];
-    snprintf(msg, sizeof(msg),
-             "'%s' %s",
-             reinterpret_cast<const char*>(syscall),
-             uv_strerror(errorno));
-    return JObject::Error(JSCT(msg));
-}
+typedef uint8_t octet;  /* for Buffer byte element */
+
+#define OCTET(a) reinterpret_cast<octet*>(a)
 
 
-} // namespace iotjs
+#endif /* IOTJS_TYPES_H */

--- a/src/iotjs_util.cpp
+++ b/src/iotjs_util.cpp
@@ -24,15 +24,39 @@
 namespace iotjs {
 
 
-char* ReadFile(const char* path) {
-  FILE* file = fopen(path, "rb");
+int jstrlen(const jschar* jstr) {
+  return strlen(reinterpret_cast<const char*>(jstr));
+}
+
+
+jschar* jstrcpy(jschar* dst, const jschar* src) {
+  return reinterpret_cast<jschar*>(strcpy(reinterpret_cast<char*>(dst),
+                                          reinterpret_cast<const char*>(src)));
+}
+
+
+jschar* jstrcat(jschar* dst, const jschar* src) {
+  return reinterpret_cast<jschar*>(strcat(reinterpret_cast<char*>(dst),
+                                          reinterpret_cast<const char*>(src)));
+}
+
+
+jschar* jstrncpy(jschar* dst, const jschar* src, size_t num) {
+  return reinterpret_cast<jschar*>(strncpy(reinterpret_cast<char*>(dst),
+                                           reinterpret_cast<const char*>(src),
+                                           num));
+}
+
+
+jschar* ReadFile(const jschar* path) {
+  FILE* file = fopen((const char*)path, "rb");
   IOTJS_ASSERT(file != NULL);
 
   fseek(file, 0, SEEK_END);
   size_t len = ftell(file);
   fseek(file, 0, SEEK_SET);
 
-  char* buff = AllocBuffer(len + 1);
+  jschar* buff = static_cast<jschar*>(AllocBuffer(len + 1));
 
   size_t read = fread(buff, 1, len, file);
   IOTJS_ASSERT(read == len);
@@ -45,29 +69,29 @@ char* ReadFile(const char* path) {
 }
 
 
-char* AllocBuffer(size_t size) {
-  char* buff = static_cast<char*>(malloc(size));
+octet* AllocBuffer(size_t size) {
+  octet* buff = static_cast<octet*>(malloc(size));
   memset(buff, 0, size);
   return buff;
 }
 
 
-char* ReallocBuffer(char* buffer, size_t size) {
-  return static_cast<char*>(realloc(buffer, size));
+octet* ReallocBuffer(octet* buffer, size_t size) {
+  return static_cast<octet*>(realloc(buffer, size));
 }
 
 
-void ReleaseBuffer(char* buffer) {
+void ReleaseBuffer(octet* buffer) {
   free(buffer);
 }
 
 
 LocalString::LocalString(size_t len)
-    : _strp(AllocBuffer(len)) {
+    : _strp(static_cast<jschar*>(AllocBuffer(len))) {
   IOTJS_ASSERT(_strp != NULL);
 }
 
-LocalString::LocalString(char* strp)
+LocalString::LocalString(jschar* strp)
     : _strp(strp) {
   IOTJS_ASSERT(_strp != NULL);
 }
@@ -75,11 +99,11 @@ LocalString::LocalString(char* strp)
 
 LocalString::~LocalString() {
   IOTJS_ASSERT(_strp != NULL);
-  ReleaseBuffer(const_cast<char*>(_strp));
+  ReleaseBuffer(const_cast<jschar*>(_strp));
 }
 
 
-LocalString::operator char* () const {
+LocalString::operator jschar* () const {
   return _strp;
 }
 

--- a/src/iotjs_util.h
+++ b/src/iotjs_util.h
@@ -17,18 +17,26 @@
 #define IOTJS_UTIL_H
 
 
+#include "iotjs_types.h"
+
 #include <assert.h>
 
 
 namespace iotjs {
 
 
-char* ReadFile(const char* path);
+int jstrlen(const jschar*);
+jschar* jstrcpy(jschar*, const jschar*);
+jschar* jstrcat(jschar*, const jschar*);
+jschar* jstrncpy(jschar*, const jschar*, size_t);
+
+jschar* ReadFile(const jschar* path);
 
 
-char* AllocBuffer(size_t size);
-char* ReallocBuffer(char* buffer, size_t size);
-void ReleaseBuffer(char* buff);
+octet* AllocBuffer(size_t size);
+octet* ReallocBuffer(octet* buffer, size_t size);
+void ReleaseBuffer(octet* buff);
+
 
 
 void PrintBacktrace();
@@ -37,13 +45,14 @@ void PrintBacktrace();
 class LocalString {
  public:
   LocalString(size_t len);
-  LocalString(char* strp);
+  LocalString(jschar* strp);
   ~LocalString();
 
-  operator char* () const;
+  operator jschar* () const;
+  const char* charbuff() { return reinterpret_cast<const char*>(_strp); }
 
  protected:
-  char* _strp;
+  jschar* _strp;
 };
 
 

--- a/tools/js2c.pl
+++ b/tools/js2c.pl
@@ -36,7 +36,7 @@ my $lisence = "/* Copyright 2015 Samsung Electronics Co., Ltd.
  * Do not modify this.
  */\n";
 my $header = "#ifndef IOTJS_JS_H\n#define IOTJS_JS_H\nnamespace iotjs{\n";
-my $start_variable = "  const char mainjs[] = {\n";
+my $start_variable = "  const jschar mainjs[] = {\n";
 my $end_variable = "0 };\n";
 my $foot = "}\n#endif\n";
 
@@ -74,8 +74,8 @@ foreach(@filenames) {
     my $name = $_;
     $name =~ s{\.[^.]+$}{};
 
-    print $out "const char $name\_n [] = \"$name\";\n";
-    print $out "const char $name\_s [] = \{\n";
+    print $out "const jschar $name\_n [] = \"$name\";\n";
+    print $out "const jschar $name\_s [] = \{\n";
 
     open(my $in, "<../src/js/$name.js") || die "Cannot open $name.js\n";
     my $data = do { local $/; <$in> };
@@ -97,8 +97,8 @@ foreach(@filenames) {
 
 my $native_struct = <<'END_NATIVE_STRUCT';
 struct native_mod {
-  const char* name;
-  const char* source;
+  const jschar* name;
+  const jschar* source;
   const int length;
 };
 


### PR DESCRIPTION
This commit is to apply latest character type change in JerryScript as uint8_t
- Update to latest JerryScript
- add new jschar type as uint8_t and change char types to this
- disable JObject(const char*) constructor which makes problem
- update JHandlerType for new jerry_api_length_t

IoT.js-DCO-1.0-Signed-off-by: SaeHie Park saehie.park@samsung.com

Related issue #118 