### PR TITLE
Compiling for Edison generated duplicated symbols

### DIFF
--- a/docs/Build-for-Edison-with-mraa.md
+++ b/docs/Build-for-Edison-with-mraa.md
@@ -29,6 +29,7 @@ In host PC
 ```
 cd mraa
 scp root@{edison ip}:/usr/lib/libmraa.so .
+scp root@{edison ip}:/usr/lib/libft4222.so .
 scp root@{edison ip}:/usr/include/mraa.h .
 scp -r root@{edison ip}:/usr/include/mraa .
 ```
@@ -40,10 +41,11 @@ in the folder `iotjs`
 ./tools/build.py \
 --target-arch=i686 \
 --compile-flag="-DUSING_MRAA" \
---external-include-dir="/home/jzd/iotjs/mraa" \
---external-shared-lib="/home/jzd/iotjs/mraa/libmraa.so"
+--external-include-dir="/home/jzd/edison/mraa" \
+--external-shared-lib="/home/jzd/edison/mraa/libmraa.so"
 ```
 **NOTE:** You should replace the above path with actual path in your host.
+The Yocto mraa.h will generate problems with check_tidy.py if it is inside the iotjs project.
 
 ## 3. Copy the binary into Edison
 

--- a/src/iotjs_module_process.cpp
+++ b/src/iotjs_module_process.cpp
@@ -15,7 +15,7 @@
 
 #include "iotjs_def.h"
 #include "iotjs_module_process.h"
-#include "iotjs_js.cpp"
+#include "iotjs_js.h"
 
 #include <stdio.h>
 #include <stdlib.h>


### PR DESCRIPTION
Including the .cpp instead of the header generated duplicated symbols when compiling for Edison.
follow @wateret suggestion in #325

Also adding extra information about how to compile for Edison.

Added clarification about the folder to set mraa.h
The Intel license headers are not the same as the Samsung ones,
so the --no_check_tidy is required if added into the iotjs project folder.

Original Edison libmraa.so requires libft4222.so symbols to link in ubuntu.

Hope it doesn't break other builds, I've been trying to check against the other examples.

Signed-off-by: Martinez Rodriguez, Sergio <sergio.martinez.rodriguez@intel.com>