### PR TITLE
Fix unexpected termination when timeout in check_test.py

### DIFF
--- a/tools/check_test.py
+++ b/tools/check_test.py
@@ -152,6 +152,7 @@ def run_test(arg):
     exitcode = 0
     attr_mismatched = False
     error_msg = ''
+    timeout_expired = False
 
     # run the test.
     try:
@@ -159,6 +160,8 @@ def run_test(arg):
                                               stderr=subprocess.STDOUT,
                                               timeout=test_attr['timeout'])
         test_output = test_output.decode().strip()
+    except subprocess.TimeoutExpired:
+        timeout_expired = True
     except Exception as e:
         exitcode = int(e.returncode)
         test_output = e.output.decode().strip()
@@ -179,6 +182,11 @@ def run_test(arg):
     # attribute mismatched
     if attr_mismatched:
         test_failed = True
+
+    # timeout expired
+    if timeout_expired:
+        test_failed = True
+        error_msg = 'timed out after %d seconds' % test_attr['timeout']
 
     # This test should have passed but failed.
     if not should_fail and exitcode != 0:


### PR DESCRIPTION
I temporarily added a test case *test_timeout.js* that takes forever.
In other words, this testcase always gets timed out.

Currently *check_test.py* terminates immediately after a timeout exception.
But with this patch even if a timeout exception is raised, it just reports timeout error for the test and keeps doing other tests.

The output is like
```
. . .
[ run_pass ] test_net3.js
[ run_pass ] test_timers2.js
[ run_pass ] test_timeout.js - timed out after 10 seconds

[ run_pass ] issue-133.js
[ run_pass ] issue-137.js
[ run_pass ] issue-198.js
[ run_pass ] issue-223.js
[ run_pass ] module_cache.js
[ run_pass ] test_require.js

[ run_pass ] Test Failed
  * test_timeout.js

Failed run_checktest
. . .
```

% *test_timeout.js* is not included in the commit.