### PR TITLE
Update document about Raspberry Pi.

### DIFF
--- a/docs/Setting-Raspberry-Pi-2.md
+++ b/docs/Setting-Raspberry-Pi-2.md
@@ -57,6 +57,21 @@ append your nameservers
    * proxy environment
    * apt-get proxy
 
+### Enable the I2C interface
+From the command line type:
+```bash
+sudo raspi-config
+```
+This will launch raspi-config utility.
+   * Select "9 Advanced Options"
+   * Select "A6 I2C"
+
+The screen will ask you to enable I2C interface.
+   * Select "Yes"
+   * Select "Ok"
+   * Select "Finish" to return to the command line.
+
+Reboot your Raspberry Pi.
 
 ### Reference
 * https://www.raspberrypi.org/documentation/installation/installing-images/linux.md


### PR DESCRIPTION
- How to enable I2C interface on Raspberry Pi.

IoT.js-DCO-1.0-Signed-off-by: Jaechul Yang jc08.yang@samsung.com