### PR TITLE
Fix UnicodeDecodeError on running check_test.py (#404)

### DIFF
--- a/tools/check_test.py
+++ b/tools/check_test.py
@@ -72,7 +72,7 @@ def is_javascript(name):
 
 
 def read_file_contents(filepath):
-    f = open(filepath, 'r')
+    f = open(filepath, 'r', encoding='utf-8')
     return f.read().encode().decode().strip()
 
 


### PR DESCRIPTION
Set encoding type utf-8 explicitly to fix UnicodeDecodeError

IoT.js-DCO-1.0-Signed-off-by: Sanggyu Lee sg5.lee@samsung.com