### PR TITLE
First Implementation I2C Module.

### DIFF
--- a/src/iotjs_module.cpp
+++ b/src/iotjs_module.cpp
@@ -26,6 +26,7 @@
 #include "iotjs_module_timer.h"
 #include "iotjs_module_gpio.h"
 #include "iotjs_module_httpparser.h"
+#include "iotjs_module_i2c.h"
 #include "iotjs_module_dns.h"
 
 

--- a/src/iotjs_module.h
+++ b/src/iotjs_module.h
@@ -34,6 +34,7 @@ typedef JObject* (*register_func)();
   F(FS, Fs, fs) \
   F(GPIO, Gpio, gpio) \
   F(HTTPPARSER, Httpparser, httpparser) \
+  F(I2C, I2c, i2c) \
   F(PROCESS, Process, process) \
   F(TCP, Tcp, tcp) \
   F(TIMER, Timer, timer)

--- a/src/iotjs_module_i2c.cpp
+++ b/src/iotjs_module_i2c.cpp
@@ -1,0 +1,140 @@
+/* Copyright 2016 Samsung Electronics Co., Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "iotjs_def.h"
+#include "iotjs_objectwrap.h"
+#include "iotjs_module_i2c.h"
+
+namespace iotjs {
+
+
+I2c::I2c(JObject& ji2c)
+    : JObjectWrap(ji2c) {
+}
+
+
+I2c::~I2c() {
+}
+
+
+JObject* I2c::GetJI2c() {
+  Module* module = GetBuiltinModule(MODULE_I2C);
+  JObject* ji2c = module->module;
+  IOTJS_ASSERT(ji2c != NULL);
+
+  return ji2c;
+}
+
+
+I2c* I2c::GetInstance() {
+  I2c* i2c = reinterpret_cast<I2c*>(I2c::GetJI2c()->GetNative());
+  IOTJS_ASSERT(i2c != NULL);
+
+  return i2c;
+}
+
+JHANDLER_FUNCTION(SetAddress) {
+  IOTJS_ASSERT(!"Not implemented");
+
+  handler.Return(JVal::Null());
+}
+
+
+JHANDLER_FUNCTION(Scan) {
+  IOTJS_ASSERT(!"Not implemented");
+
+  handler.Return(JVal::Null());
+}
+
+
+JHANDLER_FUNCTION(Open) {
+  IOTJS_ASSERT(!"Not implemented");
+
+  handler.Return(JVal::Null());
+}
+
+
+JHANDLER_FUNCTION(Close) {
+  IOTJS_ASSERT(!"Not implemented");
+
+  handler.Return(JVal::Null());
+}
+
+JHANDLER_FUNCTION(Write) {
+  IOTJS_ASSERT(!"Not implemented");
+
+  handler.Return(JVal::Null());
+}
+
+JHANDLER_FUNCTION(WriteByte) {
+  IOTJS_ASSERT(!"Not implemented");
+
+  handler.Return(JVal::Null());
+}
+
+JHANDLER_FUNCTION(WriteBlock) {
+  IOTJS_ASSERT(!"Not implemented");
+
+  handler.Return(JVal::Null());
+}
+
+JHANDLER_FUNCTION(Read) {
+  IOTJS_ASSERT(!"Not implemented");
+
+  handler.Return(JVal::Null());
+}
+
+JHANDLER_FUNCTION(ReadByte) {
+  IOTJS_ASSERT(!"Not implemented");
+
+  handler.Return(JVal::Null());
+}
+
+JHANDLER_FUNCTION(ReadBlock) {
+  IOTJS_ASSERT(!"Not implemented");
+
+  handler.Return(JVal::Null());
+}
+
+JObject* InitI2c() {
+  Module* module = GetBuiltinModule(MODULE_I2C);
+  JObject* ji2c = module->module;
+
+  if (ji2c == NULL) {
+    ji2c = new JObject();
+
+    ji2c->SetMethod("setAddress", SetAddress);
+    ji2c->SetMethod("scan", Scan);
+    ji2c->SetMethod("open", Open);
+    ji2c->SetMethod("close", Close);
+    ji2c->SetMethod("write", Write);
+    ji2c->SetMethod("writeByte", WriteByte);
+    ji2c->SetMethod("writeBlock", WriteBlock);
+    ji2c->SetMethod("read", Read);
+    ji2c->SetMethod("readByte", ReadByte);
+    ji2c->SetMethod("readBlock", ReadBlock);
+
+    // TODO: Need to implement Create for each platform.
+    // I2c* i2c = I2c::Create(*ji2c);
+    // IOTJS_ASSERT(i2c == reinterpret_cast<I2c*>(ji2c->GetNative()));
+
+    module->module = ji2c;
+  }
+
+  return ji2c;
+}
+
+
+} // namespace iotjs

--- a/src/iotjs_module_i2c.h
+++ b/src/iotjs_module_i2c.h
@@ -1,0 +1,63 @@
+/* Copyright 2016 Samsung Electronics Co., Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+#ifndef IOTJS_MODULE_I2C_H
+#define IOTJS_MODULE_I2C_H
+
+#include "iotjs_def.h"
+#include "iotjs_objectwrap.h"
+#include "iotjs_reqwrap.h"
+
+
+namespace iotjs {
+
+struct I2cReqData {
+  void* data; // pointer to I2cReqWrap
+};
+
+typedef ReqWrap<I2cReqData> I2cReqWrap;
+
+
+// This I2c class provides interfaces for I2C operation.
+class I2c : public JObjectWrap {
+ public:
+  explicit I2c(JObject& ji2c);
+  virtual ~I2c();
+
+  static I2c* Create(JObject& ji2c);
+  static I2c* GetInstance();
+  static JObject* GetJI2c();
+
+  virtual int SetAddress(I2cReqWrap* i2c_req) = 0;
+  virtual int Scan(I2cReqWrap* i2c_req) = 0;
+  virtual int Open(I2cReqWrap* i2c_req) = 0;
+  virtual int Close(I2cReqWrap* i2c_req) = 0;
+  virtual int Write(I2cReqWrap* i2c_rea) = 0;
+  virtual int WriteByte(I2cReqWrap* i2c_rea) = 0;
+  virtual int WriteBlock(I2cReqWrap* i2c_rea) = 0;
+  virtual int Read(I2cReqWrap* i2c_rea) = 0;
+  virtual int ReadByte(I2cReqWrap* i2c_rea) = 0;
+  virtual int ReadBlock(I2cReqWrap* i2c_rea) = 0;
+};
+
+
+JObject* InitI2c();
+
+
+} // namespace iotjs
+
+
+#endif /* IOTJS_MODULE_I2C_H */

--- a/src/js/i2c.js
+++ b/src/js/i2c.js
@@ -1,0 +1,181 @@
+/* Copyright 2016 Samsung Electronics Co., Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+var EventEmiter = require('events').EventEmitter;
+var util = require('util');
+var assert  = require('assert');
+var i2c = process.binding(process.binding.i2c);
+
+function I2C(address, options) {
+  if (!(this instanceof I2C)) {
+    return new I2C(address, options);
+  }
+
+  if (util.isUndefined(address)) {
+    address = 0x23; // Default device I2C address
+  }
+
+  if (util.isUndefined(options)) {
+    options = {};
+  }
+
+  assert(util.isObject(options));
+
+  if (util.isUndefined(options.device)){
+    options.device = '/dev/i2c-1';
+  }
+
+  this.address = address;
+  this.options = options;
+
+  EventEmiter.call(this);
+
+  process.on('exit', (function(_this) {
+    return function() {
+      return _this.close();
+    };
+  })(this));
+
+  this.on('data', (function(_this) {
+    return function(data) {
+      return _this.history.push(data);
+    };
+  })(this));
+
+  this.open(this.options.device, (function(_this) {
+    return function(err) {
+      if(!err) {
+        return _this.setAddress(_this.address);
+      }
+    };
+  })(this));
+}
+
+util.inherits(I2C, EventEmiter);
+
+I2C.prototype.history = [];
+
+I2C.prototype.scan = function(callback) {
+  return i2c.scan(function(err, data) {
+    return process.nextTick(function() {
+      var result = [];
+      for(var i = 0; i < data.length; i++) {
+        if(data[i] >= 0) result.push(data[i]);
+      }
+      return callback(err, result);
+    });
+  });
+};
+
+I2C.prototype.setAddress = function(address) {
+  i2c.setAddress(address);
+  return this.address = address;
+};
+
+I2C.prototype.open = function(device, callback) {
+  return i2c.open(device, function(err) {
+    return process.nextTick(function() {
+      return callback(err);
+    });
+  });
+};
+
+I2C.prototype.close = function() {
+  return i2c.close();
+};
+
+I2C.prototype.write = function(buf, callback) {
+  this.setAddress(this.address);
+  if (!Buffer.isBuffer(buf)) {
+    buf = new Buffer(buf);
+  }
+  return i2c.write(buf, function(err) {
+    return process.nextTick(function() {
+      return callback(err);
+    });
+  });
+};
+
+I2C.prototype.writeByte = function(byte, callback) {
+  this.setAddress(this.address);
+  return i2c.writeByte(byte, function(err) {
+    return process.nextTick(function() {
+      return callback(err);
+    });
+  });
+};
+
+I2C.prototype.writeBytes = function(cmd, buf, callback) {
+  this.setAddress(this.address);
+  if (!Buffer.isBuffer(buf)) {
+    buf = new Buffer(buf);
+  }
+  return i2c.writeBlock(cmd, buf, function(err) {
+    return process.nextTick(function() {
+      return callback(err);
+    });
+  });
+};
+
+I2C.prototype.read = function(len, callback) {
+  this.setAddress(this.address);
+  return i2c.read(len, function(err, data) {
+    return process.nextTick(function() {
+      return callback(err, data);
+    });
+  });
+};
+
+I2C.prototype.readByte = function(callback) {
+  this.setAddress(this.address);
+  return i2c.readByte(function(err, data) {
+    return process.nextTick(function() {
+      return callback(err, data);
+    });
+  });
+};
+
+I2C.prototype.readBytes = function(cmd, len, callback) {
+  this.setAddress(this.address);
+  return i2c.readBlock(cmd, len, null, function(err, actualBuffer) {
+    return process.nextTick(function() {
+      return callback(err, actualBuffer);
+    });
+  });
+};
+
+I2C.prototype.stream = function(cmd, len, delay) {
+  if (util.isNull(delay)) {
+    delay = 100;
+  }
+  this.setAddress(this.address);
+  return i2c.readBlock(cmd, len, delay, (function(_this) {
+    return function(err, data) {
+      if (err) {
+        return _this.emit('error', err);
+      } else {
+        return _this.emit('data', {
+          address: _this.address,
+          data: data,
+          cmd: cmd,
+          length: len,
+          timestamp: Date.now()
+        });
+      }
+    };
+  })(this));
+};
+
+module.exports = I2C;


### PR DESCRIPTION
- JS codes for I2C module. It includes JS APIs.
- Natvie CPP codes for binding I2C JS APIs.
- Now, all APIs in I2C module will generate assert "Not Implemented" when it is called.

IoT.js-DCO-1.0-Signed-off-by: Jaechul Yang jc08.yang@samsung.com