### PR TITLE
Initializing process.argv

### DIFF
--- a/include/iotjs.h
+++ b/include/iotjs.h
@@ -25,7 +25,7 @@
 
 namespace iotjs {
 
-IOTJS_EXTERN_C int Start(char* src);
+IOTJS_EXTERN_C int Start(int argc, char** argv);
 
 } // namespace itojs
 

--- a/src/iotjs_env.cpp
+++ b/src/iotjs_env.cpp
@@ -20,13 +20,18 @@
 
 namespace iotjs {
 
-Environment::Environment(uv_loop_t* loop)
-  : _loop(loop) {
+
+Environment::Environment(int argc, char** argv, uv_loop_t* loop)
+  : _argc(argc)
+  , _argv(argv)
+  , _loop(loop) {
 }
+
 
 Environment* Environment::GetEnv() {
   JObject global = JObject::Global();
   return (Environment*)global.GetNative();
 }
+
 
 } // namespace iotjs

--- a/src/iotjs_env.h
+++ b/src/iotjs_env.h
@@ -28,13 +28,17 @@ class ReqWrap;
 
 class Environment {
  public:
-  Environment(uv_loop_t* loop);
+  Environment(int argc, char** argv, uv_loop_t* loop);
 
   static Environment* GetEnv();
 
+  int argc() { return _argc; }
+  char** argv() { return _argv; }
   uv_loop_t* loop() { return _loop; }
 
  private:
+  int _argc;
+  char** _argv;
   uv_loop_t* _loop;
 }; // class Environment
 

--- a/src/iotjs_module_process.cpp
+++ b/src/iotjs_module_process.cpp
@@ -17,7 +17,8 @@
 #include "iotjs_module_process.h"
 #include "iotjs_js.h"
 
-#include <cstdlib>
+#include <stdio.h>
+#include <stdlib.h>
 #include <string.h>
 
 
@@ -214,6 +215,27 @@ JHANDLER_FUNCTION(DoExit, handler) {
 }
 
 
+// Initialize `process.argv`
+JHANDLER_FUNCTION(InitArgv, handler) {
+  IOTJS_ASSERT(handler.GetThis()->IsObject());
+
+  // environtment
+  Environment* env = Environment::GetEnv();
+
+  // process.argv
+  JObject jargv = handler.GetThis()->GetProperty("argv");
+
+  for (int i = 0; i < env->argc(); ++i) {
+    char index[10] = {0};
+    sprintf(index, "%d", i);
+    JObject value(env->argv()[i]);
+    jargv.SetProperty(index, value);
+  }
+
+  return true;
+}
+
+
 void SetNativeSources(JObject* native_sources) {
   for (int i = 0; natives[i].name; i++) {
     JObject native_source;
@@ -258,6 +280,7 @@ JObject* InitProcess() {
     process->SetMethod("readSource", ReadSource);
     process->SetMethod("cwd", Cwd);
     process->SetMethod("doExit", DoExit);
+    process->SetMethod("_initArgv", InitArgv);
     SetProcessEnv(process);
 
     // process.native_sources

--- a/src/iotjs_module_process.h
+++ b/src/iotjs_module_process.h
@@ -29,6 +29,8 @@ bool ProcessNextTick();
 
 JObject MakeCallback(JObject& function, JObject& this_, JArgList& args);
 
+void InitArgv(int argc, char** argv);
+
 JObject* InitProcess();
 
 } // namespace iotjs

--- a/src/js/iotjs.js
+++ b/src/js/iotjs.js
@@ -19,9 +19,9 @@
   global.process = process;
 
 
-  function start_iotjs() {
-    init_global();
-    init_timers();
+  function startIoTjs() {
+    initGlobal();
+    initTimers();
 
     initProcess();
 
@@ -31,7 +31,7 @@
   };
 
 
-  function init_global() {
+  function initGlobal() {
     global.process = process;
     global.global = global;
     global.GLOBAL = global;
@@ -41,7 +41,7 @@
   };
 
 
-  function init_timers() {
+  function initTimers() {
     global.setTimeout = function(callback, delay) {
       var t = Native.require('timers');
       return t.setTimeout.call(this, callback, delay);
@@ -65,10 +65,18 @@
 
 
   function initProcess() {
+    initProcessArgv();
     initProcessEvents();
     initProcessNextTick();
     initProcessUncaughtException();
     initProcessExit();
+  }
+
+
+  // Initialize `process.argv`
+  function initProcessArgv() {
+    process.argv = [];
+    process._initArgv();
   }
 
 
@@ -215,6 +223,6 @@
     return JSON.parse(text);
   };
 
-  start_iotjs();
+  startIoTjs();
 
 });

--- a/src/js/module.js
+++ b/src/js/module.js
@@ -165,6 +165,7 @@ Module.load = function(id, parent, isMain) {
   return module.exports;
 };
 
+
 Module.prototype.compile = function() {
   var self = this;
   var requireForThis = function(path) {


### PR DESCRIPTION
Previously, `process.argv` only provided information about source path. and it was not an `Array`.

This patch will make `process.argv` an Array instance and contain other arguments as well as application path(argv[1]).

This patch contains some minor refactoring, most significant one of them is changing prototype of iotjs::Start() function: `Start(char* src)` to `Start(int argc, char** argv)`. Hence programs that use IoT.js as library should be modified (ex. nuttx entry program)
