### PR TITLE
Do not turn on `JERRY_FLAG_SHOW_OPCODE`

### DIFF
--- a/src/iotjs.cpp
+++ b/src/iotjs.cpp
@@ -39,7 +39,7 @@ static bool InitJerry() {
 
 #ifdef ENABLE_JERRY_MEM_STATS
   jerry_flag |= JERRY_FLAG_MEM_STATS;
-  jerry_flag |= JERRY_FLAG_SHOW_OPCODES;
+//  jerry_flag |= JERRY_FLAG_SHOW_OPCODES;
 #endif
 
   jerry_init(jerry_flag);


### PR DESCRIPTION
There is a bug on pretty printer of JerryScript https://github.com/Samsung/jerryscript/issues/680 that prevents printing opcodes for certain tests.

IoT.js turns on 'show opcode' flag when memstat is needed. but 'show opcode' is not directly linked with memstat and even it prevent us from checking memstat due to ICE. That I think we don't need to turn on 'show opcode' for 'memstat'.

If 'show opcode' is really needed for other purpose, add a build option for it other than `ENABLE_JERRY_MEM_STATS`.
