### PR TITLE
Update I2C Document.

### DIFF
--- a/docs/IoT.js-API-I2C.md
+++ b/docs/IoT.js-API-I2C.md
@@ -8,14 +8,14 @@ The following shows i2c module APIs available for each platform.
 
 |  | Linux<br/>(Ubuntu) | Raspbian<br/>(Raspberry Pi) | Nuttx<br/>(STM32F4-Discovery) |
 | :---: | :---: | :---: | :---: |
-| scan | O | O | X |
-| write | O | O | X |
-| writeByte | O | O | X |
-| writeBytes | O | O | X |
-| read | O | O | X |
-| readByte | O | O | X |
-| readBytes | O | O | X |
-| stream | O | O | X |
+| i2c.scan | O | O | X |
+| i2c.write | O | O | X |
+| i2c.writeByte | O | O | X |
+| i2c.writeBytes | O | O | X |
+| i2c.read | O | O | X |
+| i2c.readByte | O | O | X |
+| i2c.readBytes | O | O | X |
+| i2c.stream | O | O | X |
 
 ### Constructor
 


### PR DESCRIPTION
- Add prefix for each API. (Module can have several constructors.)

IoT.js-DCO-1.0-Signed-off-by: Jaechul Yang jc08.yang@samsung.com