### PR TITLE
Enable memstat and show_opcode log of JerryScript

### DIFF
--- a/cmake/jerry.cmake
+++ b/cmake/jerry.cmake
@@ -16,7 +16,8 @@ cmake_minimum_required(VERSION 2.8)
 
 set(JERRY_ROOT ${DEP_ROOT}/jerry)
 set(JERRY_CORE_ROOT ${JERRY_ROOT}/jerry-core)
-set(JERRY_INCDIR ${JERRY_CORE_ROOT})
+set(JERRY_PORT_ROOT ${JERRY_ROOT}/targets/default)
+set(JERRY_INCDIR ${JERRY_CORE_ROOT} ${JERRY_PORT_ROOT})
 set(JERRY_BIN ${BIN_ROOT}/deps/jerry)
 set(JERRY_LIB ${LIB_ROOT}/libjerrycore.a)
 

--- a/src/iotjs.cpp
+++ b/src/iotjs.cpp
@@ -22,6 +22,7 @@
 
 #include "jerry-api.h"
 #include "jerry-port.h"
+#include "jerry-port-default.h"
 
 #include <stdio.h>
 #include <string.h>
@@ -42,10 +43,12 @@ static bool InitJerry(Environment* env) {
 
   if (env->config()->memstat) {
     jerry_flag |= JERRY_INIT_MEM_STATS;
+    jerry_port_default_set_log_level(JERRY_LOG_LEVEL_DEBUG);
   }
 
   if (env->config()->show_opcode) {
     jerry_flag |= JERRY_INIT_SHOW_OPCODES;
+    jerry_port_default_set_log_level(JERRY_LOG_LEVEL_DEBUG);
   }
 
   // Initialize jerry.


### PR DESCRIPTION
Related issue: Samsung/jerryscript#1383