### PR TITLE
implement GPIO with libmraa (issue #272)

### DIFF
--- a/cmake/iotjstuv.cmake
+++ b/cmake/iotjstuv.cmake
@@ -20,6 +20,8 @@ file(GLOB LIB_IOTJS_SRC ${SRC_ROOT}/*.cpp
 string(REPLACE ";" " " IOTJS_CFLAGS_STR "${IOTJS_CFLAGS}")
 string(REPLACE ";" " " IOTJS_LINK_FLAGS_STR "${IOTJS_LINK_FLAGS}")
 separate_arguments(EXTERNAL_INCLUDE_DIR)
+separate_arguments(EXTERNAL_STATIC_LIB)
+separate_arguments(EXTERNAL_SHARED_LIB)
 
 set(LIB_IOTJS_CFLAGS ${IOTJS_CFLAGS_STR})
 set(LIB_IOTJS_INCDIR ${EXTERNAL_INCLUDE_DIR}
@@ -58,8 +60,8 @@ function(BuildIoTjs)
   set_property(TARGET ${targetName}
                PROPERTY LINK_FLAGS ${BIN_IOTJS_LINK_FLAGS})
   target_include_directories(${targetName} PRIVATE ${BIN_IOTJS_INCDIR})
-  target_link_libraries(${targetName} libiotjs ${JERRY_LIB}
-    ${LIBTUV_LIB} ${HTTPPARSER_LIB})
+  target_link_libraries(${targetName} libiotjs ${JERRY_LIB} ${LIBTUV_LIB}
+    ${HTTPPARSER_LIB} ${EXTERNAL_STATIC_LIB} ${EXTERNAL_SHARED_LIB})
   add_dependencies(targetLibIoTjs ${targetName})
 
 endfunction()
@@ -73,8 +75,8 @@ function(BuildIoTjsLib)
   set_property(TARGET ${targetName}
                PROPERTY LINK_FLAGS ${BIN_IOTJS_LINK_FLAGS})
   target_include_directories(${targetName} PRIVATE ${BIN_IOTJS_INCDIR})
-  target_link_libraries(${targetName} libiotjs ${JERRY_LIB}
-    ${LIBTUV_LIB} ${HTTPPARSER_LIB})
+  target_link_libraries(${targetName} libiotjs ${JERRY_LIB} ${LIBTUV_LIB}
+    ${HTTPPARSER_LIB} ${EXTERNAL_STATIC_LIB} ${EXTERNAL_SHARED_LIB})
   add_dependencies(targetLibIoTjs ${targetName})
 endfunction()
 

--- a/src/platform/arm-linux/iotjs_module_gpio-arm-linux.cpp
+++ b/src/platform/arm-linux/iotjs_module_gpio-arm-linux.cpp
@@ -16,6 +16,22 @@
 
 #if defined(__LINUX__)
 
+ #if defined(USING_MRAA)
+
+#include "../iotjs_module_gpio-linux-mraa.inl.h"
+
+
+namespace iotjs {
+
+
+Gpio* Gpio::Create(JObject& jgpio) {
+  return new GpioLinuxMraa(jgpio);
+}
+
+
+} // namespace iotjs
+
+ #else
 
 #include "../iotjs_module_gpio-linux-general.inl.h"
 
@@ -30,5 +46,6 @@ Gpio* Gpio::Create(JObject& jgpio) {
 
 } // namespace iotjs
 
+ #endif
 
 #endif

--- a/src/platform/i686-linux/iotjs_module_gpio-i686-linux.cpp
+++ b/src/platform/i686-linux/iotjs_module_gpio-i686-linux.cpp
@@ -16,6 +16,22 @@
 
 #if defined(__LINUX__)
 
+ #if defined(USING_MRAA)
+
+#include "../iotjs_module_gpio-linux-mraa.inl.h"
+
+
+namespace iotjs {
+
+
+Gpio* Gpio::Create(JObject& jgpio) {
+  return new GpioLinuxMraa(jgpio);
+}
+
+
+} // namespace iotjs
+
+ #else
 
 #include "../iotjs_module_gpio-linux-general.inl.h"
 
@@ -30,5 +46,6 @@ Gpio* Gpio::Create(JObject& jgpio) {
 
 } // namespace iotjs
 
+ #endif
 
 #endif

--- a/src/platform/iotjs_module_gpio-linux-mraa.inl.h
+++ b/src/platform/iotjs_module_gpio-linux-mraa.inl.h
@@ -1,0 +1,384 @@
+/* Copyright 2015 Samsung Electronics Co., Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef IOTJS_MODULE_GPIO_LINUX_MRAA_INL_H
+#define IOTJS_MODULE_GPIO_LINUX_MRAA_INL_H
+
+
+#include <string.h>
+#include <stdlib.h>
+#include <stdio.h>
+#include <unistd.h>
+
+#include "iotjs_module_gpio.h"
+#include "mraa.h"
+
+#define GPIO_MAX_PINNO 63
+
+namespace iotjs {
+
+
+// MRAA GPIO implementation for linux.
+// Implementaion used here are based on:
+//  http://iotdk.intel.com/docs/master/mraa/
+class GpioLinuxMraa : public Gpio {
+ public:
+  explicit GpioLinuxMraa(JObject& jgpio);
+
+  static GpioLinuxMraa* GetInstance();
+
+  virtual int Initialize(GpioReqWrap* gpio_req);
+  virtual int Release(GpioReqWrap* gpio_req);
+  virtual int SetPin(GpioReqWrap* gpio_req);
+  virtual int WritePin(GpioReqWrap* gpio_req);
+  virtual int ReadPin(GpioReqWrap* gpio_req);
+
+ public:
+  bool _ExportPin(int32_t pin);
+  bool _UnexportPin(int32_t pin);
+  bool _SetPinDirection(int32_t pin, GpioDirection direction);
+  bool _SetPinMode(int32_t pin, GpioMode mode);
+  bool _WritePin(int32_t pin, bool value);
+  bool _ReadPin(int32_t pin, int32_t* value);
+  bool _initialized;
+  mraa_gpio_context _pin[GPIO_MAX_PINNO + 1];
+};
+
+
+GpioLinuxMraa::GpioLinuxMraa(JObject& jgpio)
+    : Gpio(jgpio)
+    , _initialized(false) {
+  for (int i = 0; i < GPIO_MAX_PINNO; ++i) {
+    _pin[i] = NULL;
+  }
+}
+
+
+GpioLinuxMraa* GpioLinuxMraa::GetInstance() {
+  return static_cast<GpioLinuxMraa*>(Gpio::GetInstance());
+}
+
+
+
+
+
+
+// Export GPIO pin.
+bool GpioLinuxMraa::_ExportPin(int32_t pin) {
+  IOTJS_ASSERT(pin >= 0 && pin < GPIO_MAX_PINNO);
+
+  if (this->_pin[pin] == NULL) {
+    this->_pin[pin] = mraa_gpio_init(pin);
+  }
+
+  return true;
+}
+
+
+// Unexport GPIO pin.
+bool GpioLinuxMraa::_UnexportPin(int32_t pin) {
+  IOTJS_ASSERT(pin >= 0 && pin < GPIO_MAX_PINNO);
+  int ret;
+  if (this->_pin[pin]) {
+    ret = mraa_gpio_close(this->_pin[pin]);
+    if (ret) {
+      DDLOG("GPIO _UnexportPin() - fail: %d", ret);
+      return false;
+    }
+    this->_pin[pin] = NULL;
+  }
+
+  return true;
+}
+
+
+bool GpioLinuxMraa::_SetPinDirection(int32_t pin, GpioDirection direction) {
+  IOTJS_ASSERT(pin >= 0 && pin < GPIO_MAX_PINNO);
+  IOTJS_ASSERT(direction == kGpioDirectionIn || direction == kGpioDirectionOut);
+  IOTJS_ASSERT(this->_pin[pin]);
+
+  int ret;
+  if (direction == kGpioDirectionIn) {
+    ret = mraa_gpio_dir(this->_pin[pin], MRAA_GPIO_IN);
+  } else {
+    ret = mraa_gpio_dir(this->_pin[pin], MRAA_GPIO_OUT);
+  }
+
+  if (ret) {
+    DDLOG("GPIO _SetPinDirection() - fail: %d", ret);
+    return false;
+  }
+  else {
+    return true;
+  }
+}
+
+
+// FIXME: Implement SetPinMode()
+bool GpioLinuxMraa::_SetPinMode(int32_t pin, GpioMode mode) {
+  IOTJS_ASSERT(pin >= 0 && pin < GPIO_MAX_PINNO);
+  IOTJS_ASSERT(mode == kGpioModeNone || mode == kGpioModeOpendrain);
+
+  return true;
+}
+
+
+bool GpioLinuxMraa::_WritePin(int32_t pin, bool value) {
+  IOTJS_ASSERT(pin >= 0 && pin < GPIO_MAX_PINNO);
+  IOTJS_ASSERT(this->_pin[pin]);
+  int ret = 0;
+  int v = value ? 1 : 0;
+  ret = mraa_gpio_write(this->_pin[pin], v);
+  if (ret) {
+    DDLOG("GPIO _WritePin() - write fail: %d", ret);
+    return false;
+  }
+  else {
+    return true;
+  }
+}
+
+
+bool GpioLinuxMraa::_ReadPin(int32_t pin, int32_t* value) {
+  IOTJS_ASSERT(pin >= 0 && pin < GPIO_MAX_PINNO);
+  IOTJS_ASSERT(this->_pin[pin]);
+  int ret;
+  ret = mraa_gpio_read(this->_pin[pin]);
+  if (ret < 0) {
+    DDLOG("GPIO _ReadPin() - read fail: %d", ret);
+    return false;
+  }
+  *value = ret;
+  return true;
+}
+
+
+void AfterWork(uv_work_t* work_req, int status) {
+  GpioLinuxMraa* gpio = GpioLinuxMraa::GetInstance();
+
+  GpioReqWrap* gpio_req = reinterpret_cast<GpioReqWrap*>(work_req->data);
+  GpioReqData* req_data = gpio_req->req();
+
+  if (status) {
+    req_data->result = kGpioErrSys;
+  }
+
+  JArgList jargs(2);
+  jargs.Add(JVal::Number(req_data->result));
+
+  switch (req_data->op) {
+    case kGpioOpInitize:
+    {
+      if (req_data->result == kGpioErrOk) {
+        gpio->_initialized = true;
+      }
+      break;
+    }
+    case kGpioOpRelease:
+    {
+      if (req_data->result == kGpioErrOk) {
+        gpio->_initialized = false;
+      }
+      break;
+    }
+    case kGpioOpSetPin:
+    case kGpioOpWritePin:
+    {
+      break;
+    }
+    case kGpioOpReadPin:
+    {
+      if (req_data->result == kGpioErrOk) {
+        jargs.Add(JVal::Bool(req_data->value));
+      }
+      break;
+    }
+
+    case kGpioOpSetPort:
+    case kGpioOpWritePort:
+    case kGpioOpReadPort:
+    {
+      IOTJS_ASSERT(!"Not implemented");
+      break;
+    }
+    default:
+    {
+      IOTJS_ASSERT(!"Unreachable");
+      break;
+    }
+  }
+
+  MakeCallback(gpio_req->jcallback(), *Gpio::GetJGpio(), jargs);
+
+  delete work_req;
+  delete gpio_req;
+}
+
+
+
+void InitializeWorker(uv_work_t* work_req) {
+  GpioLinuxMraa* gpio = GpioLinuxMraa::GetInstance();
+  IOTJS_ASSERT(gpio->_initialized == false);
+
+  GpioReqWrap* gpio_req = reinterpret_cast<GpioReqWrap*>(work_req->data);
+  GpioReqData* req_data = gpio_req->req();
+
+  DDDLOG("GPIO InitializeWorker()");
+
+  // always return OK
+  req_data->result = kGpioErrOk;
+}
+
+
+void ReleaseWorker(uv_work_t* work_req) {
+  GpioLinuxMraa* gpio = GpioLinuxMraa::GetInstance();
+  IOTJS_ASSERT(gpio->_initialized == true);
+
+  GpioReqWrap* gpio_req = reinterpret_cast<GpioReqWrap*>(work_req->data);
+  GpioReqData* req_data = gpio_req->req();
+
+  DDDLOG("GPIO ReleaseWorker()");
+
+  req_data->result = kGpioErrOk;
+
+  // Unexport pins that exported earlier by this module.
+  for (int i = 0; i < GPIO_MAX_PINNO; ++i) {
+    if (gpio->_pin[i]) {
+      if (!gpio->_UnexportPin(i)) {
+        req_data->result = kGpioErrSys;
+      }
+    }
+  }
+}
+
+
+void SetPinWorker(uv_work_t* work_req) {
+  GpioLinuxMraa* gpio = GpioLinuxMraa::GetInstance();
+  IOTJS_ASSERT(gpio->_initialized == true);
+
+  GpioReqWrap* gpio_req = reinterpret_cast<GpioReqWrap*>(work_req->data);
+  GpioReqData* req_data = gpio_req->req();
+
+  DDDLOG("GPIO SetPinWorker() - pin: %d, dir: %d, mode: %d",
+         req_data->pin, req_data->dir, req_data->mode);
+
+  if (req_data->dir == kGpioDirectionNone) {
+    // Unexport GPIO pin.
+    if (!gpio->_UnexportPin(req_data->pin)) {
+      req_data->result = kGpioErrSys;
+      return;
+    }
+  } else {
+    // Export GPIO pin.
+    if (!gpio->_ExportPin(req_data->pin)) {
+      req_data->result = kGpioErrSys;
+      return;
+    }
+    // Set direction.
+    if (!gpio->_SetPinDirection(req_data->pin, req_data->dir)) {
+      req_data->result = kGpioErrSys;
+      return;
+    }
+    // Set mode.
+    if (!gpio->_SetPinMode(req_data->pin, req_data->mode)) {
+      req_data->result = kGpioErrSys;
+      return;
+    }
+  }
+
+  req_data->result = kGpioErrOk;
+}
+
+
+void WritePinWorker(uv_work_t* work_req) {
+  GpioLinuxMraa* gpio = GpioLinuxMraa::GetInstance();
+  IOTJS_ASSERT(gpio->_initialized == true);
+
+  GpioReqWrap* gpio_req = reinterpret_cast<GpioReqWrap*>(work_req->data);
+  GpioReqData* req_data = gpio_req->req();
+
+  DDDLOG("GPIO WritePinWorker() - pin: %d, value: %d",
+         req_data->pin, req_data->value);
+
+  if (gpio->_WritePin(req_data->pin, req_data->value)) {
+    req_data->result = kGpioErrOk;
+  } else {
+    req_data->result = kGpioErrSys;
+  }
+}
+
+
+void ReadPinWorker(uv_work_t* work_req) {
+  GpioLinuxMraa* gpio = GpioLinuxMraa::GetInstance();
+  IOTJS_ASSERT(gpio->_initialized == true);
+
+  GpioReqWrap* gpio_req = reinterpret_cast<GpioReqWrap*>(work_req->data);
+  GpioReqData* req_data = gpio_req->req();
+
+  DDDLOG("GPIO ReadPinWorker() - pin: %d" ,req_data->pin);
+
+  if (gpio->_ReadPin(req_data->pin, &req_data->value)) {
+    req_data->result = kGpioErrOk;
+  } else {
+    req_data->result = kGpioErrSys;
+  }
+}
+
+
+#define GPIO_LINUX_MRAA_IMPL_TEMPLATE(op, initialized) \
+  do { \
+    GpioLinuxMraa* gpio = GpioLinuxMraa::GetInstance(); \
+    IOTJS_ASSERT(gpio->_initialized == initialized); \
+    Environment* env = Environment::GetEnv(); \
+    uv_work_t* req = new uv_work_t; \
+    req->data = reinterpret_cast<void*>(gpio_req); \
+    uv_queue_work(env->loop(), req, op ## Worker, AfterWork); \
+  } while (0)
+
+
+int GpioLinuxMraa::Initialize(GpioReqWrap* gpio_req) {
+  GPIO_LINUX_MRAA_IMPL_TEMPLATE(Initialize, false);
+  return 0;
+}
+
+
+int GpioLinuxMraa::Release(GpioReqWrap* gpio_req) {
+  GPIO_LINUX_MRAA_IMPL_TEMPLATE(Release, true);
+  return 0;
+}
+
+
+int GpioLinuxMraa::SetPin(GpioReqWrap* gpio_req) {
+  GPIO_LINUX_MRAA_IMPL_TEMPLATE(SetPin, true);
+  return 0;
+}
+
+
+int GpioLinuxMraa::WritePin(GpioReqWrap* gpio_req) {
+  GPIO_LINUX_MRAA_IMPL_TEMPLATE(WritePin, true);
+  return 0;
+}
+
+
+int GpioLinuxMraa::ReadPin(GpioReqWrap* gpio_req) {
+  GPIO_LINUX_MRAA_IMPL_TEMPLATE(ReadPin, true);
+  return 0;
+}
+
+
+} // namespace iotjs
+
+
+#endif /* IOTJS_MODULE_GPIO_LINUX_MRAA_INL_H */

--- a/src/platform/x86_64-linux/iotjs_module_gpio-x86_64-linux.cpp
+++ b/src/platform/x86_64-linux/iotjs_module_gpio-x86_64-linux.cpp
@@ -16,6 +16,22 @@
 
 #if defined(__LINUX__)
 
+ #if defined(USING_MRAA)
+
+#include "../iotjs_module_gpio-linux-mraa.inl.h"
+
+
+namespace iotjs {
+
+
+Gpio* Gpio::Create(JObject& jgpio) {
+  return new GpioLinuxMraa(jgpio);
+}
+
+
+} // namespace iotjs
+
+ #else
 
 #include "../iotjs_module_gpio-linux-general.inl.h"
 
@@ -30,5 +46,6 @@ Gpio* Gpio::Create(JObject& jgpio) {
 
 } // namespace iotjs
 
+ #endif
 
 #endif

--- a/tools/build.py
+++ b/tools/build.py
@@ -179,6 +179,8 @@ def init_option():
 
     parser.add_argument('--external-static-lib', action='append')
 
+    parser.add_argument('--external-shared-lib', action='append')
+
     parser.add_argument('--jerry-cmake-param', action='append')
 
     parser.add_argument('--jerry-compile-flag', action='append')
@@ -234,6 +236,8 @@ def adjust_option(option):
         option.external_include_dir = []
     if option.external_static_lib == None:
         option.external_static_lib = []
+    if option.external_shared_lib == None:
+        option.external_shared_lib = []
     if option.jerry_cmake_param == None:
         option.jerry_cmake_param = []
     if option.jerry_compile_flag == None:
@@ -639,6 +643,14 @@ def build_iotjs(option):
 
     # --cmake-param
     cmake_opt += option.cmake_param
+
+    # --external_static_lib
+    cmake_opt.append('-DEXTERNAL_STATIC_LIB=' +
+                    ' '.join(option.external_static_lib))
+
+    # --external_shared_lib
+    cmake_opt.append('-DEXTERNAL_SHARED_LIB=' +
+                    ' '.join(option.external_shared_lib))
 
     # inflate cmake option
     inflate_cmake_option(cmake_opt, option)


### PR DESCRIPTION
1, implement the external-static-lib and **externel-shared-lib** in build.py.
the externel shared lib is needed, because link-flag will put the `.so` in the wrong link order. see #272 for details.

2, implement GPIO with libmraa.
the building commands canbe:
`./tools/build.py --target-arch=i686 --compile-flag="-DUSING_MRAA" --external-include-dir="/home/jzd/iotm" --external-shared-lib="/home/jzd/iotm/libmraa.so"`
2.1: the header file and shared lib I used the command are taken from yocto linux in Edison board. And I put them into /home/jzd/iotm
2.2: USING_MRAA is a macro, which will affect the GPIO implementation in `iotjs_module_gpio-xxx-linux.cpp`. If it is defined, the iotjs will use mraa to implement GPIO. 

Mraa handles the complex mapping between board IO pin and kernel IO pin. If user want to handle the GPIO pin 13 on one board, he/she just operate the pin 13 by iotjs GPIO api. It makes the development more convenient.

example:
```javascript
var gpio = require("gpio");
gpio.initialize(init_done);
function init_done() {
  print("init done!");
  gpio.setPin(13, "out", set_done);// the led is in the board pin 13
}
function set_done() {
  print("set done!");
   gpio.writePin(13, 1);
}
```