### PR TITLE
Make license checking future proof

### DIFF
--- a/tools/check_license.py
+++ b/tools/check_license.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 
-# Copyright 2015 Samsung Electronics Co., Ltd.
+# Copyright 2015-2016 Samsung Electronics Co., Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -17,7 +17,7 @@
 import re;
 
 license = re.compile(
-u"""(#|//|\*) Copyright 2015 Samsung Electronics Co., Ltd.
+u"""(#|//|\*) Copyright \d{4}(-\d{4})? Samsung Electronics Co., Ltd.
 \s?\\1
 \s?\\1 Licensed under the Apache License, Version 2.0 \(the "License"\);
 \s?\\1 you may not use this file except in compliance with the License.


### PR DESCRIPTION
Instead of checking for a fixed year in the copyright message,
allow any year or interval.

IoT.js-DCO-1.0-Signed-off-by: Akos Kiss akiss@inf.u-szeged.hu