### PR TITLE
Fix small bug when build on x86 machine.

### DIFF
--- a/cmake/config/i686-linux.cmake
+++ b/cmake/config/i686-linux.cmake
@@ -15,4 +15,4 @@
 include(CMakeForceCompiler)
 
 set(CMAKE_SYSTEM_NAME Linux)
-set(CMAKE_SYSTEM_PROCESSOR i686)
+set(CMAKE_SYSTEM_PROCESSOR x86)


### PR DESCRIPTION
jerry-libc 's CMakeList didnt recognize the "i686" arch. iotjs will fail when building on x86 machine.
```
# Architecture-specific configuration
 if(${CMAKE_SYSTEM_PROCESSOR} STREQUAL "x86_64")
  set(DEFINES_LIBC ${DEFINES_LIBC} ${DEFINES_LIBC_X86_64})
 elseif(${CMAKE_SYSTEM_PROCESSOR} STREQUAL "armv7l-hf")
  set(DEFINES_LIBC ${DEFINES_LIBC} ${DEFINES_LIBC_ARMV7_HF})
 elseif(${CMAKE_SYSTEM_PROCESSOR} STREQUAL "armv7l-el")
  set(DEFINES_LIBC ${DEFINES_LIBC} ${DEFINES_LIBC_ARMV7_EL})
 elseif(${CMAKE_SYSTEM_PROCESSOR} STREQUAL "x86")
  set(DEFINES_LIBC ${DEFINES_LIBC} ${DEFINES_LIBC_X86})
 else()
  message(FATAL_ERROR "Unsupported machine architecture")
 endif()
```
error mesage
```
==> Build JerryScript

cmake /home/jzd/iotjs/deps/jerry -DCMAKE_TOOLCHAIN_FILE=/home/jzd/iotjs/cmake/config/i686-linux.cmake -DENABLE_LTO=OFF

-- The CXX compiler identification is GNU 4.8.4
-- The C compiler identification is GNU 4.8.4
-- The ASM compiler identification is GNU
-- Found assembler: /usr/bin/cc
-- Check for working CXX compiler: /usr/bin/c++
-- Check for working CXX compiler: /usr/bin/c++ -- works
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Check for working C compiler: /usr/bin/cc
-- Check for working C compiler: /usr/bin/cc -- works
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
CMake Error at jerry-libc/CMakeLists.txt:113 (message):
  Unsupported machine architecture


-- Configuring incomplete, errors occurred!
See also "/home/jzd/iotjs/build/i686-linux/debug/deps/jerry/CMakeFiles/CMakeOutput.log".

[Failed - 1] cmake /home/jzd/iotjs/deps/jerry -DCMAKE_TOOLCHAIN_FILE=/home/jzd/iotjs/cmake/config/i686-linux.cmake -DENABLE_LTO=OFF

```
if we change the `set(CMAKE_SYSTEM_PROCESSOR i686)` in `cmake/config/i686-linux.cmake` to `set(CMAKE_SYSTEM_PROCESSOR x86)`, it can be fixed.

