### PR TITLE
Add targets for nuttx-stm32f4 to support nuttx main repository.

### DIFF
--- a/targtes/nuttx-stm32f4/Kconfig
+++ b/targtes/nuttx-stm32f4/Kconfig
@@ -1,0 +1,26 @@
+#
+# For a description of the syntax of this configuration file,
+# see the file kconfig-language.txt in the NuttX tools repository.
+#
+
+config IOTJS
+  bool "IoT.js"
+  default n
+  ---help---
+    Enable IoT.js platform
+
+if IOTJS
+
+config IOTJS_PRIORITY
+  int "IoT.js task priority"
+  default 100
+
+config IOTJS_STACKSIZE
+  int "IoT.js stack size"
+  default 16384
+
+config IOTJS_HEAPSIZE
+  int "IoT.js heap size"
+  default 107520
+
+endif

--- a/targtes/nuttx-stm32f4/Make.defs
+++ b/targtes/nuttx-stm32f4/Make.defs
@@ -1,0 +1,18 @@
+# Copyright 2016 Samsung Electronics Co., Ltd.
+# Copyright 2016 University of Szeged
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+ifeq ($(CONFIG_IOTJS),y)
+CONFIGURED_APPS += system/iotjs
+endif

--- a/targtes/nuttx-stm32f4/Makefile
+++ b/targtes/nuttx-stm32f4/Makefile
@@ -1,0 +1,199 @@
+# Copyright 2015-2016 Samsung Electronics Co., Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+############################################################################
+#   Copyright (C) 2009, 2011-2013 Gregory Nutt. All rights reserved.
+#   Author: Gregory Nutt <gnutt@nuttx.org>
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+# 1. Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+# 2. Redistributions in binary form must reproduce the above copyright
+#    notice, this list of conditions and the following disclaimer in
+#    the documentation and/or other materials provided with the
+#    distribution.
+# 3. Neither the name NuttX nor the names of its contributors may be
+#    used to endorse or promote products derived from this software
+#    without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+# FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+# COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+# INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+# BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+# OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+# AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+# LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+# ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+#
+############################################################################
+
+# TODO, this makefile should run make under the app dirs, instead of
+# sourcing the Make.defs!
+
+-include $(TOPDIR)/.config
+-include $(TOPDIR)/Make.defs
+include $(APPDIR)/Make.defs
+
+
+CONFIG_IOTJS_PRIORITY ?= SCHED_PRIORITY_DEFAULT
+CONFIG_IOTJS_STACKSIZE ?= 16384
+CONFIG_IOTJS_HEAPSIZE ?= 107520
+# NSH sysinfo command
+
+APPNAME = iotjs
+ROOT_DIR = ../../..
+PRIORITY = $(CONFIG_IOTJS_PRIORITY)
+STACKSIZE = $(CONFIG_IOTJS_STACKSIZE)
+HEAPSIZE = $(CONFIG_IOTJS_HEAPSIZE)
+
+ASRCS =
+CSRCS = 
+CXXSRCS =
+MAINSRC = iotjs_main.cxx
+LIBS = libhttpparser.a libiotjs.a libjerrycore.a libtuv.a libjerry-libm.a libjerry-libc.a
+
+AOBJS = $(ASRCS:.S=$(OBJEXT))
+COBJS = $(CSRCS:.c=$(OBJEXT))
+CXXOBJS = $(CXXSRCS:.cxx=$(OBJEXT))
+MAINOBJ = $(MAINSRC:.cxx=$(OBJEXT))
+
+SRCS = $(ASRCS) $(CSRCS) $(CXXSRCS) $(MAINSRC)
+OBJS = $(AOBJS) $(COBJS) $(CXXOBJS)
+
+ifeq ($(R),1)
+  BUILD_TYPE = release
+else
+  BUILD_TYPE = debug
+endif
+
+ifneq ($(CONFIG_BUILD_KERNEL),y)
+  OBJS += $(MAINOBJ)
+endif
+
+ifeq ($(CONFIG_WINDOWS_NATIVE),y)
+  BIN = ..\..\libapps$(LIBEXT)
+else
+ifeq ($(WINTOOL),y)
+  BIN = ..\\..\\libapps$(LIBEXT)
+else
+  BIN = ../../libapps$(LIBEXT)
+endif
+endif
+
+ifeq ($(WINTOOL),y)
+  INSTALL_DIR = "${shell cygpath -w $(BIN_DIR)}"
+else
+  INSTALL_DIR = $(BIN_DIR)
+endif
+
+CONFIG_XYZ_PROGNAME ?= iotjs$(EXEEXT)
+PROGNAME = $(CONFIG_XYZ_PROGNAME)
+
+ROOTDEPPATH = --dep-path .
+
+# Common build
+
+VPATH =
+
+all: .built
+.PHONY: context depend clean distclean
+
+chkcxx:
+ifneq ($(CONFIG_HAVE_CXX),y)
+  @echo ""
+  @echo "In order to use this example, you toolchain must support must"
+  @echo ""
+  @echo "  (1) Explicitly select CONFIG_HAVE_CXX to build in C++ support"
+  @echo "  (2) Define CXX, CXXFLAGS, and COMPILEXX in the Make.defs file"
+  @echo "      of the configuration that you are using."
+  @echo ""
+  @exit 1
+endif
+
+
+$(AOBJS): %$(OBJEXT): %.S
+	$(call ASSEMBLE, $<, $@)
+
+$(COBJS): %$(OBJEXT): %.c
+	$(call COMPILE, $<, $@)
+
+$(CXXOBJS) $(MAINOBJ): %$(OBJEXT): %.cxx
+	$(call COMPILEXX, $<, $@)
+
+$(LIBS) : preconfig 
+	$(firstword $(AR)) x $@
+
+.built: chkcxx $(LIBS) $(OBJS)
+	$(eval OBJS += $(shell find . -name "*.obj"))
+	$(call ARCHIVE, $(BIN), $(OBJS))
+	$(Q) touch .built
+
+ifeq ($(CONFIG_BUILD_KERNEL),y)
+$(BIN_DIR)$(DELIM)$(PROGNAME): $(OBJS) $(MAINOBJ)
+	@echo "LD: $(PROGNAME)"
+	$(Q) $(LD) $(LDELFFLAGS) $(LDLIBPATH) -o $(INSTALL_DIR)$(DELIM)$(PROGNAME) $(ARCHCRT0OBJ) $(MAINOBJ) $(LDLIBS)
+	$(Q) $(NM) -u  $(INSTALL_DIR)$(DELIM)$(PROGNAME)
+
+install: $(BIN_DIR)$(DELIM)$(PROGNAME)
+
+else
+install:
+
+endif
+
+# Register application
+
+ifeq ($(CONFIG_NSH_BUILTIN_APPS),y)
+$(BUILTIN_REGISTRY)$(DELIM)iotjs.bdat: $(DEPCONFIG) Makefile
+	$(call REGISTER,"iotjs",$(PRIORITY),$(STACKSIZE),iotjs_main)
+
+context: $(BUILTIN_REGISTRY)$(DELIM)iotjs.bdat
+else
+context:
+endif
+
+# Create dependencies
+
+.depend: Makefile $(SRCS)
+	$(Q) $(MKDEP) $(ROOTDEPPATH) "$(CXX)" -- $(CXXFLAGS) -- $(SRCS) >Make.dep
+	$(Q) touch $@
+
+depend: .depend
+
+clean:
+	$(eval OBJS += $(shell find . -name "*.obj"))
+	$(call DELFILE, $(OBJS))
+	$(call DELFILE, .built)
+	$(call CLEAN)
+
+distclean: clean
+	$(call DELFILE, Make.dep)
+	$(call DELFILE, .depend)
+
+-include Make.dep
+.PHONY: preconfig
+preconfig:
+	cp $(ROOT_DIR)/iotjs/build/arm-nuttx/$(BUILD_TYPE)/lib/lib* .
+	make -C $(ROOT_DIR)/iotjs/build/arm-nuttx/$(BUILD_TYPE)/deps/jerry jerry-libm
+	make -C $(ROOT_DIR)/iotjs/build/arm-nuttx/$(BUILD_TYPE)/deps/jerry jerry-libc
+	cp $(ROOT_DIR)/iotjs/build/arm-nuttx/$(BUILD_TYPE)/deps/jerry/lib/libjerry-libc.a .
+	cp $(ROOT_DIR)/iotjs/build/arm-nuttx/$(BUILD_TYPE)/deps/jerry/lib/libjerry-libm.a .
+	

--- a/targtes/nuttx-stm32f4/README.md
+++ b/targtes/nuttx-stm32f4/README.md
@@ -1,0 +1,99 @@
+### About
+
+This directory contains files to run IoT.js on
+[STM32F4-Discovery board](http://www.st.com/content/st_com/en/products/evaluation-tools/product-evaluation-tools/mcu-eval-tools/stm32-mcu-eval-tools/stm32-mcu-discovery-kits/stm32f4discovery.html) with [NuttX](http://nuttx.org/)
+
+### How to build
+
+#### 1. Setting up the build environment for STM32F4-Discovery board
+
+Clone IoT.js and NuttX into iotjs-nuttx directory
+
+```bash
+mkdir iotjs-nuttx
+cd iotjs-nuttx
+git clone https://github.com/Samsung/iotjs.git
+git clone https://bitbucket.org/nuttx/nuttx.git
+git clone https://bitbucket.org/nuttx/apps.git
+git clone https://github.com/texane/stlink.git
+```
+
+The following directory structure is created after these commands
+
+```bash
+iotjs-nuttx
+  + apps
+  + iotjs
+  |  + targets
+  |      + nuttx-stm32f4
+  + nuttx
+  + stlink
+```
+
+#### 2. Adding IoT.js as an interpreter for NuttX
+
+```bash
+cd apps/system
+mkdir iotjs
+cp ../../iotjs/targets/nuttx-stm32f4/* ./iotjs/
+```
+
+#### 3. Configure NuttX
+
+```bash
+# assuming you are in iotjs-nuttx folder
+cd nuttx/tools
+
+# configure NuttX USB console shell
+./configure.sh stm32f4discovery/usbnsh
+
+cd ..
+# might require to run "make menuconfig" twice
+make menuconfig
+```
+
+We must set the following options:
+
+* Change `Build Setup -> Build Host Platform` from _Windows_ to _Linux_
+* Enable `System Type -> FPU support`
+* Enable `System Type -> STM32 Peripheral Support -> SDIO`
+* Enable `RTOS Features -> Pthread Options -> Enable mutex types`
+* Enable `RTOS Features -> Files and I/O -> Enable /dev/console`
+* Enable `RTOS Features -> Work queue support -> High priority (kernel) worker thread`
+* Enable `Device Drivers -> Disable driver poll interfaces`
+* Enable `Device Drivers -> MMC/SD Driver Suport`
+* Enable `Device Drivers -> MMC/SD Driver Suport -> MMC/SD SDIO transfer support`
+* Enable `Networking Support -> Networking Support`
+* Enable `Networking Support -> Socket Support -> Socket options`
+* Enable `Networking Support -> Unix Domain Socket Support`
+* Enable `Networking Support -> TCP/IP Networking`
+* Enable `Networking Support -> TCP/IP Networking -> Enable TCP/IP write buffering`
+* Enable `File Systems -> FAT file system`
+* Enable `File Systems -> FAT file system -> FAT upper/lower names`
+* Enable `File Systems -> FAT file system -> FAT long file names`
+* Enable `Device Drivers -> Network Device/PHT Support -> Late driver initialization`
+* Enable `Library Routines -> Standard Math library`
+* Enable `Application Configuration -> System Libraries and NSH Add-ons -> IoT.js`
+* Enable all childs of `Application Configuration -> System Libraries and NSH Add-ons -> readline() Support` (for those who wants to use readline)
+
+
+#### 4. Build IoT.js for NuttX
+
+```bash
+# assuming you are in iotjs-nuttx folder
+cd nuttx/
+make
+```
+For release version, you can type R=1 make on the command shell.
+
+#### 5. Flashing
+
+Connect Mini-USB for power supply and connect Micro-USB for `NSH` console.
+
+To configure `stlink` utility for flashing, follow the instructions [here](https://github.com/texane/stlink#build-from-sources).
+
+To flash,
+```bash
+# assuming you are in nuttx folder
+sudo ../stlink/build/st-flash write nuttx.bin 0x8000000
+```

--- a/targtes/nuttx-stm32f4/iotjs_main.cxx
+++ b/targtes/nuttx-stm32f4/iotjs_main.cxx
@@ -1,0 +1,110 @@
+/* Copyright 2015-2016 Samsung Electronics Co., Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/****************************************************************************
+ *   Copyright (C) 2013 Gregory Nutt. All rights reserved.
+ *   Author: Gregory Nutt <gnutt@nuttx.org>
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name NuttX nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <nuttx/config.h>
+#include <nuttx/arch.h>
+
+#include <stdio.h>
+#include <setjmp.h>
+
+#ifdef CONFIG_IOTJS
+# if !defined(CONFIG_HAVE_CXX) || !defined(CONFIG_HAVE_CXXINITIALIZE)
+#   error Need CONFIG_HAVE_CXX and CONFIG_HAVE_CXXINITIALIZE
+# endif
+#endif
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+/**
+ * Compiler built-in setjmp function.
+ *
+ * @return 0 when called the first time
+ *         1 when returns from a longjmp call
+ */
+
+int
+setjmp (jmp_buf buf)
+{
+    return __builtin_setjmp (buf);
+} /* setjmp */
+
+/**
+ * Compiler built-in longjmp function.
+ *
+ * Note:
+ *   ignores value argument
+ */
+
+void
+longjmp (jmp_buf buf, int value)
+{
+    /* Must be called with 1. */
+    __builtin_longjmp (buf, 1);
+} /* longjmp */
+
+extern "C" int iotjs_entry(int argc, char *argv[]);
+extern "C" int tuv_cleanup(void);
+
+#ifdef CONFIG_BUILD_KERNEL
+extern "C" int main(int argc, FAR char *argv[])
+#else
+extern "C" int iotjs_main(int argc, char *argv[])
+#endif
+{
+  int ret = 0;
+  up_cxxinitialize();
+  ret = iotjs_entry(argc, argv);
+  tuv_cleanup();
+  return ret;
+}


### PR DESCRIPTION
IoT.js-DCO-1.0-Signed-off-by: wonyong.kim wonyong.kim@samsung.com