### PR TITLE
fix bug in build.py: implement external_include_dir option

### DIFF
--- a/tools/build.py
+++ b/tools/build.py
@@ -365,7 +365,7 @@ def inflate_cmake_option(cmake_opt, option, for_jerry=False):
     if option.target_os == 'nuttx' and option.nuttx_home:
         include_dirs.append('%s/include' % option.nuttx_home)
         include_dirs.append('%s/include/cxx' % option.nuttx_home)
-
+    include_dirs.extend(option.external_include_dir)
     cmake_opt.append('-DEXTERNAL_INCLUDE_DIR=' + ' '.join(include_dirs))
 
 


### PR DESCRIPTION
build.py forget to use external_include_dir.