### PR TITLE
Add missing license notice for 'node.js' derived codes.

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -189,3 +189,30 @@ limitations under the License.
       of your accepting any such warranty or additional liability.
 
    END OF TERMS AND CONDITIONS
+
+--------
+
+   Copyright Node.js contributors. All rights reserved.
+
+   Permission is hereby granted, free of charge, to any person obtaining a copy
+   of this software and associated documentation files (the "Software"), to
+   deal in the Software without restriction, including without limitation the
+   rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+   sell copies of the Software, and to permit persons to whom the Software is
+   furnished to do so, subject to the following conditions:
+
+   The above copyright notice and this permission notice shall be included in
+   all copies or substantial portions of the Software.
+
+   THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+   IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+   FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+   AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+   LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+   FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+   IN THE SOFTWARE.
+
+
+   This license applies to parts of '*.js' files in '/src/js', implementing node.js 
+   compatible API, originating from the https://github.com/node/node repository:
+


### PR DESCRIPTION
IoT.js-DCO-1.0-Signed-off-by: Sung-Jae Lee sjlee@mail.com