### PR TITLE
Enable test_next_tick.js on testdriver

### DIFF
--- a/test/run_pass/attrs.js
+++ b/test/run_pass/attrs.js
@@ -156,11 +156,6 @@
       skip: ['nuttx'],
       reason: "too many socket descriptors are in need"
     },
-    'test_next_tick.js': {
-      skip: ['all'],
-      reason:
-        "driver can not run with test which checks out process.nextTick events"
-    },
     'test_timers.js': {
       timeout: {
         all: 10

--- a/tools/test_runner.js
+++ b/tools/test_runner.js
@@ -50,6 +50,10 @@ Runner.prototype.spin = function() {
   process.nextTick(function() {
       var timerOnlyAlive = !testdriver.isAliveExceptFor(that.timer);
       if (timerOnlyAlive) {
+        timerOnlyAlive = !process._onNextTick();
+      }
+
+      if (timerOnlyAlive) {
         process.exit(0);
       } else {
         if (!that.finished) {


### PR DESCRIPTION
Related to #480 
IoT.js-DCO-1.0-Signed-off-by: wonyong.kim wonyong.kim@samsung.com