### PR TITLE
Fix a bug which generate assert when i2c api is called.

### DIFF
--- a/src/module/iotjs_module_i2c.cpp
+++ b/src/module/iotjs_module_i2c.cpp
@@ -99,10 +99,7 @@ JHANDLER_FUNCTION(Open) {
   I2cReqData* req_data = req_wrap->req();
 
   req_data->op = kI2cOpOpen;
-
-  iotjs_string_t device = iotjs_jhandler_get_arg(jhandler, 0)->GetString();
-  iotjs_string_append(&req_data->device, iotjs_string_data(&device),
-                      iotjs_string_size(&device));
+  req_data->device = iotjs_jhandler_get_arg(jhandler, 0)->GetString();
 
   I2c* i2c = I2c::GetInstance();
   i2c->Open(req_wrap);

--- a/src/platform/iotjs_module_i2c-linux-general.inl.h
+++ b/src/platform/iotjs_module_i2c-linux-general.inl.h
@@ -306,6 +306,8 @@ void OpenWorker(uv_work_t* work_req) {
   } else {
     req_data->error = kI2cErrOk;
   }
+
+  iotjs_string_destroy(&req_data->device);
 }
 
 


### PR DESCRIPTION
- After merging c string apis, it doesn't work.
- Modify string generate code and add detory code.

IoT.js-DCO-1.0-Signed-off-by: Jaechul Yang jc08.yang@samsung.com