### PR TITLE
Don't rely on JS source being terminated with NL

### DIFF
--- a/src/iotjs_module_process.cpp
+++ b/src/iotjs_module_process.cpp
@@ -124,7 +124,7 @@ JHANDLER_FUNCTION(Binding) {
 static JResult WrapEval(const char* source, size_t length) {
   static const char* wrapper[2] = {
       "(function(exports, require, module) {\n",
-      "});\n" };
+      "\n});\n" };
 
   int len0 = strlen(wrapper[0]);
   int len1 = strlen(wrapper[1]);


### PR DESCRIPTION
Currently, it causes a "statement expected" error if last line of
JS code to be executed is a comment but not terminated with a NL.
This patch fixes that by always appending a NL character.

IoT.js-DCO-1.0-Signed-off-by: Akos Kiss akiss@inf.u-szeged.hu

(Note: I wanted to add a regression test to `test/run_pass/issue` but couldn't as our tidyness checker does not let files be added to the code base with no NL at EOF...)