### PR TITLE
EventEmitter.once fixed

### DIFF
--- a/src/js/events.js
+++ b/src/js/events.js
@@ -73,7 +73,7 @@ EventEmitter.prototype.once = function(type, listener) {
     throw new TypeError('listener must be a function');
   }
 
-  function f(arg1, arg2) {
+  var f = function(arg1, arg2) {
     // here `this` is this not global, because EventEmitter binds event object
     // for this when it calls back the handler.
     this.removeListener(f.type, f);

--- a/test/run_pass/test_events.js
+++ b/test/run_pass/test_events.js
@@ -22,7 +22,20 @@ var emitter = new EventEmitter();
 var eventCnt1 = 0;
 var eventCnt2 = 0;
 var eventCnt3 = 0;
+var onceCnt = 0;
 var eventSequence = "";
+
+emitter.once('once', function() {
+  onceCnt += 1;
+});
+
+
+assert.equal(onceCnt, 0);
+emitter.emit('once');
+assert.equal(onceCnt, 1);
+emitter.emit('once');
+assert.equal(onceCnt, 1);
+
 
 emitter.addListener('event', function() {
     eventCnt1 += 1;


### PR DESCRIPTION
small patch for EventEmitter.once : 
In http module, EventEmitter.once emit TypeError occasionally. This patch works fine with #140. 
In simple setting, it is failed to be reproduced.  

IoT.js-DCO-1.0-Signed-off-by: Chunseok Lee chunseok.lee@samsung.com