### PR TITLE
Remove "--static" option for RPi2.

### DIFF
--- a/.build.default.config
+++ b/.build.default.config
@@ -61,7 +61,6 @@
                      "-DTARGET_BOARD=STM32F4DIS"],
       "rpi2": ["-mcpu=cortex-a7",
                "-mfpu=neon-vfpv4",
-               "--static",
                "-DTARGET_BOARD=RP2"]
     },
     "buildtype": {


### PR DESCRIPTION
This build option causes a warning during build IoT.js with "--target-board=rpi2" option.

Without this option, it passes all test cases in test folder.
(Before removing this option, 4 tests are failed. - net3,7,8 and dns)

It tested based on "Raspbian JESSIE" which released on May, 2016. (with RPi3)

IoT.js-DCO-1.0-Signed-off-by: Jaechul Yang jc08.yang@samsung.com