### PR TITLE
modify docs/Build-for-Linux.md. Because there is wrong build option.

### DIFF
--- a/docs/Build-for-Linux.md
+++ b/docs/Build-for-Linux.md
@@ -55,31 +55,46 @@ Existing build options are listed as follows;
 ```
 buildtype=debug|release (debug is default)
 builddir=build (build is default)
+clean
 buildlib (default is False)
-target-arch=x86_64|i686|arm (depends on your host platform)
-target-os=linux|nuttx (linux is default)
-make-flags=-j (options to send to make)
-nuttx-home= (no default value)
-init-submodule (default is True)
-tidy (default is True)
-jerry-memstats (default is False)
-checktest (default is True)
+target-arch=x86|x86_64|x64|i686|arm (depends on your host platform)
+target-os=linux|nuttx|darwin|osx (linux is default)
+target-board
+cmake-param
+compile-flag
+link_flag
+external-include-dir
+external-static-lib
+external-shared-lib
+jerry-cmake-param
+jerry-compile-flag
+jerry-link-flag
+jerry-lto
+jerry-heap-section
 jerry-heaplimit (default is 81, may change)
-tuv (default is False)
+jerry-memstat (default is False)
+no-init-submodule (default is init)
+no-check-tidy (default is check)
+no-check-test (default is check)
+no-parallel-build
+no-snapshot
+nuttx-home= (no default value)
 ```
 
 To give options, please use two dashes '--' before the option name as described in following sections.
 
 Options that may need explanations.
-* builddir: compile intermediate and output files are generated here. 
+* builddir: compile intermediate and output files are generated here.
 * buildlib: generating _iotjs_ to a library if True(e.g. for NuttX). give __--buildlib__ to make it True.
-* nuttx-home: it's NuttX platform specific, to tell where the NuttX configuration and header files are.
-* init-submodule: for normal cases you can ignore this, it will checkout matching revision of each sub-module library every time. but if you want to change something or checkout other revision, use __--noinit-submodule__.
-* tidy: checks codes are tidy. we recommend to use this option. use __--notidy__ if you want to turn it off.
-* jerry-memstats: turn on the flag so that jerry dumps byte codes and literals and memory usage while parsing and execution.
-* checktest: after build makes it run all tests in test folder
+* init-submodule: for normal cases you can ignore this, it will checkout matching revision of each sub-module library every time. but if you want to change something or checkout other revision, use __--no-init-submodule__.
 * jerry-heaplimit: JerryScript default heap size (as of today) is 256Kbytes. This option is to change the size for embedded systems, nuttx for now, and current default is 81KB. For linux, this has no effect. While building nuttx if you see an error `region sram overflowed by xxxx bytes`, you may have to decrease about that amount.
-* tuv: Use `libtuv` instead of `libuv`. When we think tuv is ready, this will be default option.
+* jerry-memstats: turn on the flag so that jerry dumps byte codes and literals and memory usage while parsing and execution.
+* no-check-tidy: no checks codes are tidy. we recommend to check tidy.
+* no-check-test: do not run all tests in test folder after build.
+* nuttx-home: it's NuttX platform specific, to tell where the NuttX configuration and header files are.
+
+If you want to more detail about options, please check [Build Script](https://github.com/Samsung/iotjs/wiki/Build%20Script).
+
 
 ### 3. Build all at once
 
@@ -106,13 +121,9 @@ If you want to build 32bit version in x86_64 and debug version only produce a li
 
 To build release version and with different jerry revision. assume you have already checked it out.
 ```
-./tools/build.py --buildtype=release --noinit-submodule
+./tools/build.py --buildtype=release --no-init-submodule
 ```
 
-To build with tuv,
-```
-./tools/build.py --tuv
-```
 
 
 #### Build only IoT.js with given build option

--- a/docs/Build-for-NuttX.md
+++ b/docs/Build-for-NuttX.md
@@ -172,7 +172,7 @@ As noted in [Build for Linux](Build-for-Linux.md) page, you need to give additio
 --target-os=nuttx 
 --nuttx-home=(full path of nuttx home where .config file exist)
 --buildlib
---no-checktest
+--no-check-test
 ```
 Have to disable 'checktest' as test with Nuttx binaries are not possible.
 `buildlib` for nuttx is turned on for default.
@@ -199,7 +199,7 @@ If you have harmony in /home/maxwell/harmony, for example;
 ```
 cd harmony/iotjs
 ./tools/build.py --buildtype=release --target-arch=arm --target-os=nuttx \
---nuttx-home=/home/maxwell/harmony/nuttx/nuttx --no-checktest
+--nuttx-home=/home/maxwell/harmony/nuttx/nuttx --no-check-test
 ```
 
 ### 4. Copy libraries to nuttx/nuttx/lib folder


### PR DESCRIPTION
IoT.js-DCO-1.0-Signed-off-by: Hosung Kim hs852.kim@samsung.com