### PR TITLE
Don't allocate 1 byte heap memory for Null String

### DIFF
--- a/src/iotjs_util.cpp
+++ b/src/iotjs_util.cpp
@@ -93,7 +93,7 @@ String::String(const char* data, int size, int cap) {
   IOTJS_ASSERT(_size >= 0);
   IOTJS_ASSERT(_cap >= 0);
 
-  if (_cap >= 0) {
+  if (_cap > 0) {
     _data = AllocBuffer(_cap + 1);
   } else {
     _data = NULL;


### PR DESCRIPTION
With recently merged commit #54cd255 for fixing #323, we allocate 1
byte memory with malloc for every null string. Previously, null string
is represented by setting _data to NULL. I think memory defragmentation
should be considered more carefully in iot environment since it has
small memory. Although this patch make it easy to remove many bugs
relating non-nullchecked access, I think previous approach, i.e. without
allocation, is more suit for iotjs. If maintainers think the commit
seems good, at least, making null string as singleton would be better.

I checked tc issue-323.js pass with null check in libtuv.

IoT.js-DCO-1.0-Signed-off-by: Sanggyu Lee sg5.lee@samsung.com