### PR TITLE
Cleanup module search path order

### DIFF
--- a/docs/IoT.js-API-Module.md
+++ b/docs/IoT.js-API-Module.md
@@ -12,9 +12,10 @@ Loads the module named 'id'
 #### ``` require ``` search paths
 ``` require ``` function finds modules in the order of
 
-1. caller's directory of ``` require ``` function
-2. node_modules under the caller's directory
+1. current working directory
+2. node_modules directory under current working directory
 3. $HOME/node_modules
+4. $NODE_PATH/node_modules
 
 
 #### ``` require('id') ``` works as follows:

--- a/src/iotjs_module_process.cpp
+++ b/src/iotjs_module_process.cpp
@@ -256,14 +256,26 @@ void SetNativeSources(JObject* native_sources) {
 
 
 static void SetProcessEnv(JObject* process){
-  const char *homedir;
+  const char *homedir, *nodepath;
   homedir = getenv("HOME");
   if (homedir == NULL) {
     homedir = "";
   }
   JObject home(homedir);
+  nodepath = getenv("NODE_PATH");
+  if (nodepath == NULL) {
+#if defined(__NUTTX__)
+    nodepath = "/mnt/sdcard";
+#else
+    nodepath = "";
+#endif
+  }
+  JObject node_path(nodepath);
+
   JObject env;
   env.SetProperty("HOME", home);
+  env.SetProperty("NODE_PATH", node_path);
+
   process->SetProperty("env", env);
 }
 

--- a/src/js/module.js
+++ b/src/js/module.js
@@ -32,15 +32,19 @@ Module.wrapper = Native.wrapper;
 Module.wrap = Native.wrap;
 
 
-var moduledirs;
-// In nuttx, we assume that modules are installed under
-// /mnt/sdcard/node_modules/ directory
-if(process.platform === 'nuttx'){
-  moduledirs = [ "", process.cwd()+"/", "/mnt/sdcard/node_modules/" ];
+var cwd;
+try { cwd = process.cwd(); } catch (e) { }
+
+var moduledirs = [""]
+if(cwd){
+  moduledirs.push(cwd + "/");
+  moduledirs.push(cwd + "/node_modules/");
 }
-else {
-  moduledirs = [ "", process.cwd()+"/", process.cwd()+"/node_modules/",
-                     process.env.HOME + "/node_modules/" ];
+if(process.env.HOME){
+  moduledirs.push(process.env.HOME + "/node_modules/");
+}
+if(process.env.NODE_PATH){
+  moduledirs.push(process.env.NODE_PATH + "/node_modules/")
 }
 
 Module.concatdir = function(a, b){


### PR DESCRIPTION
Now we can handle the case when some of cwd, $HOME, or $NODE_PATH is not valid.

Related issue: #49