### PR TITLE
Implement I2C module's APIs: Scan, Read, ReadByte

### DIFF
--- a/src/js/i2c.js
+++ b/src/js/i2c.js
@@ -105,7 +105,7 @@ I2C.prototype.scan = function(callback) {
     return process.nextTick(function() {
       var result = [];
       for(var i = 0; i < data.length; i++) {
-        if(data[i] >= 0) result.push(data[i]);
+        if(data[i] == 1) result.push(i);
       }
       return callback(err, result);
     });

--- a/src/module/iotjs_module_i2c.h
+++ b/src/module/iotjs_module_i2c.h
@@ -40,7 +40,8 @@ enum I2cOp {
 enum I2cError {
   kI2cErrOk = 0,
   kI2cErrOpen = -1,
-  kI2cErrReadBlock = -2,
+  kI2cErrRead = -2,
+  kI2cErrWrite = -3,
 };
 
 struct I2cReqData {


### PR DESCRIPTION
- Implement I2C APIs for Linux platform (Scan, Read, ReadByte)
- Tested on Raspberry Pi

IoT.js-DCO-1.0-Signed-off-by: Jaechul Yang jc08.yang@samsung.com