### PR TITLE
Fix Issue #323 (empty string as a file path)

### DIFF
--- a/src/iotjs_util.cpp
+++ b/src/iotjs_util.cpp
@@ -93,7 +93,7 @@ String::String(const char* data, int size, int cap) {
   IOTJS_ASSERT(_size >= 0);
   IOTJS_ASSERT(_cap >= 0);
 
-  if (_cap > 0) {
+  if (_cap >= 0) {
     _data = AllocBuffer(_cap + 1);
   } else {
     _data = NULL;

--- a/test/run_pass/issue/issue-323.js
+++ b/test/run_pass/issue/issue-323.js
@@ -1,0 +1,27 @@
+/* Copyright 2015 Samsung Electronics Co., Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+var fs = require('fs');
+var assert = require('assert');
+
+var fileName = "";
+
+assert.throws(
+    function() {
+      var stats1 = fs.statSync(fileName);
+    },
+    Error
+);
+


### PR DESCRIPTION
empty filename as an argument to 'fs' module should not make any segmentation faults. -Fix Issue #323