### PR TITLE
Fix valgrind memcheck issues

### DIFF
--- a/src/iotjs_env.cpp
+++ b/src/iotjs_env.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2015 Samsung Electronics Co., Ltd.
+/* Copyright 2015-2016 Samsung Electronics Co., Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -45,7 +45,7 @@ Environment::~Environment() {
     for (int i = 2; i < _argc; ++i) {
       delete _argv[i];
     }
-    delete _argv;
+    delete [] _argv;
   }
 }
 

--- a/src/js/buffer.js
+++ b/src/js/buffer.js
@@ -1,4 +1,4 @@
-/* Copyright 2015 Samsung Electronics Co., Ltd.
+/* Copyright 2015-2016 Samsung Electronics Co., Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -151,6 +151,7 @@ Buffer.prototype.write = function(string, offset, length) {
   var remaining = this.length - offset;
   length = util.isUndefined(length) ? remaining : ~~length;
   length = boundRange(length, 0, remaining);
+  length = boundRange(length, 0, string.length);
 
   return this._builtin.write(string, offset, length);
 };


### PR DESCRIPTION
I've run iotjs through valgrind with its own "pass tests". It has reported some memory issues which are fixed in this PR's patches.

Depends on #332 