### PR TITLE
Fix first-time build for nuttx error and update documnet

### DIFF
--- a/targets/nuttx-stm32f4/Makefile
+++ b/targets/nuttx-stm32f4/Makefile
@@ -137,7 +137,14 @@ $(COBJS): %$(OBJEXT): %.c
 $(CXXOBJS) $(MAINOBJ): %$(OBJEXT): %.cxx
 	$(call COMPILEXX, $<, $@)
 
-$(LIBS) : preconfig
+copylibs :
+	cp $(ROOT_DIR)/iotjs/build/arm-nuttx/$(BUILD_TYPE)/lib/lib* .
+	make -C $(ROOT_DIR)/iotjs/build/arm-nuttx/$(BUILD_TYPE)/deps/jerry jerry-libm
+	make -C $(ROOT_DIR)/iotjs/build/arm-nuttx/$(BUILD_TYPE)/deps/jerry jerry-libc
+	cp $(ROOT_DIR)/iotjs/build/arm-nuttx/$(BUILD_TYPE)/deps/jerry/lib/libjerry-libc.a .
+	cp $(ROOT_DIR)/iotjs/build/arm-nuttx/$(BUILD_TYPE)/deps/jerry/lib/libjerry-libm.a .
+
+$(LIBS) : copylibs
 	$(firstword $(AR)) x $@
 
 .built: chkcxx $(LIBS) $(OBJS)
@@ -190,8 +197,3 @@ distclean: clean
 -include Make.dep
 .PHONY: preconfig
 preconfig:
-	cp $(ROOT_DIR)/iotjs/build/arm-nuttx/$(BUILD_TYPE)/lib/lib* .
-	make -C $(ROOT_DIR)/iotjs/build/arm-nuttx/$(BUILD_TYPE)/deps/jerry jerry-libm
-	make -C $(ROOT_DIR)/iotjs/build/arm-nuttx/$(BUILD_TYPE)/deps/jerry jerry-libc
-	cp $(ROOT_DIR)/iotjs/build/arm-nuttx/$(BUILD_TYPE)/deps/jerry/lib/libjerry-libc.a .
-	cp $(ROOT_DIR)/iotjs/build/arm-nuttx/$(BUILD_TYPE)/deps/jerry/lib/libjerry-libm.a .

--- a/targets/nuttx-stm32f4/README.md
+++ b/targets/nuttx-stm32f4/README.md
@@ -54,7 +54,7 @@ $ make menuconfig
 
 We must set the following options:
 
-* Change `Build Setup -> Build Host Platform` from _Windows_ to _Linux_
+* Change `Build Setup -> Build Host Platform` from _Windows_ to [_Linux_|_OSX_]
 * Enable `System Type -> FPU support`
 * Enable `System Type -> STM32 Peripheral Support -> SDIO`
 * Enable `RTOS Features -> Pthread Options -> Enable mutex types`


### PR DESCRIPTION
* Change content about host platform
* Prevent copy IoT.js libs to nuttx at "make menuconfig" time

IoT.js-DCO-1.0-Signed-off-by: wonyong.kim wonyong.kim@samsung.com