### PR TITLE
js2c.py generate iotjs_js.h and iotjs_js.cpp

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,7 +3,7 @@
 /build
 /build/*
 /src/iotjs_js.h
-/src/native_js.h
+/src/iotjs_js.cpp
 /test/tmp/*
 
 # IDE related files

--- a/src/iotjs_module_process.cpp
+++ b/src/iotjs_module_process.cpp
@@ -15,7 +15,7 @@
 
 #include "iotjs_def.h"
 #include "iotjs_module_process.h"
-#include "native_js.h"
+#include "iotjs_js.cpp"
 
 #include <stdio.h>
 #include <stdlib.h>


### PR DESCRIPTION
follow @wateret suggestion in #318 

js2c.py generate iotjs_js.h and iotjs_js.cpp, and put definations into the cpp file, put declaration into the header file.In this way, other cpp files can include the iotjs_js.h when they needs the module codes, and that actions will not waste flashsize.

In nuttx, the total size of nuttx.bin is same (481k) after this patch