### PR TITLE
Removed `jholder` from `ObjectWrap`.

### DIFF
--- a/src/iotjs_handlewrap.cpp
+++ b/src/iotjs_handlewrap.cpp
@@ -20,8 +20,8 @@
 namespace iotjs {
 
 
-HandleWrap::HandleWrap(JObject& jobject, JObject& jholder, uv_handle_t* handle)
-    : JObjectWrap(jobject, jholder)
+HandleWrap::HandleWrap(JObject& jobject, uv_handle_t* handle)
+    : JObjectWrap(jobject)
     , __handle(handle) {
   __handle->data = this;
 }

--- a/src/iotjs_handlewrap.h
+++ b/src/iotjs_handlewrap.h
@@ -32,7 +32,6 @@ namespace iotjs {
 class HandleWrap : public JObjectWrap {
  public:
   HandleWrap(JObject& jobject, /* Object that connect with the uv handle*/
-             JObject& jholder, /* Object holding the object */
              uv_handle_t* handle);
 
   virtual ~HandleWrap();

--- a/src/iotjs_module_buffer.cpp
+++ b/src/iotjs_module_buffer.cpp
@@ -23,10 +23,9 @@
 namespace iotjs {
 
 
-BufferWrap::BufferWrap(JObject& jbuffer,
-                       JObject& jbuiltin,
+BufferWrap::BufferWrap(JObject& jbuiltin,
                        size_t length)
-    : JObjectWrap(jbuiltin, jbuffer)
+    : JObjectWrap(jbuiltin)
     , _buffer(NULL)
     , _length(length) {
   _buffer = AllocBuffer(length);
@@ -57,13 +56,13 @@ BufferWrap* BufferWrap::FromJBuffer(JObject& jbuffer) {
 
 
 
-JObject& BufferWrap::jbuiltin() {
+JObject BufferWrap::jbuiltin() {
   return jobject();
 }
 
 
-JObject& BufferWrap::jbuffer() {
-  return jholder();
+JObject BufferWrap::jbuffer() {
+  return jbuiltin().GetProperty("_buffer");
 }
 
 
@@ -152,7 +151,9 @@ JHANDLER_FUNCTION(Buffer) {
   JObject* jbuffer = handler.GetArg(0);
   JObject* jbuiltin = handler.GetThis();
 
-  BufferWrap* buffer_wrap = new BufferWrap(*jbuffer, *jbuiltin, length);
+  jbuiltin->SetProperty("_buffer", *jbuffer);
+
+  BufferWrap* buffer_wrap = new BufferWrap(*jbuiltin, length);
   IOTJS_ASSERT(buffer_wrap == (BufferWrap*)(jbuiltin->GetNative()));
   IOTJS_ASSERT(buffer_wrap->buffer() != NULL);
 

--- a/src/iotjs_module_buffer.h
+++ b/src/iotjs_module_buffer.h
@@ -32,15 +32,15 @@ JObject CreateBuffer(size_t len);
 
 class BufferWrap : public JObjectWrap {
  public:
-  BufferWrap(JObject& jbuffer, JObject& jbuiltin, size_t length);
+  BufferWrap(JObject& jbuiltin, size_t length);
 
   virtual ~BufferWrap();
 
   static BufferWrap* FromJBufferBuiltin(JObject& jbuiltin);
   static BufferWrap* FromJBuffer(JObject& jbuffer);
 
-  JObject& jbuiltin();
-  JObject& jbuffer();
+  JObject jbuiltin();
+  JObject jbuffer();
 
   char* buffer();
   size_t length();

--- a/src/iotjs_module_timer.cpp
+++ b/src/iotjs_module_timer.cpp
@@ -25,9 +25,7 @@ namespace iotjs {
 class TimerWrap : public HandleWrap {
  public:
   explicit TimerWrap(Environment* env, JObject& jtimer)
-      : HandleWrap(jtimer,
-                   JObject::Null(),
-                   reinterpret_cast<uv_handle_t*>(&_handle))
+      : HandleWrap(jtimer, reinterpret_cast<uv_handle_t*>(&_handle))
       , _timeout(0)
       , _repeat(0)
       , _jcallback(NULL) {

--- a/src/iotjs_objectwrap.cpp
+++ b/src/iotjs_objectwrap.cpp
@@ -30,8 +30,7 @@ static void FreeObjectWrap(const uintptr_t wrapper) {
 
 
 JObjectWrap::JObjectWrap(JObject& jobject)
-    : _jobject(NULL)
-    , _jholder(NULL) {
+    : _jobject(NULL) {
   IOTJS_ASSERT(jobject.IsObject());
 
   // This wrapper hold pointer to the javascript object but never increase
@@ -44,46 +43,17 @@ JObjectWrap::JObjectWrap(JObject& jobject)
 }
 
 
-JObjectWrap::JObjectWrap(JObject& jobject, JObject& jholder)
-    : JObjectWrap(jobject) {
-  IOTJS_ASSERT(jholder.IsObject() || jholder.IsNull() || jholder.IsUndefined());
-
-  if (jholder.IsObject()) {
-    set_jholder(jholder);
-  }
-}
-
-
 JObjectWrap::~JObjectWrap() {
   IOTJS_ASSERT(_jobject != NULL);
   IOTJS_ASSERT(_jobject->IsObject());
 
   delete _jobject;
-
-  if (_jholder != NULL) {
-    delete _jholder;
-  }
 }
 
 
 JObject& JObjectWrap::jobject() {
   IOTJS_ASSERT(_jobject != NULL);
   return *_jobject;
-}
-
-
-JObject& JObjectWrap::jholder() {
-  IOTJS_ASSERT(_jholder != NULL);
-  return *_jholder;
-}
-
-
-void JObjectWrap::set_jholder(JObject& jholder) {
-  IOTJS_ASSERT(_jholder == NULL);
-  IOTJS_ASSERT(jholder.IsObject());
-
-  JRawValueType raw_value = jholder.raw_value();
-  _jholder = new JObject(&raw_value, false);
 }
 
 

--- a/src/iotjs_objectwrap.h
+++ b/src/iotjs_objectwrap.h
@@ -28,19 +28,14 @@ namespace iotjs {
 class JObjectWrap {
  public:
   explicit JObjectWrap(JObject& jobject);
-  explicit JObjectWrap(JObject& jobject, JObject& jholder);
-
   virtual ~JObjectWrap();
 
   JObject& jobject();
-  JObject& jholder();
-  void set_jholder(JObject& jholder);
 
   virtual void Destroy(void);
 
  protected:
   JObject* _jobject;
-  JObject* _jholder;
 };
 
 

--- a/src/js/stream_writable.js
+++ b/src/js/stream_writable.js
@@ -208,8 +208,12 @@ function doWrite(stream, chunk, callback) {
   state.writing = true;
   state.writingLength = chunk.length;
 
+  var afterWrite = function(status) {
+    stream._onwrite(status);
+  };
+
   // Write down the chunk data.
-  stream._write(chunk, callback, stream._onwrite);
+  stream._write(chunk, callback, afterWrite);
 }
 
 

--- a/test/run_pass/test_httpclient_timeout2.js
+++ b/test/run_pass/test_httpclient_timeout2.js
@@ -33,9 +33,6 @@ var server = http.createServer(function(req, res) {
 });
 
 
-
-
-
 server.listen(options.port, function() {
   var req = http.request(options, function(res) {
     var destroyer = function() {
@@ -48,7 +45,6 @@ server.listen(options.port, function() {
       // after connection established
       req.setTimeout(100, destroyer);
     });
-
   });
 
   req.on('close', function() {


### PR DESCRIPTION
Fix for #228 

This patch accomopany with huge change in net module because implementation of previous net module and tcp builtin was based on `jholder`.
