### PR TITLE
Emitting end and finish event of duplex stream more properly

### DIFF
--- a/src/js/events.js
+++ b/src/js/events.js
@@ -29,7 +29,6 @@ EventEmitter.prototype.emit = function(type, arg1, arg2) {
   if (!this._events) {
     this._events = {};
   }
-
   var handler = this._events[type];
   if (util.isUndefined(handler)) {
     return false;
@@ -37,7 +36,7 @@ EventEmitter.prototype.emit = function(type, arg1, arg2) {
     if (util.isFunction(handler)) {
       handler.call(this, arg1, arg2);
     } else {
-      listeners = handler;
+      var listeners = handler;
       for (i = 0; i < listeners.length; ++i) {
         listeners[i].call(this, arg1, arg2);
       }

--- a/src/js/stream_readable.js
+++ b/src/js/stream_readable.js
@@ -174,12 +174,12 @@ function emitEnd(stream) {
   if (stream.length > 0 || !state.ended) {
     throw new Error('stream ended on non-EOF stream');
   }
-
   if (!state.endEmitted) {
     state.endEmitted = true;
     stream.emit('end');
   }
 };
+
 
 function emitReadable(stream) {
   stream.emit('readable');
@@ -187,8 +187,14 @@ function emitReadable(stream) {
 
 
 function emitData(stream, data) {
+  var state = stream._readableState;
+
   assert.equal(readBuffer(stream), null);
   stream.emit('data', data);
+
+  if (state.ended && state.length == 0) {
+    emitEnd(stream);
+  }
 };
 
 

--- a/src/js/stream_writable.js
+++ b/src/js/stream_writable.js
@@ -197,8 +197,13 @@ function endWritable(stream, callback) {
   if (callback) {
     stream.once('finish', callback);
   }
-  // write out buffered data.
-  writeBuffered(stream);
+
+  // If nothing left, emit finish event at next tick.
+  if (!state.writing && state.buffer.length == 0) {
+    process.nextTick(function(){
+      emitFinish(stream);
+    });
+  }
 }
 
 
@@ -207,7 +212,7 @@ function emitFinish(stream) {
   var state = stream._writableState;
   if (!state.ended) {
     state.ended = true;
-    stream.emit('finish')
+    stream.emit('finish');
   }
 }
 


### PR DESCRIPTION
This commit fixes two problems

1. In some situation 'end' event was not emitted from the first place.
2. In some situation 'end` event was lost because the socket closed before triggering 'end' listener.