### PR TITLE
Enable error message description on debug build

### DIFF
--- a/tools/build.py
+++ b/tools/build.py
@@ -442,6 +442,7 @@ def build_libjerry(option):
 
     if option.buildtype == 'debug':
         cmake_opt.append('-DCMAKE_BUILD_TYPE=Debug')
+        cmake_opt.append('-DFEATURE_ERROR_MESSAGES=On')
 
     if option.target_os == 'nuttx':
         cmake_opt.append('-DEXTERNAL_LIBC_INTERFACE=' +


### PR DESCRIPTION
The decriptive error messages on JavaScript exception, which
are enhanced by latest jerry commmits, are helpful on debugging.
It would be better to include this feature on by default on debug build.

IoT.js-DCO-1.0-Signed-off-by: Sanggyu Lee sg5.lee@samsung.com