### PR TITLE
Platform source code also should be configurable

### DIFF
--- a/cmake/iotjs.cmake
+++ b/cmake/iotjs.cmake
@@ -29,6 +29,11 @@ set(IOTJS_MODULE_SRC "")
 separate_arguments(IOTJS_MODULES)
 foreach(module ${IOTJS_MODULES})
     list(APPEND IOTJS_MODULE_SRC ${SRC_ROOT}/module/iotjs_module_${module}.cpp)
+    set(PLATFORM_SRC "${SRC_ROOT}/platform/${PLATFORM_DESCRIPT}/iotjs_module")
+    set(PLATFORM_SRC "${PLATFORM_SRC}_${module}-${PLATFORM_DESCRIPT}.cpp")
+    if(EXISTS "${PLATFORM_SRC}")
+        list(APPEND IOTJS_MODULE_SRC ${PLATFORM_SRC})
+    endif()
     string(TOUPPER ${module} module)
     set(IOTJS_CFLAGS "${IOTJS_CFLAGS} -UENABLE_MODULE_${module}")
     set(IOTJS_CFLAGS "${IOTJS_CFLAGS} -DENABLE_MODULE_${module}=1")
@@ -36,8 +41,7 @@ endforeach()
 
 
 file(GLOB LIB_IOTJS_SRC ${SRC_ROOT}/*.cpp
-                        ${IOTJS_MODULE_SRC}
-                        ${SRC_ROOT}/platform/${PLATFORM_DESCRIPT}/*.cpp)
+                        ${IOTJS_MODULE_SRC})
 
 string(REPLACE ";" " " IOTJS_CFLAGS_STR "${IOTJS_CFLAGS}")
 string(REPLACE ";" " " IOTJS_LINK_FLAGS_STR "${IOTJS_LINK_FLAGS}")


### PR DESCRIPTION
Related issue: https://github.com/Samsung/iotjs/issues/436
PR #458 didn't exclude the module-only source codes from `platform` directory. This PR fixes it.