### PR TITLE
Fix string length computation in iotjs::WrapEval

### DIFF
--- a/src/iotjs_module_process.cpp
+++ b/src/iotjs_module_process.cpp
@@ -130,10 +130,10 @@ static JResult WrapEval(const char* source) {
   int len2 = strlen(source);
   int len3 = strlen(wrapper[1]);
 
-  String code("", len1 + len2 + len3 + 1);
+  String code(NULL, len1 + len2 + len3);
   strcpy(code.data(), wrapper[0]);
-  strcat(code.data() + len1, source);
-  strcat(code.data() + len1 + len2, wrapper[1]);
+  strcpy(code.data() + len1, source);
+  strcpy(code.data() + len1 + len2, wrapper[1]);
 
   return JObject::Eval(code);
 }


### PR DESCRIPTION
The iotjs::String constructor automatically allocates at least
size+1 bytes for the data (that +1 byte for the terminating zero),
so there is no need for the +1 on the caller side.

Moreover, strcpy can work just as fine as strcat in this case,
since caller knows where the first string ends, so there is no need
to make strcat figure that out.

IoT.js-DCO-1.0-Signed-off-by: Akos Kiss akiss@inf.u-szeged.hu