### PR TITLE
Fixed misreferencing for socket state

### DIFF
--- a/src/js/http_client.js
+++ b/src/js/http_client.js
@@ -163,6 +163,7 @@ function socketOnEnd() {
     socket.parser = null;
     req.parser = null;
   }
+
   socket.destroy();
 }
 
@@ -199,7 +200,7 @@ var responseOnEnd = function() {
   var req = res.req;
   var socket = req.socket;
 
-  if(socket.writable) {
+  if (socket._socketState.writable) {
     socket.destroySoon();
   }
 };

--- a/src/js/http_server.js
+++ b/src/js/http_server.js
@@ -230,8 +230,8 @@ function connectionListener(socket) {
 
     this.parser = null;
 
-    if (!self.httpAllowHalfOpen) {
-      if (socket.writable) socket.end();
+    if (!self.httpAllowHalfOpen && socket._socketState.writable) {
+      socket.end();
     }
   }
 


### PR DESCRIPTION
Fixed miss referencing for socket state.

net module of IoT.js maintain its state through `socket._socketState` object.