### PR TITLE
Correct tidy and license check

### DIFF
--- a/tools/check_license.py
+++ b/tools/check_license.py
@@ -17,19 +17,19 @@
 import re;
 
 license = re.compile(
-u"""(#|//|\*) Copyright \d{4}(-\d{4})? Samsung Electronics Co., Ltd.
-\s?\\1
-\s?\\1 Licensed under the Apache License, Version 2.0 \(the "License"\);
-\s?\\1 you may not use this file except in compliance with the License.
-\s?\\1 You may obtain a copy of the License at
-\s?\\1
-\s?\\1     http://www.apache.org/licenses/LICENSE-2.0
-\s?\\1
-\s?\\1 Unless required by applicable law or agreed to in writing, software
-\s?\\1 distributed under the License is distributed on an "AS IS" BASIS
-\s?\\1 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-\s?\\1 See the License for the specific language governing permissions and
-\s?\\1 limitations under the License.""")
+u"""((#|//|\*) Copyright .*
+)+\s?\\2
+\s?\\2 Licensed under the Apache License, Version 2.0 \(the "License"\);
+\s?\\2 you may not use this file except in compliance with the License.
+\s?\\2 You may obtain a copy of the License at
+\s?\\2
+\s?\\2     http://www.apache.org/licenses/LICENSE-2.0
+\s?\\2
+\s?\\2 Unless required by applicable law or agreed to in writing, software
+\s?\\2 distributed under the License is distributed on an "AS IS" BASIS
+\s?\\2 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+\s?\\2 See the License for the specific language governing permissions and
+\s?\\2 limitations under the License.""")
 
 
 def check_license(contents):

--- a/tools/check_tidy.py
+++ b/tools/check_tidy.py
@@ -33,7 +33,7 @@ count_err = 0
 
 interesting_exts = ['.c', '.cpp', '.cc', '.h', '.js', '.py', '.sh', '.cmake']
 skip_dirs = ['deps', 'build']
-skip_files = ['iotjs_js.h']
+skip_files = ['iotjs_js.h', 'check_signed_off.sh']
 
 
 def report_error_name_line(name, line, msg):
@@ -56,7 +56,7 @@ def check_tidy(src_dir):
     count_empty_lines = 0
 
     for (dirpath, dirnames, filenames) in os.walk(src_dir):
-        if any(d in dirpath for d in skip_dirs):
+        if any(d in os.path.relpath(dirpath, src_dir) for d in skip_dirs):
             continue
 
         files = [os.path.join(dirpath, name) for name in filenames


### PR DESCRIPTION
- Enable tidy check in travis 
  (We exclude 'build' directory when tidy checking, but travis build path starts with '/home/travis/build')
- Adapt new license check script from jerryscript to be able to have multiple license owners
- Exclude check_signed_off.sh from tidy check (To make it easier to use the same script with jerryscript)