### PR TITLE
Fix bug in 64bit -> 32bit cross build

### DIFF
--- a/cmake/config/i686-linux.cmake
+++ b/cmake/config/i686-linux.cmake
@@ -19,6 +19,8 @@ set(CMAKE_SYSTEM_PROCESSOR x86)
 
 set(FLAGS_COMMON -D__LINUX__
                  -D__i686__
+                 -march=i686
+                 -m32
                  -fno-builtin)
 
 foreach(FLAG ${FLAGS_COMMON})

--- a/tools/build.py
+++ b/tools/build.py
@@ -318,6 +318,8 @@ def build_libuv():
             check_run_cmd('./nuttx-configure', [opt_nuttx_home()])
         elif opt_target_arch() == 'arm' and opt_target_os() =='linux':
             check_run_cmd('./armlinux-configure')
+        elif opt_target_arch() == 'i686':
+            check_run_cmd('./gyp_uv.py', ['-f', 'make', '-Dtarget_arch=ia32'])
         else:
             check_run_cmd('./gyp_uv.py', ['-f', 'make'])
 


### PR DESCRIPTION
When cross-build 32bit version iotjs in 64bit host, the `./tools/build.py --target-arch=i686` will not succeed, because the "-m32" or "-march=i686" flag is not set in the `cmake/config/i686-linux.cmake`.

This patch fixs the bug.

1, add "-m32" or "-march=i686" flag in i686-linux.cmake
2, libuv is built by gyp. So we modified the `tools/build.py` to pass the target_arch to the gyp_uv
3, libtuv use the `opt_cmake_toolchain_file()` as its CMAKE_TOOLCHAIN_FILE, like other dep_modules did. so libtuv can also support i686 cross-build.