### PR TITLE
Implement fs.rename and fs.renameSync

### DIFF
--- a/docs/IoT.js-API-File-System.md
+++ b/docs/IoT.js-API-File-System.md
@@ -3,6 +3,20 @@
 
 ### Methods
 
+#### fs.close(fd, callback)
+
+* `fd: Int` - file descriptor.
+* `callback: Function(err) `
+ * `err: Error`
+
+Closes the file of fd asynchronously.
+
+#### fs.closeSync(fd)
+
+* `fd: Int` - file descriptor.
+
+Closes the file of fd synchronously.
+
 #### fs.open(path, flags[, mode], callback)
 
 * `path: String` - file path to be opened.
@@ -59,6 +73,58 @@ Reads entire file asynchronously.
 
 Reads entire file synchronously.
 
+#### fs.rename(oldPath, newPath, callback)
+
+* `oldPath: String` - old file path
+* `newPath: String` - new file path
+* `callback: Function(err)` - callback function.
+ * `err: Error`
+
+Renames `oldPath` to `newPath` asynchronously.
+
+#### fs.renameSync(oldPath, newPath)
+
+* `oldPath: String` - old file path
+* `newPath: String` - new file path
+
+Renames `oldPath` to `newPath` synchronously.
+
+#### fs.stat(path, callback)
+
+* `path: String` - file path to be stated
+* callback: Function(err, stat)` - callback function.
+ * `err: Error`
+ * `stat: Object`
+
+#### fs.statSync(path)
+
+* `path: String` - file path to be stated
+
+#### fs.fstat(fd, callback)
+
+* `fd: Number` - file descriptor to be stated
+* callback: Function(err, stat)` - callback function.
+ * `err: Error`
+ * `stat: Object`
+
+#### fs.fstatSync(fd)
+
+* `fd: Number` - file descriptor to be stated
+
+ ### Class: fs.Stats
+
+ fs.Stats class is a object returned from ```fs.stats()```,```fs.fstats()``` and their synchronous counterparts.
+
+ ### Methods
+
+ #### stats.isDirectory()
+
+ Returns true if stated file is a directory
+
+ #### stats.isFile()
+
+ Returns true if stated file is a file
+
 #### fs.write(fd, buffer, offset, length, position, callback)
 
 * `fd: Int` - file descriptor.
@@ -96,20 +162,6 @@ Writes entire `data` to the file specified by `path` asynchronously.
 
 Writes entire `data` to the file specified by `path` synchronously.
 
-#### fs.close(fd, callback)
-
-* `fd: Int` - file descriptor.
-* `callback: Function(err) `
- * `err: Error`
-
-Closes the file of fd asynchronously.
-
-#### fs.closeSync(fd)
-
-* `fd: Int` - file descriptor.
-
-Closes the file of fd synchronously.
-
 #### fs.unlink(path, callback)
 
 * `path: String` - file path to be removed
@@ -123,39 +175,3 @@ Removes the file specified by `path` asynchronously.
 * `path: String` - file path to be removed
 
 Removes the file specified by `path` synchronously.
-
-#### fs.stat(path, callback)
-
-* `path: String` - file path to be stated
-* callback: Function(err, stat)` - callback function.
- * `err: Error`
- * `stat: Object`
-
-#### fs.statSync(path)
-
-* `path: String` - file path to be stated
-
-#### fs.fstat(fd, callback)
-
-* `fd: Number` - file descriptor to be stated
-* callback: Function(err, stat)` - callback function.
- * `err: Error`
- * `stat: Object`
-
-#### fs.fstatSync(fd)
-
-* `fd: Number` - file descriptor to be stated
-
-## Class: fs.Stats
-
-fs.Stats class is a object returned from ```fs.stats()```,```fs.fstats()``` and their synchronous counterparts.
-
-### Methods
-
-#### stats.isDirectory()
-
-Returns true if stated file is a directory
-
-#### stats.isFile()
-
-Returns true if stated file is a file

--- a/src/js/fs.js
+++ b/src/js/fs.js
@@ -383,6 +383,21 @@ fs.unlinkSync = function(path) {
 };
 
 
+fs.rename = function(oldPath, newPath, callback) {
+  checkArgString(oldPath);
+  checkArgString(newPath);
+  checkArgFunction(callback);
+  fsBuiltin.rename(oldPath, newPath, callback);
+};
+
+
+fs.renameSync = function(oldPath, newPath) {
+  checkArgString(oldPath);
+  checkArgString(newPath);
+  fsBuiltin.rename(oldPath, newPath);
+};
+
+
 function convertFlags(flag) {
   if (util.isString(flag)) {
     switch (flag) {

--- a/src/module/iotjs_module_fs.cpp
+++ b/src/module/iotjs_module_fs.cpp
@@ -336,14 +336,33 @@ JHANDLER_FUNCTION(Unlink) {
   JHANDLER_CHECK(handler.GetThis()->IsObject());
   JHANDLER_CHECK(handler.GetArgLength() >= 1);
   JHANDLER_CHECK(handler.GetArg(0)->IsString());
-  Environment* env = Environment::GetEnv();
 
+  Environment* env = Environment::GetEnv();
   String path = handler.GetArg(0)->GetString();
 
   if (handler.GetArgLength() > 1 && handler.GetArg(1)->IsFunction()) {
     FS_ASYNC(env, unlink, handler.GetArg(1), path.data());
   } else {
     FS_SYNC(env, unlink, path.data());
+    handler.Return(JVal::Undefined());
+  }
+}
+
+
+JHANDLER_FUNCTION(Rename) {
+  JHANDLER_CHECK(handler.GetThis()->IsObject());
+  JHANDLER_CHECK(handler.GetArgLength() >= 2);
+  JHANDLER_CHECK(handler.GetArg(0)->IsString());
+  JHANDLER_CHECK(handler.GetArg(1)->IsString());
+
+  Environment* env = Environment::GetEnv();
+  String oldPath = handler.GetArg(0)->GetString();
+  String newPath = handler.GetArg(1)->GetString();
+
+  if (handler.GetArgLength() > 2 && handler.GetArg(2)->IsFunction()) {
+    FS_ASYNC(env, rename, handler.GetArg(2), oldPath.data(), newPath.data());
+  } else {
+    FS_SYNC(env, rename, oldPath.data(), newPath.data());
     handler.Return(JVal::Undefined());
   }
 }
@@ -363,6 +382,7 @@ JObject* InitFs() {
     fs->SetMethod("mkdir", Mkdir);
     fs->SetMethod("rmdir", Rmdir);
     fs->SetMethod("unlink", Unlink);
+    fs->SetMethod("rename", Rename);
 
     module->module = fs;
   }

--- a/test/resources/rename.txt
+++ b/test/resources/rename.txt
@@ -1,0 +1,1 @@
+Hello IoT.js!!

--- a/test/run_pass/test_fs_rename.js
+++ b/test/run_pass/test_fs_rename.js
@@ -1,0 +1,34 @@
+/* Copyright 2016 Samsung Electronics Co., Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+ /*
+ @STDOUT=Pass
+ */
+
+var fs = require('fs');
+var assert = require('assert');
+
+var file1 = "../resources/rename.txt";
+var file2 = "../resources/rename.txt.async";
+
+fs.rename(file1, file2, function(err) {
+  assert.equal(err, null);
+  assert.equal(fs.existsSync(file1), false);
+  assert.equal(fs.existsSync(file2), true);
+  fs.rename(file2, file1, function(err) {
+    assert.equal(err, null);
+    console.log("Pass");
+  });
+});

--- a/test/run_pass/test_fs_rename_sync.js
+++ b/test/run_pass/test_fs_rename_sync.js
@@ -1,0 +1,25 @@
+/* Copyright 2016 Samsung Electronics Co., Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+var fs = require('fs');
+var assert = require('assert');
+
+var file1 = "../resources/rename.txt";
+var file2 = "../resources/rename.txt.sync";
+
+fs.renameSync(file1, file2);
+assert.equal(fs.existsSync(file1), false);
+assert.equal(fs.existsSync(file2), true);
+fs.renameSync(file2, file1);


### PR DESCRIPTION
This patch is for issue #28.

- implement fs.rename and fs.renameSync
- add testcases for rename/renameSync APIs
- update FileSystem API document
 : add description for above APIs
 : sort method lists by alphabetically
 : indent description for class fs.Stats

IoT.js-DCO-1.0-Signed-off-by: Sanggyu Lee sg5.lee@samsung.com