### PR TITLE
Enable TCP for NuttX

### DIFF
--- a/src/iotjs_def.h
+++ b/src/iotjs_def.h
@@ -144,6 +144,7 @@ typedef struct { \
 #include <uv.h>
 #include <assert.h>
 #include <limits.h> /* PATH_MAX */
+#include <string.h>
 
 
 #endif /* IOTJS_DEF_H */

--- a/src/js/stream_writable.js
+++ b/src/js/stream_writable.js
@@ -92,7 +92,7 @@ Writable.prototype.write = function(chunk, callback) {
   var state = this._writableState;
   var res = false;
 
-  if (state.ended || state.ending) {
+  if (state.ended) {
     writeAfterEnd(this, callback);
   } else {
     res = writeOrBuffer(this, chunk, callback);
@@ -111,6 +111,17 @@ Writable.prototype._write = function(chunk, callback, onwrite) {
 
 Writable.prototype.end = function(chunk, callback) {
   var state = this._writableState;
+
+  // Because NuttX cannot poll 'EOF',so forcely raise EOF event.
+  if (process.platform == 'nuttx') {
+    if (!state.ending) {
+      if (util.isNullOrUndefined(chunk)) {
+        chunk = '\\e\\n\\d';
+      } else {
+        chunk += '\\e\\n\\d';
+      }
+    }
+  }
 
   if (!util.isNullOrUndefined(chunk)) {
     this.write(chunk);
@@ -267,4 +278,3 @@ function emitFinish(stream) {
 
 
 module.exports = Writable;
-

--- a/src/module/iotjs_module_dns.cpp
+++ b/src/module/iotjs_module_dns.cpp
@@ -24,7 +24,7 @@ namespace iotjs {
 
 typedef ReqWrap<uv_getaddrinfo_t> GetAddrInfoReqWrap;
 
-
+#if !defined(__NUTTX__)
 static void AfterGetAddrInfo(uv_getaddrinfo_t* req, int status, addrinfo* res) {
   GetAddrInfoReqWrap* req_wrap = reinterpret_cast<GetAddrInfoReqWrap*>(
       req->data);
@@ -63,6 +63,7 @@ static void AfterGetAddrInfo(uv_getaddrinfo_t* req, int status, addrinfo* res) {
 
   delete req_wrap;
 }
+#endif
 
 
 JHANDLER_FUNCTION(GetAddrInfo) {
@@ -89,6 +90,32 @@ JHANDLER_FUNCTION(GetAddrInfo) {
     JHANDLER_THROW_RETURN(TypeError, "bad address family");
   }
 
+#if defined(__NUTTX__)
+  JArgList args(3);
+  int err = 0;
+  char ip[INET6_ADDRSTRLEN];
+  const char* hostname_data = iotjs_string_data(&hostname);
+
+  if (strcmp(hostname_data, "localhost") == 0) {
+    strcpy(ip, "127.0.0.1");
+  } else {
+    sockaddr_in addr;
+    int result = inet_pton(AF_INET, hostname_data, &(addr.sin_addr));
+
+    if (result != 1) {
+      err = errno;
+    } else {
+      inet_ntop(AF_INET, &(addr.sin_addr), ip, INET6_ADDRSTRLEN);
+    }
+  }
+
+  args.Add(JVal::Number(err));
+  JObject ipobj(ip);
+  args.Add(ipobj);
+  args.Add(JVal::Number(family));
+
+  MakeCallback(*jcallback, JObject::Undefined(), args);
+#else
   GetAddrInfoReqWrap* req_wrap = new GetAddrInfoReqWrap(*jcallback);
 
   struct addrinfo hints = {0};
@@ -106,6 +133,7 @@ JHANDLER_FUNCTION(GetAddrInfo) {
   if (err) {
     delete req_wrap;
   }
+#endif
 
   handler.Return(JVal::Number(err));
 

--- a/test/run_pass/attrs.js
+++ b/test/run_pass/attrs.js
@@ -133,48 +133,16 @@
       skip: ['nuttx'],
       reason: "not implemented for nuttx"
     },
-    'test_net1.js': {
-      skip: ['nuttx'],
-      reason: "not implemented for nuttx"
-    },
-    'test_net2.js': {
-      skip: ['nuttx'],
-      reason: "not implemented for nuttx"
-    },
     'test_net3.js': {
       timeout: {
         all: 20
       },
       skip: ['nuttx'],
-      reason: "not implemented for nuttx"
-    },
-    'test_net4.js': {
-      skip: ['nuttx'],
-      reason: "not implemented for nuttx"
-    },
-    'test_net5.js': {
-      skip: ['nuttx'],
-      reason: "not implemented for nuttx"
-    },
-    'test_net6.js': {
-      skip: ['nuttx'],
-      reason: "not implemented for nuttx"
+      reason: "too many socket descriptors, too long buffers are in need"
     },
     'test_net7.js': {
       skip: ['nuttx'],
-      reason: "not implemented for nuttx"
-    },
-    'test_net8.js': {
-      skip: ['nuttx'],
-      reason: "not implemented for nuttx"
-    },
-    'test_net9.js': {
-      skip: ['nuttx'],
-      reason: "not implemented for nuttx"
-    },
-    'test_net10.js': {
-      skip: ['nuttx'],
-      reason: "not implemented for nuttx"
+      reason: "too many socket descriptors are in need"
     },
     'test_next_tick.js': {
       skip: ['all'],


### PR DESCRIPTION
* On Nuttx Side, EOF doesn't come with the event when polled.  In order to workaround this issue, when called `Socket.prototype.end`,  I marked the last chunk with magic string, `\\e\\n\\d` to check if it is the last buffer.
* For this implementation, `writeAfterEnd` should be checked with only flag `state.ended`, because when ReadableStream is ended, it calls `onSocketEnd`. In the default mode, `state.allowHalfOpen` is false, it calls `destroySoon`, in the end, automatically calls `Socket.prototype.end`. Therfore, for example, it is possible when socket receiving `end` event, `Socket.prototype.end` was already called so that it might raise an error `write after end`.
![screenshot_2016-11-01_21-12-36](https://cloud.githubusercontent.com/assets/5644396/19890148/3a54b0de-a07c-11e6-803f-c55a40b66198.png)
