### PR TITLE
Implements fs.unlink(Sync) and fs.writeFile(Sync)

### DIFF
--- a/docs/IoT.js-API-File-System.md
+++ b/docs/IoT.js-API-File-System.md
@@ -30,14 +30,13 @@
  * `bytesRead: Number`
  * `buffer: Buffer`
 
-#### fs.readSync(fd, buffer, offset, length, position, callback)
+#### fs.readSync(fd, buffer, offset, length, position)
 
 * `fd: Int` - file descriptor.
 * `buffer: Buffer` - buffer that the data will be written to.
 * `offset: Number` - offset of the buffer where to start writing.
 * `length: Number` - number of bytes to read.
 * `position: Number` - specifying where to start read data from the file, if `null`, read from current position.
-
 
 #### fs.readFile(path[, options], callback)
 
@@ -51,7 +50,7 @@
 
 Reads entire file asynchronously.
 
-#### fs.readFileSync(path[, options], callback)
+#### fs.readFileSync(path[, options])
 
 * `path: String` - file path to be opened.
 * `options: Object` - options for the operation.
@@ -79,9 +78,29 @@ Reads entire file synchronously.
 * `length: Number` - number of bytes to write.
 * `position: Number` - specifying where to start write data to the file, if `null`, read from current position.
 
+#### fs.writeFile(path, data, [, options], callback)
+
+* `path: String` - file path that the `data` will be written
+* `data: Buffer` - buffer that contains data
+* `options: Object` - options for the operation
+* `callback: Function(err)` - callback function
+ * `err: Error`
+
+Writes entire `data` to the file specified by `path` asynchronously.
+
+#### fs.writeFileSync(path, data, [, options])
+
+* `path: String` - file path that the `data` will be written
+* `data: Buffer` - buffer that contains data
+* `options: Object` - options for the operation
+
+Writes entire `data` to the file specified by `path` synchronously.
+
 #### fs.close(fd, callback)
 
 * `fd: Int` - file descriptor.
+* `callback: Function(err) `
+ * `err: Error`
 
 Closes the file of fd asynchronously.
 
@@ -90,6 +109,20 @@ Closes the file of fd asynchronously.
 * `fd: Int` - file descriptor.
 
 Closes the file of fd synchronously.
+
+#### fs.unlink(path, callback)
+
+* `path: String` - file path to be removed
+* `callback: Function(err) `
+ * `err: Error`
+
+Removes the file specified by `path` asynchronously.
+
+#### fs.unlinkSync(path)
+
+* `path: String` - file path to be removed
+
+Removes the file specified by `path` synchronously.
 
 #### fs.stat(path, callback)
 

--- a/src/module/iotjs_module_fs.cpp
+++ b/src/module/iotjs_module_fs.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2015 Samsung Electronics Co., Ltd.
+/* Copyright 2015-2016 Samsung Electronics Co., Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -332,6 +332,23 @@ JHANDLER_FUNCTION(Rmdir) {
 }
 
 
+JHANDLER_FUNCTION(Unlink) {
+  JHANDLER_CHECK(handler.GetThis()->IsObject());
+  JHANDLER_CHECK(handler.GetArgLength() >= 1);
+  JHANDLER_CHECK(handler.GetArg(0)->IsString());
+  Environment* env = Environment::GetEnv();
+
+  String path = handler.GetArg(0)->GetString();
+
+  if (handler.GetArgLength() > 1 && handler.GetArg(1)->IsFunction()) {
+    FS_ASYNC(env, unlink, handler.GetArg(1), path.data());
+  } else {
+    FS_SYNC(env, unlink, path.data());
+    handler.Return(JVal::Undefined());
+  }
+}
+
+
 JObject* InitFs() {
   Module* module = GetBuiltinModule(MODULE_FS);
   JObject* fs = module->module;
@@ -345,6 +362,7 @@ JObject* InitFs() {
     fs->SetMethod("stat", Stat);
     fs->SetMethod("mkdir", Mkdir);
     fs->SetMethod("rmdir", Rmdir);
+    fs->SetMethod("unlink", Unlink);
 
     module->module = fs;
   }

--- a/test/run_pass/test_fs_writefile_unlink.js
+++ b/test/run_pass/test_fs_writefile_unlink.js
@@ -1,0 +1,45 @@
+/* Copyright 2016 Samsung Electronics Co., Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+ /*
+  @STDOUT=Pass
+ */
+
+var fs = require('fs');
+var assert = require('assert');
+
+var file1 = "../resources/tobeornottobe.txt";
+var file2 = "../resources/tobeornottobe_async.txt";
+
+fs.readFile(file1, function(err, buf1) {
+  assert.equal(err, null);
+  fs.writeFile(file2, buf1, function(err) {
+    assert.equal(err, null);
+    fs.exists(file2, function(exists) {
+      assert.equal(exists, true);
+      fs.readFile(file1, function(err, buf2) {
+        assert.equal(err, null);
+        assert.equal(buf1.toString(), buf2.toString());
+        fs.unlink(file2, function(err) {
+          assert.equal(err, null);
+          fs.exists(file2, function(exists) {
+            assert.equal(exists, false);
+            console.log("Pass");
+          });
+        });
+      });
+    });
+  });
+});

--- a/test/run_pass/test_fs_writefile_unlink_sync.js
+++ b/test/run_pass/test_fs_writefile_unlink_sync.js
@@ -1,0 +1,39 @@
+/* Copyright 2016 Samsung Electronics Co., Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+var fs = require('fs');
+var assert = require('assert');
+
+var file1 = "../resources/tobeornottobe.txt";
+var file2 = "../resources/tobeornottobe_sync.txt";
+
+/* make a new file2 from file1 */
+var buf1 = fs.readFileSync(file1);
+fs.writeFileSync(file2, buf1);
+
+/* Does file2 exists ? */
+var result = fs.existsSync(file2);
+assert.equal(result, true);
+
+/* Is file2 equal to file1 */
+var buf2 = fs.readFileSync(file2);
+assert(buf1.toString(), buf2.toString());
+
+/* Remove file2 */
+fs.unlinkSync(file2);
+
+/* Is file2 removed? */
+result = fs.existsSync(file2);
+assert.equal(result, false);


### PR DESCRIPTION
This patch is for issue #28.

- Implements fs.writeFile and fs.writeFileAsync
- Implements fs.unlink and fs.unlinkSync
- Adds testcases for above file system APIs
- Add documentation for above APIs
- Fix wrong description in existing File System APIs

IoT.js-DCO-1.0-Signed-off-by: Sanggyu Lee sg5.lee@samsung.com