### PR TITLE
Added IoT.js command line option '--memstat' and '--show-opcodes'

### DIFF
--- a/src/iotjs_env.cpp
+++ b/src/iotjs_env.cpp
@@ -1,0 +1,100 @@
+/* Copyright 2015 Samsung Electronics Co., Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "iotjs_env.h"
+
+#include <string.h>
+
+
+namespace iotjs {
+
+
+/**
+ * Construct an instance of Environment.
+ */
+Environment::Environment()
+    : _argc(0)
+    , _argv(NULL)
+    , _loop(NULL)
+    , _state(kInitializing) {
+  _config.memstat = false;
+  _config.show_opcode = false;
+}
+
+
+/**
+ * Release an instance of Environment.
+ */
+Environment::~Environment() {
+  if (_argv) {
+    // release command line argument strings.
+    // _argv[0] and _argv[1] refer addresses in static memory space.
+    // Ohters refer adresses in heap space that is need to be deallocated.
+    for (int i = 2; i < _argc; ++i) {
+      delete _argv[i];
+    }
+    delete _argv;
+  }
+}
+
+/**
+ * Parse command line arguments
+ */
+bool Environment::ParseCommandLineArgument(int argc, char** argv) {
+  // There must be at least two arguemnts.
+  if (argc < 2) {
+    fprintf(stderr,
+            "usage: iotjs <js> [<iotjs arguments>] [-- <app arguments>]\n");
+    return false;
+  }
+
+  // Second argument should be IoT.js application.
+  char* app = argv[1];
+  _argc = 2;
+
+  // Parse IoT.js command line arguments.
+  int i = 2;
+  while (i < argc) {
+    if (!strcmp(argv[i], "--")) {
+      ++i;
+      break;
+    }
+    if (!strcmp(argv[i], "--memstat")) {
+      _config.memstat = true;
+    } else if (!strcmp(argv[i], "--show-opcodes")) {
+      _config.show_opcode = true;
+    } else {
+      fprintf(stderr, "unknown command line argument %s\n", argv[i]);
+      return false;
+    }
+    ++i;
+  }
+
+  // Remaining arguments are for application.
+  _argv = new char*[_argc + argc - i];
+  _argv[0] = argv[0];
+  _argv[1] = argv[1];
+  while (i < argc) {
+    _argv[_argc] = new char[strlen(argv[i]) + 1];
+    strcpy(_argv[_argc], argv[i]);
+    _argc++;
+    i++;
+  }
+
+  return true;
+}
+
+
+} // namespace iotjs

--- a/src/iotjs_env.h
+++ b/src/iotjs_env.h
@@ -24,6 +24,12 @@
 namespace iotjs {
 
 
+struct Config {
+  bool memstat;
+  bool show_opcode;
+};
+
+
 class Environment {
  public:
   enum State {
@@ -33,6 +39,9 @@ class Environment {
     kExiting
   };
 
+  /**
+   * Get the singleton instance of Environment.
+   */
   static Environment* GetEnv() {
     if (Environment::_env == NULL) {
       Environment::_env = new Environment();
@@ -40,6 +49,9 @@ class Environment {
     return _env;
   }
 
+  /**
+   * Release the singleton instance of Environment.
+   */
   static void Release() {
     if (Environment::_env) {
       delete Environment::_env;
@@ -47,19 +59,21 @@ class Environment {
     }
   }
 
-  void Init(int argc, char** argv, uv_loop_t* loop) {
-    _argc = argc;
-    _argv = argv;
-    _loop = loop;
-  }
+  /**
+   * Parse command line arguments
+   */
+  bool ParseCommandLineArgument(int argc, char** argv);
 
   int argc() {return _argc; }
 
   char** argv() { return _argv; }
 
   uv_loop_t* loop() { return _loop; }
+  void set_loop(uv_loop_t* loop) { _loop = loop; }
 
   State state() { return _state; }
+
+  const Config* config() { return &_config;}
 
   void GoStateRunningMain() {
     IOTJS_ASSERT(_state == kInitializing);
@@ -77,21 +91,33 @@ class Environment {
   }
 
  private:
+  // Number of application arguments including 'iotjs' and app name.
   int _argc;
+
+  // Application arguments list including 'iotjs' and app name.
   char** _argv;
+
+  // I/O event loop.
   uv_loop_t* _loop;
 
+  // Running state.
   State _state;
+
+  // Run config
+  Config _config;
 
 
  private:
-  Environment()
-      : _argc(0)
-      , _argv(NULL)
-      , _loop(NULL)
-      , _state(kInitializing) {
-  }
+  /**
+   * Constructor on private section.
+   *  To prevent create an instance of Environment.
+   *  The only way to create an instance of Environment is by using GetEnv().
+   */
+  Environment();
 
+  ~Environment();
+
+  // The singleton instance of Environment.
   static Environment* _env;
 }; // class Environment
 

--- a/tools/build.py
+++ b/tools/build.py
@@ -213,9 +213,6 @@ def init_option():
 
 
 def adjust_option(option):
-    if option.jerry_memstat:
-        option.buildtype = 'debug'
-        option.no_check_test = True
     if option.target_os.lower() == 'nuttx':
         option.buildlib = True;
         if option.nuttx_home == '':
@@ -644,10 +641,6 @@ def build_iotjs(option):
     # --build-lib
     if option.buildlib:
         cmake_opt.append('-DBUILD_TO_LIB=YES')
-
-    # --jerry-memstat
-    if option.jerry_memstat:
-        option.compile_flag.append('-DENABLE_JERRY_MEM_STATS')
 
     # --cmake-param
     cmake_opt += option.cmake_param


### PR DESCRIPTION
Added IoT.js command line option '--memstat' and '--show-opcodes'

Removed `ENABLE_JERRY_MEM_STATS` compilation flag.

Related issue: #312
