### PR TITLE
Remove leftover dead code from command line parsing

### DIFF
--- a/src/iotjs_env.cpp
+++ b/src/iotjs_env.cpp
@@ -60,10 +60,6 @@ bool Environment::ParseCommandLineArgument(int argc, char** argv) {
     return false;
   }
 
-  // Second argument should be IoT.js application.
-  char* app = argv[1];
-  _argc = 2;
-
   // Parse IoT.js command line arguments.
   int i = 2;
   while (i < argc) {
@@ -83,6 +79,7 @@ bool Environment::ParseCommandLineArgument(int argc, char** argv) {
   }
 
   // Remaining arguments are for application.
+  _argc = 2;
   _argv = new char*[_argc + argc - i];
   _argv[0] = argv[0];
   _argv[1] = argv[1];


### PR DESCRIPTION
(...and relocate the initialization of `_argc` where it fits
better.)

IoT.js-DCO-1.0-Signed-off-by: Akos Kiss akiss@inf.u-szeged.hu