### PR TITLE
Implement PWM for linux

### DIFF
--- a/src/js/pwm.js
+++ b/src/js/pwm.js
@@ -16,82 +16,152 @@
 var util = require('util');
 var pwm = process.binding(process.binding.pwm);
 
-// PWM(pin[, options][, callback])
-function PWM(pin, options, callback) {
-    if (!(this instanceof PWM)) {
-        return new PWM(pin, options, callback);
-    }
 
-    if (!util.isNumber(pin) && !util.isString(pin)) {
-        throw new TypeError('Bad arguments - pin');
-    }
-
-    this._pin = pin;
-
-    // Check arguments.
-    if (util.isFunction(options)) {
-        callback = options;
-        options = {};
-    } else if (!util.isObject(options)) {
-        options = {};
-    }
-
-    return pwm.export(this._pin, options, function(err) {
-        if (util.isFunction(callback)) {
-            callback(err);
-        }
-    });
+function PwmError(code, operation, message) {
+  this.name = 'PwmError';
+  this.code = code;
+  this.operation = operation;
+  this.message = operation + ': ' + message;
 }
 
-// pwm.setDutyCycle(dutyCycle[, callback])
-PWM.prototype.setDutyCycle = function(dutyCycle, callback) {
-    // Check arguments.
-    if (!util.isNumber(dutyCycle)) {
-        throw new TypeError('Bad arguments - dutyCycle');
-    }
+util.inherits(PwmError, Error);
 
-    return pwm.setDutyCycle(this._pin, dutyCycle, function(err) {
-        if (util.isFunction(callback)) {
-            callback(err);
-        }
-    });
-};
+
+function CreatePwmError(operation, errno) {
+  if (errno == pwm.kPwmErrOk) {
+    return null;
+  }
+
+  switch (errno) {
+    case pwm.kPwmErrExport:
+      return new PwmError(errno, operation, 'Failed to export PWM');
+    case pwm.kPwmErrUnexport:
+      return new PwmError(errno, operation, 'Failed to unexport PWM');
+    case pwm.kPwmErrEnable:
+      return new PwmError(errno, operation, 'Failed to enable PWM');
+    case pwm.kPwmErrWrite:
+      return new PwmError(errno, operation, 'Failed to write value');
+    case pwm.kPwmErrSys:
+      return new PwmError(errno, operation, 'System error');
+  }
+  return new PwmError(errno, operation, 'Unknown error');
+}
+
+
+// PWM(pin[, options][, callback])
+function PWM(pin, options, callback) {
+  var self = this;
+
+  if (!(this instanceof PWM)) {
+    return new PWM(pin, options, callback);
+  }
+
+  if (!util.isNumber(pin) && !util.isString(pin)) {
+    throw new TypeError('Bad arguments - pin');
+  }
+
+  self._options = {};
+
+  var pinPath = pin + ''; // make string
+
+  // Check arguments.
+  if (util.isFunction(options)) {
+    callback = options;
+  } else if (util.isObject(options)) {
+    if (util.isNumber(options.dutyCycle)) {
+      self._options.dutyCycle = options.dutyCycle;
+    }
+    if (util.isNumber(options.period)) {
+      self._options.period = options.period;
+    }
+  }
+
+  self._pinPath = pwm.export(pinPath, self._options, function (err) {
+    var errObj = CreatePwmError('PWM()', err);
+
+    if (util.isFunction(callback)) {
+      callback(errObj);
+    }
+  });
+}
 
 // pwm.setPeriod(period[, callback])
-PWM.prototype.setPeriod = function(period, callback) {
-    // Check arguments.
-    if (!util.isNumber(period)) {
-        throw new TypeError('Bad arguments - period');
-    }
+PWM.prototype.setPeriod = function (period, callback) {
+  var self = this;
+  // Check arguments.
+  if (!util.isNumber(period)) {
+    throw new TypeError('Bad arguments - period');
+  }
 
-    return pwm.setDutyCycle(this._pin, period, function(err) {
-        if (util.isFunction(callback)) {
-            callback(err);
-        }
-    });
+  if (period < self._options.dutyCycle) {
+    throw new Error('setPeriod() - period is smaller than dutyCycle')
+  }
+
+  self._options.period = period;
+
+  return pwm.setPeriod(self._pinPath, period, function (err) {
+    var errObj = CreatePwmError('setPeriod()', err);
+
+    if (util.isFunction(callback)) {
+      callback(errObj);
+    }
+  });
 };
 
-// pwm.enable(enable[, callback])
-PWM.prototype.enable = function(enable, callback) {
-    // Check arguments.
-    if (!util.isNumber(enable) && !util.isBoolean(enable)) {
-        throw new TypeError('Bad arguments - enable');
-    }
+// pwm.setDutyCycle(dutyCycle[, callback])
+PWM.prototype.setDutyCycle = function (dutyCycle, callback) {
+  var self = this;
+  // Check arguments.
+  if (!util.isNumber(dutyCycle)) {
+    throw new TypeError('Bad arguments - dutyCycle');
+  }
 
-    return pwm.enable(this._pin, enable, function(err) {
-        if (util.isFunction(callback)) {
-            callback(err);
-        }
-    });
+  if (util.isNullOrUndefined(self._options.period)) {
+    throw new Error('setDutyCycle() - first set period, ' +
+      'before calling this function');
+  }
+
+  if (dutyCycle > self._options.period) {
+    throw new Error('setDutyCycle() - dutyCycle is bigger than period');
+  }
+
+  self._options.dutyCycle = dutyCycle;
+
+  return pwm.setDutyCycle(self._pinPath, dutyCycle, function (err) {
+    var errObj = CreatePwmError('setDutyCycle()', err);
+
+    if (util.isFunction(callback)) {
+      callback(errObj);
+    }
+  });
+};
+
+// pwm.setEnable(enable[, callback])
+PWM.prototype.setEnable = function (enable, callback) {
+  var self = this;
+  // Check arguments.
+  if (!util.isNumber(enable) && !util.isBoolean(enable)) {
+    throw new TypeError('Bad arguments - enable');
+  }
+
+  return pwm.setEnable(self._pinPath, !!enable, function (err) {
+    var errObj = CreatePwmError('setEnable()', err);
+
+    if (util.isFunction(callback)) {
+      callback(errObj);
+    }
+  });
 };
 
 // pwm.unexport([callback])
-PWM.prototype.unexport = function(callback) {
-    return pwm.unexport(this._pin, function(err) {
-        if (util.isFunction(callback)) {
-            callback(err);
-        }
-    });
+PWM.prototype.unexport = function (callback) {
+  return pwm.unexport(this._pinPath, function (err) {
+    var errObj = CreatePwmError('unexport()', err);
+
+    if (util.isFunction(callback)) {
+      callback(errObj);
+    }
+  });
 };
 
 module.exports = PWM;

--- a/src/module/iotjs_module_pwm.h
+++ b/src/module/iotjs_module_pwm.h
@@ -24,7 +24,32 @@
 
 namespace iotjs {
 
+enum PwmOp {
+  kPwmOpExport,
+  kPwmOpSetDutyCycle,
+  kPwmOpSetPeriod,
+  kPwmOpSetEnable,
+  kPwmOpUnexport,
+};
+
+enum PwmError {
+  kPwmErrOk = 0,
+  kPwmErrExport = -1,
+  kPwmErrUnexport = -2,
+  kPwmErrEnable = -3,
+  kPwmErrWrite = -4,
+  kPwmErrSys = -5,
+};
+
 struct PwmReqData {
+  iotjs_string_t device;
+  int32_t duty_cycle;
+  int32_t period;
+  bool enable;
+
+  PwmError result;
+  PwmOp op;
+
   void* data; // pointer to PwmReqWrap
 };
 
@@ -41,11 +66,12 @@ class Pwm : public JObjectWrap {
   static Pwm* GetInstance();
   static const iotjs_jval_t* GetJPwm();
 
+  virtual int InitializePwmPath(PwmReqWrap* pwm_req) = 0;
   virtual int Export(PwmReqWrap* pwm_req) = 0;
-  virtual int SetDutyCycle(PwmReqWrap* pwm_req) = 0;
   virtual int SetPeriod(PwmReqWrap* pwm_req) = 0;
-  virtual int Enable(PwmReqWrap* pwm_req) = 0;
-  virtual int Unexport(PwmReqWrap* pwm_rea) = 0;
+  virtual int SetDutyCycle(PwmReqWrap* pwm_req) = 0;
+  virtual int SetEnable(PwmReqWrap* pwm_req) = 0;
+  virtual int Unexport(PwmReqWrap* pwm_req) = 0;
 };
 
 

--- a/src/platform/arm-linux/iotjs_module_pwm-arm-linux.cpp
+++ b/src/platform/arm-linux/iotjs_module_pwm-arm-linux.cpp
@@ -1,0 +1,33 @@
+/* Copyright 2016 Samsung Electronics Co., Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+#if defined(__LINUX__)
+
+#include "../iotjs_module_pwm-linux-general.inl.h"
+
+
+namespace iotjs {
+
+
+Pwm* Pwm::Create(const iotjs_jval_t* jpwm) {
+  return new PwmLinuxGeneral(jpwm);
+}
+
+
+} // namespace iotjs
+
+
+#endif

--- a/src/platform/arm-nuttx/iotjs_module_pwm-arm-nuttx.cpp
+++ b/src/platform/arm-nuttx/iotjs_module_pwm-arm-nuttx.cpp
@@ -1,0 +1,93 @@
+/* Copyright 2016 Samsung Electronics Co., Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#if defined(__NUTTX__)
+
+
+#include "module/iotjs_module_pwm.h"
+
+
+namespace iotjs {
+
+
+// PWM implementation for arm-nuttx target.
+class PwmArmNuttx : public Pwm {
+ public:
+  explicit PwmArmNuttx(const iotjs_jval_t* jpwm);
+
+  static PwmArmNuttx* GetInstance();
+  virtual int InitializePwmPath(PwmReqWrap* pwm_req);
+  virtual int Export(PwmReqWrap* pwm_req);
+  virtual int SetPeriod(PwmReqWrap* pwm_req);
+  virtual int SetDutyCycle(PwmReqWrap* pwm_req);
+  virtual int SetEnable(PwmReqWrap* pwm_req);
+  virtual int Unexport(PwmReqWrap* pwm_req);
+};
+
+
+Pwm* Pwm::Create(const iotjs_jval_t* jpwm) {
+  return new PwmArmNuttx(jpwm);
+}
+
+
+PwmArmNuttx::PwmArmNuttx(const iotjs_jval_t* jpwm)
+    : Pwm(jpwm) {
+}
+
+
+PwmArmNuttx* PwmArmNuttx::GetInstance() {
+  return static_cast<PwmArmNuttx*>(Pwm::GetInstance());
+}
+
+
+int PwmArmNuttx::InitializePwmPath(PwmReqWrap* pwm_req) {
+  IOTJS_ASSERT(!"Not implemented");
+  return 0;
+}
+
+
+int PwmArmNuttx::Export(PwmReqWrap* pwm_req) {
+  IOTJS_ASSERT(!"Not implemented");
+  return 0;
+}
+
+
+int PwmArmNuttx::SetPeriod(PwmReqWrap* pwm_req) {
+  IOTJS_ASSERT(!"Not implemented");
+  return 0;
+}
+
+
+int PwmArmNuttx::SetDutyCycle(PwmReqWrap* pwm_req) {
+  IOTJS_ASSERT(!"Not implemented");
+  return 0;
+}
+
+
+int PwmArmNuttx::SetEnable(PwmReqWrap* pwm_req) {
+  IOTJS_ASSERT(!"Not implemented");
+  return 0;
+}
+
+
+int PwmArmNuttx::Unexport(PwmReqWrap* pwm_req) {
+  IOTJS_ASSERT(!"Not implemented");
+  return 0;
+}
+
+
+} // namespace iotjs
+
+#endif // __NUTTX__

--- a/src/platform/i686-linux/iotjs_module_pwm-i686-linux.cpp
+++ b/src/platform/i686-linux/iotjs_module_pwm-i686-linux.cpp
@@ -1,0 +1,33 @@
+/* Copyright 2016 Samsung Electronics Co., Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+#if defined(__LINUX__)
+
+#include "../iotjs_module_pwm-linux-general.inl.h"
+
+
+namespace iotjs {
+
+
+Pwm* Pwm::Create(const iotjs_jval_t* jpwm) {
+  return new PwmLinuxGeneral(jpwm);
+}
+
+
+} // namespace iotjs
+
+
+#endif

--- a/src/platform/iotjs_device_io-linux-general.h
+++ b/src/platform/iotjs_device_io-linux-general.h
@@ -1,0 +1,194 @@
+/* Copyright 2016 Samsung Electronics Co., Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef IOTJS_DEVICE_IO_LINUX_GENERAL_H
+#define IOTJS_DEVICE_IO_LINUX_GENERAL_H
+
+#include <uv.h>
+
+namespace iotjs {
+
+
+// uv fs request wrapper for auto cleanup.
+class LocalDeviceFsReq : public uv_fs_t {
+ public:
+  ~LocalDeviceFsReq() {
+    uv_fs_req_cleanup(this);
+  }
+};
+
+
+// Checks if given directory exists.
+bool DeviceCheckPath(const char* path) {
+  const iotjs_environment_t* env = iotjs_environment_get();
+
+  DDDLOG("DeviceCheckPath() - path: %s", path);
+
+  // stat for the path.
+  LocalDeviceFsReq fs_req;
+  int err = uv_fs_stat(iotjs_environment_loop(env), &fs_req, path, NULL);
+
+  // exist?
+  if (err || fs_req.result) {
+    return false;
+  }
+
+  DDDLOG("DeviceCheckPath() - path exist");
+
+  return true;
+}
+
+
+bool DeviceOpenWriteClose(const char* path, char* value) {
+  const iotjs_environment_t* env = iotjs_environment_get();
+  uv_loop_t* loop = iotjs_environment_loop(env);
+
+  DDLOG("DeviceOpenWriteClose() - path %s, value: %s", path, value);
+
+  // Open file.
+  LocalDeviceFsReq fs_req;
+  int fd = uv_fs_open(loop, &fs_req, path, O_WRONLY, 0666, NULL);
+  if (fd < 0) {
+    DDLOG("DeviceOpenWriteClose() - open %s failed: %d", path, fd);
+    return false;
+  }
+
+  // Write value.
+  uv_buf_t uvbuf = uv_buf_init(value, strlen(value));
+  uv_fs_req_cleanup(&fs_req);
+  int write_err = uv_fs_write(loop, &fs_req, fd, &uvbuf, 1, 0, NULL);
+
+  // Close file.
+  uv_fs_req_cleanup(&fs_req);
+  int close_err = uv_fs_close(loop, &fs_req, fd, NULL);
+
+  if (write_err < 0) {
+    DDLOG("DeviceOpenWriteClose() - write %s %s failed: %d", path, value,
+          write_err);
+    return false;
+  }
+
+  if (close_err < 0) {
+    DDLOG("DeviceOpenWriteClose() - close failed: %d", close_err);
+    return false;
+  }
+
+  return true;
+}
+
+
+bool DeviceOpenReadClose(const char* path, char* buffer, int buffer_len) {
+  const iotjs_environment_t* env = iotjs_environment_get();
+  uv_loop_t* loop = iotjs_environment_loop(env);
+
+  DDDLOG("DeviceOpenReadClose() - path %s", path);
+
+  // Open file.
+  LocalDeviceFsReq fs_open_req;
+  int fd = uv_fs_open(loop, &fs_open_req, path, O_RDONLY, 0666, NULL);
+  if (fd < 0) {
+    DDLOG("DeviceOpenReadClose() - open %s failed: %d", path, fd);
+    return false;
+  }
+
+  // Write value.
+  LocalDeviceFsReq fs_write_req;
+  uv_buf_t uvbuf = uv_buf_init(buffer, buffer_len);
+  int err = uv_fs_read(loop, &fs_write_req, fd, &uvbuf, 1, 0, NULL);
+  if (err < 0) {
+    DDLOG("DeviceOpenReadClose() - read failed: %d", err);
+    return false;
+  }
+
+  DDDLOG("DeviceOpenReadClose() - read value: %s", buffer);
+
+  // Close file.
+  LocalDeviceFsReq fs_close_req;
+  err = uv_fs_close(loop, &fs_close_req, fd, NULL);
+  if (err < 0) {
+    DDLOG("DeviceOpenReadClose() - close failed: %d", err);
+    return false;
+  }
+
+  return true;
+}
+
+
+// Export.
+bool DeviceExport(const char* export_path, int value, const char* exported_path,
+                  const char** created_files, int created_files_length) {
+
+  DDLOG("DeviceExport() - path: %s", export_path);
+
+  // Write export pin.
+  char buff[10] = {0};
+  snprintf(buff, 9, "%d", value);
+
+  if (!DeviceOpenWriteClose(export_path, buff)) {
+    return false;
+  }
+
+  // Wait for directory creation.
+  int count = 0;
+  int count_limit = created_files_length * 10;
+  char buffer[10];
+  char path[64] = {0};
+  char check_format[64] = {0};
+
+  while (!DeviceCheckPath(exported_path) && count < count_limit) {
+    usleep(100 * 1000); // sleep 100 miliseconds.
+    count++;
+  }
+
+  strcat(check_format, exported_path);
+  strcat(check_format, "%s");
+
+  for (int i = 0; i < created_files_length; i++) {
+    snprintf(path, 63, check_format, created_files[i]);
+
+    DDDLOG("DeviceExport() - created file: %s", created_files[i]);
+
+    while (!DeviceOpenReadClose(path, buffer, 10) && count < count_limit) {
+      usleep(100 * 1000); // sleep 100 miliseconds.
+      count++;
+    }
+  }
+
+  usleep(1000 * 100); // sleep another 1000 milisec.
+
+  return count < count_limit;
+}
+
+
+// Unexport.
+bool DeviceUnexport(const char* export_path, int value) {
+
+  DDDLOG("Device Unexport() - path: %s", DeviceUnexport);
+
+  char buff[10] = {0};
+  snprintf(buff, 9, "%d", value);
+
+  if (!DeviceOpenWriteClose(export_path, buff)) {
+    return false;
+  }
+
+  return true;
+}
+
+
+} // namespace iotjs
+
+
+#endif /* IOTJS_DEVICE_IO_LINUX_GENERAL_H */

--- a/src/platform/iotjs_module_pwm-linux-general.inl.h
+++ b/src/platform/iotjs_module_pwm-linux-general.inl.h
@@ -1,0 +1,351 @@
+/* Copyright 2016 Samsung Electronics Co., Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef IOTJS_MODULE_PWM_LINUX_GENERAL_INL_H
+#define IOTJS_MODULE_PWM_LINUX_GENERAL_INL_H
+
+
+#include <string.h>
+#include <stdlib.h>
+#include <stdio.h>
+#include <unistd.h>
+
+#include "module/iotjs_module_pwm.h"
+#include "iotjs_device_io-linux-general.h"
+
+
+#define PWM_INTERFACE "/sys/class/pwm/pwmchip%d/"
+#define PWM_PIN_INTERFACE "pwm%d/"
+#define PWM_PIN_FORMAT PWM_INTERFACE PWM_PIN_INTERFACE
+#define PWM_EXPORT PWM_INTERFACE "export"
+#define PWM_UNEXPORT PWM_INTERFACE "unexport"
+#define PWM_PIN_DUTYCYCLE "duty_cycle"
+#define PWM_PIN_PERIOD "period"
+#define PWM_PIN_ENABlE "enable"
+#define PWM_DEFAULT_CHIP_NUMBER 0
+
+
+namespace iotjs {
+
+
+// Generic PWM implementation for linux.
+class PwmLinuxGeneral : public Pwm {
+ public:
+  explicit PwmLinuxGeneral(const iotjs_jval_t* jpwm);
+
+  static PwmLinuxGeneral* GetInstance();
+
+  virtual int InitializePwmPath(PwmReqWrap* pwm_req);
+  virtual int Export(PwmReqWrap* pwm_req);
+  virtual int SetPeriod(PwmReqWrap* pwm_req);
+  virtual int SetDutyCycle(PwmReqWrap* pwm_req);
+  virtual int SetEnable(PwmReqWrap* pwm_req);
+  virtual int Unexport(PwmReqWrap* pwm_req);
+
+ public:
+};
+
+
+PwmLinuxGeneral::PwmLinuxGeneral(const iotjs_jval_t* jpwm)
+    : Pwm(jpwm)
+{
+}
+
+
+PwmLinuxGeneral* PwmLinuxGeneral::GetInstance() {
+  return static_cast<PwmLinuxGeneral*>(Pwm::GetInstance());
+}
+
+
+// Set PWM period.
+bool SetPwmPeriod(PwmReqData* req_data) {
+  IOTJS_ASSERT(!iotjs_string_is_empty(&req_data->device));
+
+  char path_buff[64] = {0};
+  char value_buff[32] = {0};
+
+  strcat(path_buff, iotjs_string_data(&req_data->device));
+  strcat(path_buff, PWM_PIN_PERIOD);
+
+  DDDLOG("PWM SetPeriod - path: %s, value: %d", path_buff, req_data->period);
+
+  snprintf(value_buff, 31, "%d", req_data->period);
+
+  if (!DeviceOpenWriteClose(path_buff, value_buff)) {
+    return false;
+  }
+
+  return true;
+}
+
+
+// Set PWM Duty-Cycle.
+bool SetPwmDutyCycle(PwmReqData* req_data) {
+  IOTJS_ASSERT(!iotjs_string_is_empty(&req_data->device));
+
+  char path_buff[64] = {0};
+  char value_buff[32] = {0};
+
+  strcat(path_buff, iotjs_string_data(&req_data->device));
+  strcat(path_buff, PWM_PIN_DUTYCYCLE);
+
+  DDDLOG("PWM SetdutyCycle - path: %s, value: %d",
+         path_buff, req_data->duty_cycle);
+
+  snprintf(value_buff, 31, "%d", req_data->duty_cycle);
+
+  if (!DeviceOpenWriteClose(path_buff, value_buff)) {
+    return false;
+  }
+
+  return true;
+}
+
+
+void AfterPwmWork(uv_work_t* work_req, int status) {
+  PwmLinuxGeneral* pwm = PwmLinuxGeneral::GetInstance();
+  PwmReqWrap* pwm_req = reinterpret_cast<PwmReqWrap*>(work_req->data);
+  PwmReqData* req_data = pwm_req->req();
+
+  if (status) {
+    req_data->result = kPwmErrSys;
+  }
+
+  iotjs_jargs_t jargs = iotjs_jargs_create(1);
+  iotjs_jargs_append_number(&jargs, req_data->result);
+
+  switch (req_data->op) {
+    case kPwmOpExport:
+    case kPwmOpSetDutyCycle:
+    case kPwmOpSetPeriod:
+    case kPwmOpSetEnable:
+    case kPwmOpUnexport:
+      break;
+    default:
+    {
+      IOTJS_ASSERT(!"Unreachable");
+      break;
+    }
+  }
+
+  iotjs_make_callback(pwm_req->jcallback(), Pwm::GetJPwm(), &jargs);
+
+  iotjs_jargs_destroy(&jargs);
+  iotjs_string_destroy(&req_data->device);
+
+  delete work_req;
+  delete pwm_req;
+}
+
+
+void ExportWorker(uv_work_t* work_req) {
+  PwmReqWrap* pwm_req = reinterpret_cast<PwmReqWrap*>(work_req->data);
+  PwmReqData* req_data = pwm_req->req();
+
+  IOTJS_ASSERT(!iotjs_string_is_empty(&req_data->device));
+
+  const char* path = iotjs_string_data(&req_data->device);
+  const char* export_path;
+  int32_t chip_number, pwm_number;
+
+  // See if the pwm is already opened.
+  if (!DeviceCheckPath(path)) {
+    // Get chip_number and pwm_number.
+    if (sscanf(path, PWM_PIN_FORMAT, &chip_number, &pwm_number) != 2) {
+      req_data->result = kPwmErrExport;
+      return;
+    }
+
+    // Write export pwm
+    char buffer[64] = {0};
+    snprintf(buffer, 63, PWM_EXPORT, chip_number);
+
+    const char* created_files[] = {PWM_PIN_DUTYCYCLE, PWM_PIN_PERIOD,
+                                   PWM_PIN_ENABlE};
+    int created_files_length = sizeof(created_files) / sizeof(created_files[0]);
+    if (!DeviceExport(buffer, pwm_number, path, created_files,
+                      created_files_length)) {
+      req_data->result = kPwmErrExport;
+      return;
+    }
+  }
+
+  // Set options.
+  if (req_data->period >= 0) {
+    if (!SetPwmPeriod(req_data)) {
+      req_data->result = kPwmErrWrite;
+      return;
+    }
+  }
+
+  if (req_data->duty_cycle >= 0) {
+    if (!SetPwmDutyCycle(req_data)) {
+      req_data->result = kPwmErrWrite;
+      return;
+    }
+  }
+
+  DDDLOG("PWM ExportWorker - path: %s", path);
+
+  req_data->result = kPwmErrOk;
+}
+
+
+void SetPeriodWorker(uv_work_t* work_req) {
+  PwmReqWrap* pwm_req = reinterpret_cast<PwmReqWrap*>(work_req->data);
+  PwmReqData* req_data = pwm_req->req();
+
+  if (!SetPwmPeriod(req_data)) {
+    req_data->result = kPwmErrWrite;
+    return;
+  }
+
+  DDDLOG("PWM SetPeriodWorker");
+
+  req_data->result = kPwmErrOk;
+}
+
+
+void SetDutyCycleWorker(uv_work_t* work_req) {
+  PwmReqWrap* pwm_req = reinterpret_cast<PwmReqWrap*>(work_req->data);
+  PwmReqData* req_data = pwm_req->req();
+
+  if (!SetPwmDutyCycle(req_data)) {
+    req_data->result = kPwmErrWrite;
+    return;
+  }
+
+  DDDLOG("PWM SetDutyCycleWorker");
+
+  req_data->result = kPwmErrOk;
+}
+
+
+void SetEnableWorker(uv_work_t* work_req) {
+  PwmReqWrap* pwm_req = reinterpret_cast<PwmReqWrap*>(work_req->data);
+  PwmReqData* req_data = pwm_req->req();
+
+  IOTJS_ASSERT(!iotjs_string_is_empty(&req_data->device));
+
+  iotjs_string_append(&req_data->device, PWM_PIN_ENABlE, -1);
+  const char* path = iotjs_string_data(&req_data->device);
+
+  char buff[10] = {0};
+  snprintf(buff, 9, "%d", req_data->enable);
+  if (!DeviceOpenWriteClose(path, buff)) {
+    req_data->result = kPwmErrWrite;
+    return;
+  }
+
+  DDDLOG("PWM SetEnableWorker - path: %s", path);
+
+  req_data->result = kPwmErrOk;
+}
+
+
+void UnexportWorker(uv_work_t* work_req) {
+  PwmReqWrap* pwm_req = reinterpret_cast<PwmReqWrap*>(work_req->data);
+  PwmReqData* req_data = pwm_req->req();
+
+  IOTJS_ASSERT(!iotjs_string_is_empty(&req_data->device));
+
+  const char* path = iotjs_string_data(&req_data->device);
+  const char* export_path;
+  int32_t chip_number, pwm_number;
+
+  if (DeviceCheckPath(path)) {
+    sscanf(path, PWM_PIN_FORMAT, &chip_number, &pwm_number);
+    // Write export pin
+    char buffer[64] = {0};
+    snprintf(buffer, 63, PWM_UNEXPORT, chip_number);
+
+    DeviceUnexport(buffer, pwm_number);
+  }
+
+  DDDLOG("Pwm Unexport - path: %s", path);
+
+  req_data->result = kPwmErrOk;
+}
+
+
+#define PWM_LINUX_GENERAL_IMPL_TEMPLATE(op) \
+  do { \
+    PwmLinuxGeneral* pwm = PwmLinuxGeneral::GetInstance(); \
+    const iotjs_environment_t* env = iotjs_environment_get(); \
+    uv_loop_t* loop = iotjs_environment_loop(env); \
+    uv_work_t* req = new uv_work_t; \
+    req->data = reinterpret_cast<void*>(pwm_req); \
+    uv_queue_work(loop, req, op ## Worker, AfterPwmWork); \
+  } while (0)
+
+
+int PwmLinuxGeneral::InitializePwmPath(PwmReqWrap* pwm_req) {
+  PwmReqData* req_data = pwm_req->req();
+
+  int32_t chip_number, pwm_number;
+  const char* path = iotjs_string_data(&req_data->device);
+  char buffer[64] = {0};
+
+  if (sscanf(path, PWM_PIN_FORMAT, &chip_number, &pwm_number) == 2) {
+
+  } else if (sscanf(path, "%d", &pwm_number) == 1) {
+    chip_number = PWM_DEFAULT_CHIP_NUMBER;
+  } else {
+    return -1;
+  }
+
+  // Create Device Path
+  iotjs_string_make_empty(&req_data->device);
+  snprintf(buffer, 63, PWM_PIN_FORMAT, chip_number, pwm_number);
+  iotjs_string_append(&req_data->device, buffer, -1);
+
+  return 0;
+}
+
+
+int PwmLinuxGeneral::Export(PwmReqWrap* pwm_req) {
+  PWM_LINUX_GENERAL_IMPL_TEMPLATE(Export);
+  return 0;
+}
+
+
+int PwmLinuxGeneral::SetPeriod(PwmReqWrap* pwm_req) {
+  PWM_LINUX_GENERAL_IMPL_TEMPLATE(SetPeriod);
+  return 0;
+}
+
+
+int PwmLinuxGeneral::SetDutyCycle(PwmReqWrap* pwm_req) {
+  PWM_LINUX_GENERAL_IMPL_TEMPLATE(SetDutyCycle);
+  return 0;
+}
+
+
+int PwmLinuxGeneral::SetEnable(PwmReqWrap* pwm_req) {
+  PWM_LINUX_GENERAL_IMPL_TEMPLATE(SetEnable);
+  return 0;
+}
+
+
+int PwmLinuxGeneral::Unexport(PwmReqWrap* pwm_req) {
+  PWM_LINUX_GENERAL_IMPL_TEMPLATE(Unexport);
+  return 0;
+}
+
+
+} // namespace iotjs
+
+
+#endif /* IOTJS_MODULE_PWM_LINUX_GENERAL_INL_H */

--- a/src/platform/x86_64-linux/iotjs_module_pwm-x86_64-linux.cpp
+++ b/src/platform/x86_64-linux/iotjs_module_pwm-x86_64-linux.cpp
@@ -1,0 +1,33 @@
+/* Copyright 2016 Samsung Electronics Co., Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+#if defined(__LINUX__)
+
+#include "../iotjs_module_pwm-linux-general.inl.h"
+
+
+namespace iotjs {
+
+
+Pwm* Pwm::Create(const iotjs_jval_t* jpwm) {
+  return new PwmLinuxGeneral(jpwm);
+}
+
+
+} // namespace iotjs
+
+
+#endif

--- a/test/run_pass/attrs.js
+++ b/test/run_pass/attrs.js
@@ -156,6 +156,10 @@
       skip: ['nuttx'],
       reason: "too many socket descriptors are in need"
     },
+    'test_pwm.js': {
+      skip: ['all'],
+      reason: "need to setup test environment"
+    },
     'test_timers.js': {
       timeout: {
         all: 10

--- a/test/run_pass/test_pwm.js
+++ b/test/run_pass/test_pwm.js
@@ -1,0 +1,87 @@
+/* Copyright 2016 Samsung Electronics Co., Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+var assert = require('assert');
+var pwm = require('pwm');
+var option = {
+  period: 1000000,
+  dutyCycle: 250000
+};
+
+var callback = function (err) {
+  if (err) {
+    assert.fail();
+  }
+};
+
+var pwm0 = new pwm(0, option, function (err) {
+  console.log('PWM initialized');
+
+  if (err) {
+    assert.fail();
+  }
+
+  pwm0.setEnable(1, callback);
+
+s  test1();
+});
+
+function test1() {
+  var maxCnt = 3,
+    loopCnt = maxCnt,
+    dutyCycle;
+
+  console.log('test1 start');
+  var test1Loop = setInterval(function () {
+    loopCnt--;
+
+    dutyCycle = (option.dutyCycle * (maxCnt - loopCnt));
+    pwm0.setDutyCycle(dutyCycle, callback);
+
+    console.log('Duty-Cycle : %d', dutyCycle);
+
+    if (loopCnt <= 0) {
+      clearInterval(test1Loop);
+      console.log('test1 complete');
+      test2();
+    }
+  }, 1000);
+}
+
+function test2() {
+  var maxCnt = 3,
+    loopCnt = maxCnt,
+    period;
+
+  option.period = 500000;
+  option.dutyCycle = 250000;
+  pwm0.setDutyCycle(option.dutyCycle, callback);
+
+  console.log('test2 start');
+  var test2Loop = setInterval(function () {
+    loopCnt--;
+
+    period = (option.period * (maxCnt - loopCnt));
+    pwm0.setPeriod(period, callback);
+
+    console.log('Period : %d', period);
+
+    if (loopCnt <= 0) {
+      clearInterval(test2Loop);
+      console.log('test2 complete');
+    }
+  }, 1000);
+}

--- a/test/testsets.js
+++ b/test/testsets.js
@@ -64,6 +64,7 @@ function testsets() {
       'test_net10.js',
       'test_next_tick.js',
       'test_process.js',
+      'test_pwm.js',
       'test_stream.js',
       'test_timers.js',
       'test_timers2.js',


### PR DESCRIPTION
- Implement PWM API for general linux.
- Add testsuite, and tested on rpi2
- rename enable into setEnable

IoT.js-DCO-1.0-Signed-off-by: Hosung Kim hs852.kim@samsung.com