### PR TITLE
Separate the iotjs.js and other js modules in iotjs_js.h.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 /build
 /build/*
 /src/iotjs_js.h
+/src/native_js.h
 /test/tmp/*
 
 # IDE related files

--- a/src/iotjs_module_process.cpp
+++ b/src/iotjs_module_process.cpp
@@ -15,7 +15,7 @@
 
 #include "iotjs_def.h"
 #include "iotjs_module_process.h"
-#include "iotjs_js.h"
+#include "native_js.h"
 
 #include <stdio.h>
 #include <stdlib.h>

--- a/tools/js2c.py
+++ b/tools/js2c.py
@@ -67,10 +67,16 @@ LICENSE = '''/* Copyright 2015 Samsung Electronics Co., Ltd.
  */
 '''
 
-HEADER = '''#ifndef IOTJS_JS_H
+HEADER1 = '''#ifndef IOTJS_JS_H
 #define IOTJS_JS_H
 namespace iotjs {
 '''
+
+HEADER2 = '''#ifndef NATIVE_JS_H
+#define NATIVE_JS_H
+namespace iotjs {
+'''
+
 FOOTER = '''}
 #endif
 '''
@@ -87,14 +93,20 @@ if len(sys.argv) >= 2:
     no_snapshot = True if sys.argv[2] == 'no_snapshot' else False
     DUMPER = sys.argv[3]
 
-fout = open(SRC_PATH + 'iotjs_js.h', 'w')
-
-fout.write(LICENSE);
-fout.write(HEADER);
+fout1 = open(SRC_PATH + 'iotjs_js.h', 'w')
+fout2 = open(SRC_PATH + 'native_js.h', 'w')
+fout1.write(LICENSE);
+fout1.write(HEADER1);
+fout2.write(LICENSE);
+fout2.write(HEADER2);
 
 files = glob.glob(JS_PATH + '*.js')
 for path in files:
     name = extractName(path)
+    if name != 'iotjs':
+        fout = fout2
+    else:
+        fout = fout1
     fout.write('const char ' + name + '_n [] = "' + name + '";\n')
     if no_snapshot == True:
         fout.write('const char ' + name + '_s [] = {\n')
@@ -169,11 +181,14 @@ const size_t length;
 __attribute__ ((used)) static struct native_mod natives[] = {
 '''
 
-fout.write(NATIVE_STRUCT)
+fout2.write(NATIVE_STRUCT)
 filenames = map(extractName, files)
 for name in filenames:
-    writeLine(fout, '{ ' + name + '_n, ' + name + '_s, ' + name + '_l },', 1)
-writeLine(fout, '{ NULL, NULL, 0 }', 1)
-writeLine(fout, '};')
+    if name != 'iotjs':
+        writeLine(fout2,
+                  '{ ' + name + '_n, ' + name + '_s, ' + name + '_l },', 1)
+writeLine(fout2, '{ NULL, NULL, 0 }', 1)
+writeLine(fout2, '};')
 
-fout.write(FOOTER)
+fout1.write(FOOTER)
+fout2.write(FOOTER)


### PR DESCRIPTION
problem
---
`js2c.py` will turn all js module code and `iotjs.js` into const array in `iotjs_js.h`.

`iotjs.cpp` needs `iotjs.js`, `iotjs_module_process.cpp` needs other js modules, so they both include `iotjs_js.h`

Every const char array are stored in the .rodata section **twice**, which waste the storage resource, especially in embedded environment. e.g. for `System.map` in nuttx, 
```
jzd@jzd32:~/nuttx_ws/nuttx/nuttx$ cat iotjs/System.map | grep iotjs_s
0805e624 t _ZN5iotjsL7iotjs_sE
08083574 t _ZN5iotjsL7iotjs_sE
jzd@jzd32:~/nuttx_ws/nuttx/nuttx$ cat iotjs/System.map | grep gpio_s
080612ac t _ZN5iotjsL6gpio_sE
0807555c t _ZN5iotjsL6gpio_sE
```
solution
---
separate the iotjs_js.h into 2 files:
1. `iotjs_js.h` is only for `iotjs.js` 
2. `native_js.h` is for all other native js modules

So that no array will be multiple referenced.

result
---
in nuttx case, when the jerryheap is set to 64KB

||origin(kb)|after patch(kb)|decrease(%)|
---|---|---|---
whole flash size(nuttx.bin)|553|480|13.2|
iotjs own flash size (text + rodata + data)|425|352|17.1|

the iotjs own flash size is from `System.map`
**It can save more than 10% flash memory**
