### PR TITLE
Integer type correction using JObject(int v)

### DIFF
--- a/src/iotjs_module_fs.cpp
+++ b/src/iotjs_module_fs.cpp
@@ -66,7 +66,7 @@ static void After(uv_fs_t* req) {
       case UV_FS_READ:
       case UV_FS_WRITE:
       {
-        JObject arg1(static_cast<int32_t>(req->result));
+        JObject arg1(static_cast<int>(req->result));
         jarg.Add(arg1);
         break;
       }
@@ -248,7 +248,7 @@ JObject MakeStatObject(uv_stat_t* statbuf) {
 
 
 #define X(name)                              \
-  JObject name((int32_t)statbuf->st_##name);        \
+  JObject name((int)statbuf->st_##name);        \
 
   X(dev)
   X(mode)


### PR DESCRIPTION
IoT.js-DCO-1.0-Signed-off-by: SaeHie Park saehie.park@samsung.com

JObject ctor for int is defined as `JObject(int v)`. In some platforms using int32_t fails.