### PR TITLE
Guarantee a javascirpt object is alive during corresponding handle is open

### DIFF
--- a/src/iotjs_handlewrap.h
+++ b/src/iotjs_handlewrap.h
@@ -27,8 +27,20 @@ namespace iotjs {
 
 
 // UV handle wrapper.
-// This wrapper might refer javascript object but never increase reference count
-// If the object is freed by GC, then this wrapper instance will be also freed.
+// This wrapper connects a Javascript object and a libuv handler.
+// This wrapper will increase ref count for the Javascript object and decrease
+//  it after corresponding handle has closed. Hence the Javasciprt object will
+//  not turn into garbage untile the handle is open.
+
+// Javascirpt object
+//   ->
+// Create a handle wrap, initializing uv handle, increase ref count.
+//   ->
+// The javascript object will be alive until handle has closed.
+//   ->
+// Handle closed, release handle, decrease ref count.
+//   ->
+// The javascript object now can be reclaimed by GC.
 class HandleWrap : public JObjectWrap {
  public:
   HandleWrap(JObject& jobject, /* Object that connect with the uv handle*/
@@ -42,11 +54,14 @@ class HandleWrap : public JObjectWrap {
 
   void Close(OnCloseHandler on_close_cb);
 
+  void OnClose();
+
  protected:
   virtual void Destroy(void);
 
  protected:
   uv_handle_t* __handle;
+  OnCloseHandler _on_close_cb;
 };
 
 

--- a/src/js/net.js
+++ b/src/js/net.js
@@ -62,6 +62,7 @@ function Socket(options) {
 
   if (options.handle) {
     this._handle = options.handle;
+    this._handle.owner = this;
   }
 
   this.on('finish', onSocketFinish);
@@ -87,6 +88,7 @@ Socket.prototype.connect = function() {
 
   if (!self._handle) {
     self._handle = createTCP();
+    self._handle.owner = self;
   }
 
   if (util.isFunction(callback)) {
@@ -485,12 +487,6 @@ Server.prototype.close = function(callback) {
   }
   if (this._handle) {
     this._handle.close();
-
-    // FIXME(wateret) _handleTemp is a temporary handle storage
-    // that prevents the socket object from garbage collection.
-    // Below line should be removed after issue #221 is resolved.
-    this._handleTemp = this._handle;
-
     this._handle = null;
   }
   this._emitCloseIfDrained();

--- a/src/js/net.js
+++ b/src/js/net.js
@@ -272,10 +272,7 @@ function close(socket) {
 
   if (this._server) {
     var server = this._server;
-    var sockets = server._sockets;
-    var idx = sockets.indexOf(this);
-    delete sockets[idx];
-    sockets.count--;
+    server._socketCount--;
     server._emitCloseIfDrained();
   }
 }
@@ -411,8 +408,7 @@ function Server(options, connectionListener) {
   }
 
   this._handle = null;
-  this._sockets = [];
-  this._sockets.count = 0;
+  this._socketCount = 0;
 
   this.allowHalfOpen = options.allowHalfOpen || false;
 }
@@ -497,7 +493,7 @@ Server.prototype.close = function(callback) {
 Server.prototype._emitCloseIfDrained = function() {
   var self = this;
 
-  if (self._handle || self._sockets.count > 0) {
+  if (self._handle || self._socketCount > 0) {
     return;
   }
 
@@ -531,8 +527,7 @@ function onconnection(status, clientHandle) {
 
   onSocketConnect(socket);
 
-  server._sockets.push(socket);
-  server._sockets.count++;
+  server._socketCount++;
 
   server.emit('connection', socket);
 }

--- a/src/js/timers.js
+++ b/src/js/timers.js
@@ -20,11 +20,6 @@ var util = require('util');
 var TIMEOUT_MAX = 2147483647; // 2^31-1
 
 
-// Timeout holders
-// Todo, profile and optimize
-var timersList = [];
-
-
 function Timeout(after) {
   this.after = after;
   this.isrepeat = false;
@@ -50,14 +45,13 @@ Timeout.prototype.activate = function() {
 
   if (this.isrepeat) {
     repeat = this.after;
+
   }
 
   handler.timeoutObj = this;
   this.handler = handler;
 
   handler.start(this.after, repeat, handleTimeout);
-
-  timersList.push(this);
 };
 
 
@@ -67,12 +61,6 @@ Timeout.prototype.close = function() {
     this.handler.timeoutObj = undefined;
     this.handler.stop();
     this.handler = undefined;
-  }
-
-  // remove 'this' from list
-  var idx = timersList.indexOf(this);
-  if (idx > -1) {
-    timersList.splice(idx, 1);
   }
 };
 

--- a/test/run_pass/test_net7.js
+++ b/test/run_pass/test_net7.js
@@ -13,10 +13,6 @@
  * limitations under the License.
  */
 
- /*
-   @SKIP
- */
-
 
 var net = require('net');
 var assert = require('assert');
@@ -25,7 +21,7 @@ var stream = require('stream');
 
 var port = 9827;
 
-var count = 50;
+var count = 40;
 var check = [];
 
 function serverListen() {


### PR DESCRIPTION
Changes:

* HandleWrap increases ref count for Javascript object when intialize. prevent GC.
* HandleWrap decreases ref count for Javascript object when close handle. allow GC.
* Close all unclosed handle just before clean up program.
* Rework on timer builtin.
