### PR TITLE
Http fix

### DIFF
--- a/src/js/http_client.js
+++ b/src/js/http_client.js
@@ -28,7 +28,7 @@ function ClientRequest(options, cb) {
 
 
   var port = options.port = options.port || 80;
-  var host = options.host = options.hostname || '127.0.0.1';
+  var host = options.host = options.hostname || options.host || '127.0.0.1';
   var method = options.method || 'GET';
 
   self.path = options.path || '/';


### PR DESCRIPTION
This PR fixes:

1. do not ignore `options.host` when creating http request.
2. simplifying sequence for setup connection information of http client.
3. fix timing of 'finish' event.