### PR TITLE
Rename MakeCallback into InvokeCallback

### DIFF
--- a/src/iotjs_module_dns.cpp
+++ b/src/iotjs_module_dns.cpp
@@ -58,8 +58,8 @@ static void AfterGetAddrInfo(uv_getaddrinfo_t* req, int status, addrinfo* res) {
 
   uv_freeaddrinfo(res);
 
-  // Make the callback into JavaScript
-  MakeCallback(req_wrap->jcallback(), JObject::Undefined(), args);
+  // Invoke the JavaScript callback
+  InvokeCallback(req_wrap->jcallback(), JObject::Undefined(), args);
 
   delete req_wrap;
 }

--- a/src/iotjs_module_fs.cpp
+++ b/src/iotjs_module_fs.cpp
@@ -73,7 +73,7 @@ static void After(uv_fs_t* req) {
     }
   }
 
-  JObject res = MakeCallback(cb, JObject::Undefined(), jarg);
+  JObject res = InvokeCallback(cb, JObject::Undefined(), jarg);
 
   delete req_wrap;
 }

--- a/src/iotjs_module_httpparser.cpp
+++ b/src/iotjs_module_httpparser.cpp
@@ -175,7 +175,7 @@ public:
 
     argv.Add(info);
 
-    return (MakeCallback(func, jobj, argv).GetBoolean()? 1 : 0);
+    return (InvokeCallback(func, jobj, argv).GetBoolean()? 1 : 0);
 
   }
 
@@ -193,7 +193,7 @@ public:
     argv.Add(leng);
 
 
-    MakeCallback(func, jobj, argv);
+    InvokeCallback(func, jobj, argv);
 
     return 0;
   }
@@ -203,7 +203,7 @@ public:
     JObject func = jobj.GetProperty("OnMessageComplete");
     IOTJS_ASSERT(func.IsFunction());
 
-    MakeCallback(func, jobj, JArgList::Empty());
+    InvokeCallback(func, jobj, JArgList::Empty());
 
     return 0;
   }
@@ -222,7 +222,7 @@ public:
       argv.Add(jurl);
     }
 
-    MakeCallback(func, jobj, argv);
+    InvokeCallback(func, jobj, argv);
 
     url.MakeEmpty();
     flushed = true;

--- a/src/iotjs_module_process.cpp
+++ b/src/iotjs_module_process.cpp
@@ -86,10 +86,10 @@ bool ProcessNextTick() {
 }
 
 
-// Make a callback for the given `function` with `this_` binding and `args`
+// Invoke a callback for the given `function` with `this_` binding and `args`
 // arguments. The next tick callbacks registered via `process.nextTick()`
 // will be called after the callback function `function` returns.
-JObject MakeCallback(JObject& function, JObject& this_, JArgList& args) {
+JObject InvokeCallback(JObject& function, JObject& this_, JArgList& args) {
   // Calls back the function.
   JResult jres = function.Call(this_, args);
   if (jres.IsException()) {

--- a/src/iotjs_module_process.h
+++ b/src/iotjs_module_process.h
@@ -27,7 +27,7 @@ void ProcessEmitExit(int code);
 
 bool ProcessNextTick();
 
-JObject MakeCallback(JObject& function, JObject& this_, JArgList& args);
+JObject InvokeCallback(JObject& function, JObject& this_, JArgList& args);
 
 void InitArgv(int argc, char** argv);
 

--- a/src/iotjs_module_tcp.cpp
+++ b/src/iotjs_module_tcp.cpp
@@ -82,7 +82,7 @@ static void AfterClose(uv_handle_t* handle) {
   // callback function.
   JObject jcallback = jtcp.GetProperty("onclose");
   if (jcallback.IsFunction()) {
-    MakeCallback(jcallback, JObject::Undefined(), JArgList::Empty());
+    InvokeCallback(jcallback, JObject::Undefined(), JArgList::Empty());
   }
 }
 
@@ -142,8 +142,8 @@ static void AfterConnect(uv_connect_t* req, int status) {
   JArgList args(1);
   args.Add(JVal::Number(status));
 
-  // Make callback.
-  MakeCallback(jcallback, JObject::Undefined(), args);
+  // Invoke callback.
+  InvokeCallback(jcallback, JObject::Undefined(), args);
 
   // Release request wrapper.
   delete req_wrap;
@@ -237,7 +237,7 @@ static void OnConnection(uv_stream_t* handle, int status) {
     args.Add(jclient_tcp);
   }
 
-  MakeCallback(jonconnection, jtcp, args);
+  InvokeCallback(jonconnection, jtcp, args);
 }
 
 
@@ -271,8 +271,8 @@ void AfterWrite(uv_write_t* req, int status) {
   JArgList args(1);
   args.Add(JVal::Number(status));
 
-  // Make callback.
-  MakeCallback(jcallback, JObject::Undefined(), args);
+  // Invoke callback.
+  InvokeCallback(jcallback, JObject::Undefined(), args);
 
   // Release request wrapper.
   delete req_wrap;
@@ -354,7 +354,7 @@ void OnRead(uv_stream_t* handle, ssize_t nread, const uv_buf_t* buf) {
         jargs.Set(2, JVal::Bool(true));
       }
 
-      MakeCallback(jonread, JObject::Undefined(), jargs);
+      InvokeCallback(jonread, JObject::Undefined(), jargs);
     }
     return;
   }
@@ -365,7 +365,7 @@ void OnRead(uv_stream_t* handle, ssize_t nread, const uv_buf_t* buf) {
   buffer_wrap->Copy(buf->base, nread);
 
   jargs.Add(jbuffer);
-  MakeCallback(jonread, JObject::Undefined(), jargs);
+  InvokeCallback(jonread, JObject::Undefined(), jargs);
 
   ReleaseBuffer(buf->base);
 }
@@ -399,7 +399,7 @@ static void AfterShutdown(uv_shutdown_t* req, int status) {
   JArgList args(1);
   args.Add(JVal::Number(status));
 
-  MakeCallback(jonshutdown, JObject::Undefined(), args);
+  InvokeCallback(jonshutdown, JObject::Undefined(), args);
 
   delete req_wrap;
 }

--- a/src/iotjs_module_timer.cpp
+++ b/src/iotjs_module_timer.cpp
@@ -73,7 +73,7 @@ void TimerWrap::OnTimeout() {
   IOTJS_ASSERT(_jcallback->IsFunction());
 
   // Call javascirpt timeout callback function.
-  MakeCallback(*_jcallback, jobject(), JArgList::Empty());
+  InvokeCallback(*_jcallback, jobject(), JArgList::Empty());
 }
 
 

--- a/src/platform/iotjs_module_gpio-linux-general.inl.h
+++ b/src/platform/iotjs_module_gpio-linux-general.inl.h
@@ -372,7 +372,7 @@ void AfterWork(uv_work_t* work_req, int status) {
     }
   }
 
-  MakeCallback(gpio_req->jcallback(), *Gpio::GetJGpio(), jargs);
+  InvokeCallback(gpio_req->jcallback(), *Gpio::GetJGpio(), jargs);
 
   delete work_req;
   delete gpio_req;

--- a/src/platform/iotjs_module_gpio-linux-mraa.inl.h
+++ b/src/platform/iotjs_module_gpio-linux-mraa.inl.h
@@ -223,7 +223,7 @@ void AfterWork(uv_work_t* work_req, int status) {
     }
   }
 
-  MakeCallback(gpio_req->jcallback(), *Gpio::GetJGpio(), jargs);
+  InvokeCallback(gpio_req->jcallback(), *Gpio::GetJGpio(), jargs);
 
   delete work_req;
   delete gpio_req;


### PR DESCRIPTION
`MakeCallback()` function actually calls the callback. Since its naming can be misleading (it seems like it creates the callback object), I propose to change its name into `InvokeCallback()`.