### PR TITLE
Implement I2C Module's APIs: write, writeByte, writeBlock, on('data')…

### DIFF
--- a/src/module/iotjs_module_i2c.h
+++ b/src/module/iotjs_module_i2c.h
@@ -41,15 +41,16 @@ enum I2cError {
   kI2cErrOk = 0,
   kI2cErrOpen = -1,
   kI2cErrRead = -2,
-  kI2cErrWrite = -3,
+  kI2cErrReadBlock = -3,
+  kI2cErrWrite = -4,
 };
 
 struct I2cReqData {
   String device;
   char* buf_data;
-  int buf_len;
-  int8_t byte;
-  int8_t cmd;
+  uint8_t buf_len;
+  uint8_t byte;
+  uint8_t cmd;
   int32_t delay;
 
   I2cOp op;
@@ -71,7 +72,7 @@ class I2c : public JObjectWrap {
   static I2c* GetInstance();
   static JObject* GetJI2c();
 
-  virtual int SetAddress(int8_t address) = 0;
+  virtual int SetAddress(uint8_t address) = 0;
   virtual int Scan(I2cReqWrap* i2c_req) = 0;
   virtual int Open(I2cReqWrap* i2c_req) = 0;
   virtual int Close() = 0;

--- a/src/platform/arm-nuttx/iotjs_module_i2c-arm-nuttx.cpp
+++ b/src/platform/arm-nuttx/iotjs_module_i2c-arm-nuttx.cpp
@@ -16,7 +16,7 @@
 #if defined(__NUTTX__)
 
 
-#include "iotjs_module_i2c.h"
+#include "module/iotjs_module_i2c.h"
 
 
 namespace iotjs {
@@ -29,7 +29,7 @@ class I2cArmNuttx : public I2c {
 
   static I2cArmNuttx* GetInstance();
 
-  virtual int SetAddress(int8_t address);
+  virtual int SetAddress(uint8_t address);
   virtual int Scan(I2cReqWrap* i2c_req);
   virtual int Open(I2cReqWrap* i2c_req);
   virtual int Close();
@@ -58,7 +58,7 @@ I2cArmNuttx* I2cArmNuttx::GetInstance()
 }
 
 
-int I2cArmNuttx::SetAddress(int8_t address) {
+int I2cArmNuttx::SetAddress(uint8_t address) {
   IOTJS_ASSERT(!"Not implemented");
   return 0;
 }

--- a/test/config-largemem.js
+++ b/test/config-largemem.js
@@ -37,6 +37,7 @@ function testset(idx) {
       'test_gpio1.js',
       'test_gpio2.js',
       'test_gpio3.js',
+      'test_i2c.js',
       'test_http_get.js',
       'test_http_header.js',
       'test_httpclient_timeout.js',

--- a/test/config-smallmem.js
+++ b/test/config-smallmem.js
@@ -84,6 +84,7 @@ function testset(idx) {
       'test_uncaught2.js',
       'test_uncaught_error1.js',
       'test_uncaught_error2.js',
+      'test_i2c.js',
     ]
   });
 

--- a/test/run_pass/attrs.js
+++ b/test/run_pass/attrs.js
@@ -88,6 +88,10 @@
       skip: ['all'],
       reason: "not implemented"
     },
+    'test_i2c.js': {
+      skip: ['all'],
+      reason: "need to setup test environment",
+    },
     'test_http_get.js': {
       timeout: {
         all: 20

--- a/test/run_pass/test_i2c.js
+++ b/test/run_pass/test_i2c.js
@@ -1,0 +1,70 @@
+/* Copyright 2016 Samsung Electronics Co., Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/* This test is based on Raspberry Pi with GY-30 Sensor. */
+
+var assert = require('assert');
+var i2c = require('i2c');
+
+var address = 0x23;
+var wire = new i2c(address, {device: '/dev/i2c-1'});
+
+wire.write([0x10], function(err) {
+  assert.equal(err, null);
+  console.log('write done');
+});
+
+wire.writeByte(0x10, function(err) {
+  assert.equal(err, null);
+  console.log('writeByte done');
+});
+
+wire.read(2, function(err, res) {
+  assert.equal(err, null);
+  assert.equal(res.length, 2, 'I2C read failed.(length is not equal)');
+  console.log('read result: '+res[0]+', '+res[1]);
+});
+
+wire.readByte(function(err, res) {
+  assert.equal(err, null);
+  console.log('readByte result: '+res);
+});
+
+wire.readBytes(0x20, 2, function(err, res) {
+  assert.equal(err, null);
+  assert.equal(res.length, 2, 'I2C readBytes failed.(length is not equal)');
+  console.log('readBytes(cmd:0x20, length:2) result: '+res[0]+', '+res[1]);
+});
+
+wire.scan(function(err, res) {
+  assert.equal(err, null);
+  console.log('scan result: ' + res.length + ' device\(s\) scanned.');
+  for (var i = 0; i < res.length; i++) {
+    console.log(' .result[' + i + ']: ' + res[i]);
+  }
+  wire.stream(0x20, 2, 1000);
+});
+
+var count = 0;
+wire.on('data', function(data) {
+  console.log('data listener');
+  console.log('data.timestamp: '+data.timestamp);
+  console.log('data.address: '+data.address);
+  console.log('data.cmd: '+data.cmd);
+  console.log('data.length: '+data.length);
+  console.log('data.data: '+data.data);
+  console.log('');
+  if(count++ == 2) process.exit();
+});


### PR DESCRIPTION
…, stream

- Implement I2C APIs for Linux platform (write, writeByte, writeBlock, on, stream)
- Tested on Raspberry Pi
- Add Testcase for I2C APIs related read (read, readByte, readBytes, on('data), stream, scan)

IoT.js-DCO-1.0-Signed-off-by: Jaechul Yang jc08.yang@samsung.com