### PR TITLE
Rework iotjs_reqwrap_t and hide destructors of object wraps

### DIFF
--- a/src/iotjs_reqwrap.c
+++ b/src/iotjs_reqwrap.c
@@ -18,12 +18,13 @@
 
 
 void iotjs_reqwrap_initialize(iotjs_reqwrap_t* reqwrap,
-                              const iotjs_jval_t* jcallback, uv_req_t* request,
-                              void* wrap) {
+                              const iotjs_jval_t* jcallback,
+                              uv_req_t* request) {
   IOTJS_VALIDATED_STRUCT_CONSTRUCTOR(iotjs_reqwrap_t, reqwrap);
+  IOTJS_ASSERT(iotjs_jval_is_function(jcallback));
   _this->jcallback = iotjs_jval_create_copied(jcallback);
   _this->request = request;
-  _this->request->data = wrap;
+  _this->request->data = reqwrap;
 }
 
 

--- a/src/iotjs_reqwrap.h
+++ b/src/iotjs_reqwrap.h
@@ -34,8 +34,7 @@ typedef struct {
 
 
 void iotjs_reqwrap_initialize(iotjs_reqwrap_t* reqwrap,
-                              const iotjs_jval_t* jcallback, uv_req_t* request,
-                              void* wrap);
+                              const iotjs_jval_t* jcallback, uv_req_t* request);
 void iotjs_reqwrap_destroy(iotjs_reqwrap_t* reqwrap);
 
 // To retrieve javascript callback funciton object.

--- a/src/module/iotjs_module_buffer.c
+++ b/src/module/iotjs_module_buffer.c
@@ -20,6 +20,8 @@
 #include <string.h>
 
 
+static void iotjs_bufferwrap_destroy(iotjs_bufferwrap_t* bufferwrap);
+
 iotjs_bufferwrap_t* iotjs_bufferwrap_create(const iotjs_jval_t* jbuiltin,
                                             size_t length) {
   iotjs_bufferwrap_t* bufferwrap = IOTJS_ALLOC(iotjs_bufferwrap_t);
@@ -44,7 +46,7 @@ iotjs_bufferwrap_t* iotjs_bufferwrap_create(const iotjs_jval_t* jbuiltin,
 }
 
 
-void iotjs_bufferwrap_destroy(iotjs_bufferwrap_t* bufferwrap) {
+static void iotjs_bufferwrap_destroy(iotjs_bufferwrap_t* bufferwrap) {
   IOTJS_VALIDATED_STRUCT_DESTRUCTOR(iotjs_bufferwrap_t, bufferwrap);
   if (_this->buffer != NULL) {
     iotjs_buffer_release(_this->buffer);

--- a/src/module/iotjs_module_buffer.h
+++ b/src/module/iotjs_module_buffer.h
@@ -29,7 +29,6 @@ typedef struct {
 
 iotjs_bufferwrap_t* iotjs_bufferwrap_create(const iotjs_jval_t* jbuiltin,
                                             size_t length);
-void iotjs_bufferwrap_destroy(iotjs_bufferwrap_t* bufferwrap);
 
 iotjs_bufferwrap_t* iotjs_bufferwrap_from_jbuiltin(
     const iotjs_jval_t* jbuiltin);

--- a/src/module/iotjs_module_dns.h
+++ b/src/module/iotjs_module_dns.h
@@ -1,0 +1,43 @@
+/* Copyright 2015-2016 Samsung Electronics Co., Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+#ifndef IOTJS_MODULE_DNS_H
+#define IOTJS_MODULE_DNS_H
+
+
+#include "iotjs_def.h"
+#include "iotjs_reqwrap.h"
+
+
+typedef struct {
+  iotjs_reqwrap_t reqwrap;
+  uv_getaddrinfo_t req;
+} IOTJS_VALIDATED_STRUCT(iotjs_getaddrinfo_reqwrap_t);
+
+#define THIS iotjs_getaddrinfo_reqwrap_t* getaddrinfo_reqwrap
+
+iotjs_getaddrinfo_reqwrap_t* iotjs_getaddrinfo_reqwrap_create(
+    const iotjs_jval_t* jcallback);
+
+void iotjs_getaddrinfo_reqwrap_dispatched(THIS);
+
+uv_getaddrinfo_t* iotjs_getaddrinfo_reqwrap_req(THIS);
+const iotjs_jval_t* iotjs_getaddrinfo_reqwrap_jcallback(THIS);
+
+#undef THIS
+
+
+#endif /* IOTJS_MODULE_DNS_H */

--- a/src/module/iotjs_module_fs.h
+++ b/src/module/iotjs_module_fs.h
@@ -1,0 +1,39 @@
+/* Copyright 2015-2016 Samsung Electronics Co., Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+#ifndef IOTJS_MODULE_FS_H
+#define IOTJS_MODULE_FS_H
+
+
+#include "iotjs_def.h"
+#include "iotjs_reqwrap.h"
+
+
+typedef struct {
+  iotjs_reqwrap_t reqwrap;
+  uv_fs_t req;
+} IOTJS_VALIDATED_STRUCT(iotjs_fs_reqwrap_t);
+
+
+iotjs_fs_reqwrap_t* iotjs_fs_reqwrap_create(const iotjs_jval_t* jcallback);
+
+void iotjs_fs_reqwrap_dispatched(iotjs_fs_reqwrap_t* fs_reqwrap);
+
+uv_fs_t* iotjs_fs_reqwrap_req(iotjs_fs_reqwrap_t* fs_reqwrap);
+const iotjs_jval_t* iotjs_fs_reqwrap_jcallback(iotjs_fs_reqwrap_t* fs_reqwrap);
+
+
+#endif /* IOTJS_MODULE_FS_H */

--- a/src/module/iotjs_module_gpio.h
+++ b/src/module/iotjs_module_gpio.h
@@ -65,23 +65,23 @@ typedef struct {
   GpioMode mode; // only for set pin
   GpioError result;
   GpioOp op;
-} iotjs_gpioreqdata_t;
+} iotjs_gpio_reqdata_t;
 
 
 typedef struct {
   iotjs_reqwrap_t reqwrap;
   uv_work_t req;
-  iotjs_gpioreqdata_t req_data;
-} IOTJS_VALIDATED_STRUCT(iotjs_gpioreqwrap_t);
+  iotjs_gpio_reqdata_t req_data;
+} IOTJS_VALIDATED_STRUCT(iotjs_gpio_reqwrap_t);
 
-#define THIS iotjs_gpioreqwrap_t* gpioreqwrap
-void iotjs_gpioreqwrap_initialize(THIS, const iotjs_jval_t* jcallback,
-                                  GpioOp op);
-void iotjs_gpioreqwrap_destroy(THIS);
-uv_work_t* iotjs_gpioreqwrap_req(THIS);
-const iotjs_jval_t* iotjs_gpioreqwrap_jcallback(THIS);
-iotjs_gpioreqwrap_t* iotjs_gpioreqwrap_from_request(uv_work_t* req);
-iotjs_gpioreqdata_t* iotjs_gpioreqwrap_data(THIS);
+#define THIS iotjs_gpio_reqwrap_t* gpio_reqwrap
+iotjs_gpio_reqwrap_t* iotjs_gpio_reqwrap_create(const iotjs_jval_t* jcallback,
+                                                GpioOp op);
+void iotjs_gpio_reqwrap_dispatched(THIS);
+uv_work_t* iotjs_gpio_reqwrap_req(THIS);
+const iotjs_jval_t* iotjs_gpio_reqwrap_jcallback(THIS);
+iotjs_gpio_reqwrap_t* iotjs_gpio_reqwrap_from_request(uv_work_t* req);
+iotjs_gpio_reqdata_t* iotjs_gpio_reqwrap_data(THIS);
 #undef THIS
 
 
@@ -92,7 +92,6 @@ typedef struct {
 } IOTJS_VALIDATED_STRUCT(iotjs_gpio_t);
 
 iotjs_gpio_t* iotjs_gpio_create(const iotjs_jval_t* jgpio);
-void iotjs_gpio_destroy(iotjs_gpio_t* gpio);
 const iotjs_jval_t* iotjs_gpio_get_jgpio();
 iotjs_gpio_t* iotjs_gpio_get_instance();
 bool iotjs_gpio_initialized();

--- a/src/module/iotjs_module_httpparser.c
+++ b/src/module/iotjs_module_httpparser.c
@@ -15,70 +15,18 @@
 
 
 #include "iotjs_def.h"
+#include "iotjs_module_httpparser.h"
 #include "iotjs_module_buffer.h"
-#include "iotjs_objectwrap.h"
-#include "http_parser.h"
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 
 
-// If # of header fields == HEADER_MAX, flush header to JS side.
-// This is weired : # of maximum headers in C equals to HEADER_MAX-1.
-// This is because , OnHeaders cb, we increase n_fields first,
-// and check whether field == HEADER_MAX.
-// ex) HEADER_MAX 2 means that we can keep at most 1 header field/value
-// during http parsing.
-// Increse this to minimize inter JS-C call
-#define HEADER_MAX 10
-
-
-typedef struct {
-  iotjs_jobjectwrap_t jobjectwrap;
-
-  http_parser parser;
-
-  iotjs_string_t url;
-  iotjs_string_t status_msg;
-
-  iotjs_string_t fields[HEADER_MAX];
-  iotjs_string_t values[HEADER_MAX];
-  size_t n_fields;
-  size_t n_values;
-
-  iotjs_jval_t* cur_jbuf;
-  char* cur_buf;
-  size_t cur_buf_len;
-
-  bool flushed;
-} IOTJS_VALIDATED_STRUCT(iotjs_httpparserwrap_t);
-
-typedef enum http_parser_type http_parser_type;
 #define THIS iotjs_httpparserwrap_t* httpparserwrap
 
-iotjs_httpparserwrap_t* iotjs_httpparserwrap_create(const iotjs_jval_t* jparser,
-                                                    http_parser_type type);
-void iotjs_httpparserwrap_destroy(THIS);
 
-void iotjs_httpparserwrap_initialize(THIS, http_parser_type type);
+static void iotjs_httpparserwrap_destroy(THIS);
 
-int iotjs_httpparserwrap_on_message_begin(THIS);
-int iotjs_httpparserwrap_on_url(THIS, const char* at, size_t length);
-int iotjs_httpparserwrap_on_status(THIS, const char* at, size_t length);
-int iotjs_httpparserwrap_on_header_field(THIS, const char* at, size_t length);
-int iotjs_httpparserwrap_on_header_value(THIS, const char* at, size_t length);
-int iotjs_httpparserwrap_on_headers_complete(THIS);
-int iotjs_httpparserwrap_on_body(THIS, const char* at, size_t length);
-int iotjs_httpparserwrap_on_message_complete(THIS);
-
-iotjs_jval_t iotjs_httpparserwrap_make_header(THIS);
-
-void iotjs_httpparserwrap_flush(THIS);
-
-void iotjs_httpparserwrap_set_buf(THIS, iotjs_jval_t* jbuf, char* buf, int sz);
-
-iotjs_jval_t* iotjs_httpparserwrap_jobject(THIS);
-http_parser* iotjs_httpparserwrap_parser(THIS);
 
 iotjs_httpparserwrap_t* iotjs_httpparserwrap_create(const iotjs_jval_t* jparser,
                                                     http_parser_type type) {
@@ -102,7 +50,7 @@ iotjs_httpparserwrap_t* iotjs_httpparserwrap_create(const iotjs_jval_t* jparser,
 }
 
 
-void iotjs_httpparserwrap_destroy(THIS) {
+static void iotjs_httpparserwrap_destroy(THIS) {
   IOTJS_VALIDATED_STRUCT_DESTRUCTOR(iotjs_httpparserwrap_t, httpparserwrap);
 
   iotjs_string_destroy(&_this->url);

--- a/src/module/iotjs_module_httpparser.h
+++ b/src/module/iotjs_module_httpparser.h
@@ -1,0 +1,90 @@
+/* Copyright 2015-2016 Samsung Electronics Co., Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+#ifndef IOTJS_MODULE_HTTPPARSER_H
+#define IOTJS_MODULE_HTTPPARSER_H
+
+
+#include "iotjs_objectwrap.h"
+
+#include "http_parser.h"
+
+
+// If # of header fields == HEADER_MAX, flush header to JS side.
+// This is weired : # of maximum headers in C equals to HEADER_MAX-1.
+// This is because , OnHeaders cb, we increase n_fields first,
+// and check whether field == HEADER_MAX.
+// ex) HEADER_MAX 2 means that we can keep at most 1 header field/value
+// during http parsing.
+// Increse this to minimize inter JS-C call
+#define HEADER_MAX 10
+
+
+typedef struct {
+  iotjs_jobjectwrap_t jobjectwrap;
+
+  http_parser parser;
+
+  iotjs_string_t url;
+  iotjs_string_t status_msg;
+
+  iotjs_string_t fields[HEADER_MAX];
+  iotjs_string_t values[HEADER_MAX];
+  size_t n_fields;
+  size_t n_values;
+
+  iotjs_jval_t* cur_jbuf;
+  char* cur_buf;
+  size_t cur_buf_len;
+
+  bool flushed;
+} IOTJS_VALIDATED_STRUCT(iotjs_httpparserwrap_t);
+
+
+typedef enum http_parser_type http_parser_type;
+
+
+#define THIS iotjs_httpparserwrap_t* httpparserwrap
+
+
+iotjs_httpparserwrap_t* iotjs_httpparserwrap_create(const iotjs_jval_t* jparser,
+                                                    http_parser_type type);
+
+void iotjs_httpparserwrap_initialize(THIS, http_parser_type type);
+
+int iotjs_httpparserwrap_on_message_begin(THIS);
+int iotjs_httpparserwrap_on_url(THIS, const char* at, size_t length);
+int iotjs_httpparserwrap_on_status(THIS, const char* at, size_t length);
+int iotjs_httpparserwrap_on_header_field(THIS, const char* at, size_t length);
+int iotjs_httpparserwrap_on_header_value(THIS, const char* at, size_t length);
+int iotjs_httpparserwrap_on_headers_complete(THIS);
+int iotjs_httpparserwrap_on_body(THIS, const char* at, size_t length);
+int iotjs_httpparserwrap_on_message_complete(THIS);
+
+iotjs_jval_t iotjs_httpparserwrap_make_header(THIS);
+
+void iotjs_httpparserwrap_flush(THIS);
+
+void iotjs_httpparserwrap_set_buf(THIS, iotjs_jval_t* jbuf, char* buf, int sz);
+
+iotjs_jval_t* iotjs_httpparserwrap_jobject(THIS);
+http_parser* iotjs_httpparserwrap_parser(THIS);
+
+
+#undef THIS
+
+
+#endif /* IOTJS_MODULE_HTTPPARSER_H */

--- a/src/module/iotjs_module_i2c.h
+++ b/src/module/iotjs_module_i2c.h
@@ -54,23 +54,24 @@ typedef struct {
 
   I2cOp op;
   I2cError error;
-} iotjs_i2creqdata_t;
+} iotjs_i2c_reqdata_t;
 
 
 typedef struct {
   iotjs_reqwrap_t reqwrap;
   uv_work_t req;
-  iotjs_i2creqdata_t req_data;
-} IOTJS_VALIDATED_STRUCT(iotjs_i2creqwrap_t);
+  iotjs_i2c_reqdata_t req_data;
+} IOTJS_VALIDATED_STRUCT(iotjs_i2c_reqwrap_t);
 
 
-#define THIS iotjs_i2creqwrap_t* i2creqwrap
-void iotjs_i2creqwrap_initialize(THIS, const iotjs_jval_t* jcallback, I2cOp op);
-void iotjs_i2creqwrap_destroy(THIS);
-uv_work_t* iotjs_i2creqwrap_req(THIS);
-const iotjs_jval_t* iotjs_i2creqwrap_jcallback(THIS);
-iotjs_i2creqwrap_t* iotjs_i2creqwrap_from_request(uv_work_t* req);
-iotjs_i2creqdata_t* iotjs_i2creqwrap_data(THIS);
+#define THIS iotjs_i2c_reqwrap_t* i2c_reqwrap
+void iotjs_i2c_reqwrap_initialize(THIS, const iotjs_jval_t* jcallback,
+                                  I2cOp op);
+void iotjs_i2c_reqwrap_dispatched(THIS);
+uv_work_t* iotjs_i2c_reqwrap_req(THIS);
+const iotjs_jval_t* iotjs_i2c_reqwrap_jcallback(THIS);
+iotjs_i2c_reqwrap_t* iotjs_i2c_reqwrap_from_request(uv_work_t* req);
+iotjs_i2c_reqdata_t* iotjs_i2c_reqwrap_data(THIS);
 #undef THIS
 
 
@@ -80,7 +81,6 @@ typedef struct {
 } IOTJS_VALIDATED_STRUCT(iotjs_i2c_t);
 
 iotjs_i2c_t* iotjs_i2c_create(const iotjs_jval_t* ji2c);
-void iotjs_i2c_destroy(iotjs_i2c_t* i2c);
 const iotjs_jval_t* iotjs_i2c_get_ji2c();
 iotjs_i2c_t* iotjs_i2c_get_instance();
 

--- a/src/module/iotjs_module_pwm.h
+++ b/src/module/iotjs_module_pwm.h
@@ -48,23 +48,24 @@ typedef struct {
 
   PwmError result;
   PwmOp op;
-} iotjs_pwmreqdata_t;
+} iotjs_pwm_reqdata_t;
 
 
 typedef struct {
   iotjs_reqwrap_t reqwrap;
   uv_work_t req;
-  iotjs_pwmreqdata_t req_data;
-} IOTJS_VALIDATED_STRUCT(iotjs_pwmreqwrap_t);
+  iotjs_pwm_reqdata_t req_data;
+} IOTJS_VALIDATED_STRUCT(iotjs_pwm_reqwrap_t);
 
 
-#define THIS iotjs_pwmreqwrap_t* pwmreqwrap
-void iotjs_pwmreqwrap_initialize(THIS, const iotjs_jval_t* jcallback, PwmOp op);
-void iotjs_pwmreqwrap_destroy(THIS);
-uv_work_t* iotjs_pwmreqwrap_req(THIS);
-const iotjs_jval_t* iotjs_pwmreqwrap_jcallback(THIS);
-iotjs_pwmreqwrap_t* iotjs_pwmreqwrap_from_request(uv_work_t* req);
-iotjs_pwmreqdata_t* iotjs_pwmreqwrap_data(THIS);
+#define THIS iotjs_pwm_reqwrap_t* pwm_reqwrap
+iotjs_pwm_reqwrap_t* iotjs_pwm_reqwrap_create(const iotjs_jval_t* jcallback,
+                                              PwmOp op);
+void iotjs_pwm_reqwrap_dispatched(THIS);
+uv_work_t* iotjs_pwm_reqwrap_req(THIS);
+const iotjs_jval_t* iotjs_pwm_reqwrap_jcallback(THIS);
+iotjs_pwm_reqwrap_t* iotjs_pwm_reqwrap_from_request(uv_work_t* req);
+iotjs_pwm_reqdata_t* iotjs_pwm_reqwrap_data(THIS);
 #undef THIS
 
 
@@ -74,14 +75,13 @@ typedef struct {
 } IOTJS_VALIDATED_STRUCT(iotjs_pwm_t);
 
 iotjs_pwm_t* iotjs_pwm_create(const iotjs_jval_t* jpwm);
-void iotjs_pwm_destroy(iotjs_pwm_t* pwm);
 const iotjs_jval_t* iotjs_pwm_get_jpwm();
 iotjs_pwm_t* iotjs_pwm_get_instance();
 bool iotjs_pwm_initialized();
 void iotjs_pwm_set_initialized(iotjs_pwm_t* pwm, bool initialized);
 
 
-int PwmInitializePwmPath(iotjs_pwmreqdata_t* req_data);
+int PwmInitializePwmPath(iotjs_pwm_reqdata_t* req_data);
 void ExportWorker(uv_work_t* work_req);
 void SetPeriodWorker(uv_work_t* work_req);
 void SetDutyCycleWorker(uv_work_t* work_req);

--- a/src/module/iotjs_module_tcp.c
+++ b/src/module/iotjs_module_tcp.c
@@ -22,20 +22,7 @@
 #include "iotjs_reqwrap.h"
 
 
-typedef struct {
-  iotjs_handlewrap_t handlewrap;
-  uv_tcp_t handle;
-} IOTJS_VALIDATED_STRUCT(iotjs_tcpwrap_t);
-
-
-iotjs_tcpwrap_t* iotjs_tcpwrap_create(const iotjs_jval_t* jtcp);
-void iotjs_tcpwrap_destroy(iotjs_tcpwrap_t* tcpwrap);
-
-iotjs_tcpwrap_t* iotjs_tcpwrap_from_handle(uv_tcp_t* handle);
-iotjs_tcpwrap_t* iotjs_tcpwrap_from_jobject(const iotjs_jval_t* jtcp);
-
-uv_tcp_t* iotjs_tcpwrap_tcp_handle(iotjs_tcpwrap_t* tcpwrap);
-iotjs_jval_t* iotjs_tcpwrap_jobject(iotjs_tcpwrap_t* tcpwrap);
+static void iotjs_tcpwrap_destroy(iotjs_tcpwrap_t* tcpwrap);
 
 
 iotjs_tcpwrap_t* iotjs_tcpwrap_create(const iotjs_jval_t* jtcp) {
@@ -53,7 +40,7 @@ iotjs_tcpwrap_t* iotjs_tcpwrap_create(const iotjs_jval_t* jtcp) {
 }
 
 
-void iotjs_tcpwrap_destroy(iotjs_tcpwrap_t* tcpwrap) {
+static void iotjs_tcpwrap_destroy(iotjs_tcpwrap_t* tcpwrap) {
   IOTJS_VALIDATED_STRUCT_DESTRUCTOR(iotjs_tcpwrap_t, tcpwrap);
   iotjs_handlewrap_destroy(&_this->handlewrap);
   IOTJS_RELEASE(tcpwrap);
@@ -88,105 +75,129 @@ iotjs_jval_t* iotjs_tcpwrap_jobject(iotjs_tcpwrap_t* tcpwrap) {
 }
 
 
-typedef struct {
-  iotjs_reqwrap_t reqwrap;
-  uv_connect_t req;
-} IOTJS_VALIDATED_STRUCT(iotjs_connectreqwrap_t);
+#define THIS iotjs_connect_reqwrap_t* connect_reqwrap
 
 
-#define THIS iotjs_connectreqwrap_t* connectreqwrap
+static void iotjs_connect_reqwrap_destroy(THIS);
 
-void iotjs_connectreqwrap_initialize(THIS, const iotjs_jval_t* jcallback) {
-  IOTJS_VALIDATED_STRUCT_CONSTRUCTOR(iotjs_connectreqwrap_t, connectreqwrap);
-  iotjs_reqwrap_initialize(&_this->reqwrap, jcallback, (uv_req_t*)&_this->req,
-                           connectreqwrap);
+
+iotjs_connect_reqwrap_t* iotjs_connect_reqwrap_create(
+    const iotjs_jval_t* jcallback) {
+  iotjs_connect_reqwrap_t* connect_reqwrap =
+      IOTJS_ALLOC(iotjs_connect_reqwrap_t);
+  IOTJS_VALIDATED_STRUCT_CONSTRUCTOR(iotjs_connect_reqwrap_t, connect_reqwrap);
+  iotjs_reqwrap_initialize(&_this->reqwrap, jcallback, (uv_req_t*)&_this->req);
+  return connect_reqwrap;
 }
 
 
-void iotjs_connectreqwrap_destroy(THIS) {
-  IOTJS_VALIDATED_STRUCT_DESTRUCTOR(iotjs_connectreqwrap_t, connectreqwrap);
+static void iotjs_connect_reqwrap_destroy(THIS) {
+  IOTJS_VALIDATED_STRUCT_DESTRUCTOR(iotjs_connect_reqwrap_t, connect_reqwrap);
   iotjs_reqwrap_destroy(&_this->reqwrap);
+  IOTJS_RELEASE(connect_reqwrap);
 }
 
 
-uv_connect_t* iotjs_connectreqwrap_req(THIS) {
-  IOTJS_VALIDATED_STRUCT_METHOD(iotjs_connectreqwrap_t, connectreqwrap);
+void iotjs_connect_reqwrap_dispatched(THIS) {
+  IOTJS_VALIDATED_STRUCT_METHOD(iotjs_connect_reqwrap_t, connect_reqwrap);
+  iotjs_connect_reqwrap_destroy(connect_reqwrap);
+}
+
+
+uv_connect_t* iotjs_connect_reqwrap_req(THIS) {
+  IOTJS_VALIDATED_STRUCT_METHOD(iotjs_connect_reqwrap_t, connect_reqwrap);
   return &_this->req;
 }
 
 
-const iotjs_jval_t* iotjs_connectreqwrap_jcallback(THIS) {
-  IOTJS_VALIDATED_STRUCT_METHOD(iotjs_connectreqwrap_t, connectreqwrap);
+const iotjs_jval_t* iotjs_connect_reqwrap_jcallback(THIS) {
+  IOTJS_VALIDATED_STRUCT_METHOD(iotjs_connect_reqwrap_t, connect_reqwrap);
   return iotjs_reqwrap_jcallback(&_this->reqwrap);
 }
 
 #undef THIS
 
 
-typedef struct {
-  iotjs_reqwrap_t reqwrap;
-  uv_write_t req;
-} IOTJS_VALIDATED_STRUCT(iotjs_writereqwrap_t);
+#define THIS iotjs_write_reqwrap_t* write_reqwrap
 
 
-#define THIS iotjs_writereqwrap_t* writereqwrap
+static void iotjs_write_reqwrap_destroy(THIS);
 
-void iotjs_writereqwrap_initialize(THIS, const iotjs_jval_t* jcallback) {
-  IOTJS_VALIDATED_STRUCT_CONSTRUCTOR(iotjs_writereqwrap_t, writereqwrap);
-  iotjs_reqwrap_initialize(&_this->reqwrap, jcallback, (uv_req_t*)&_this->req,
-                           writereqwrap);
+
+iotjs_write_reqwrap_t* iotjs_write_reqwrap_create(
+    const iotjs_jval_t* jcallback) {
+  iotjs_write_reqwrap_t* write_reqwrap = IOTJS_ALLOC(iotjs_write_reqwrap_t);
+  IOTJS_VALIDATED_STRUCT_CONSTRUCTOR(iotjs_write_reqwrap_t, write_reqwrap);
+  iotjs_reqwrap_initialize(&_this->reqwrap, jcallback, (uv_req_t*)&_this->req);
+  return write_reqwrap;
 }
 
 
-void iotjs_writereqwrap_destroy(THIS) {
-  IOTJS_VALIDATED_STRUCT_DESTRUCTOR(iotjs_writereqwrap_t, writereqwrap);
+static void iotjs_write_reqwrap_destroy(THIS) {
+  IOTJS_VALIDATED_STRUCT_DESTRUCTOR(iotjs_write_reqwrap_t, write_reqwrap);
   iotjs_reqwrap_destroy(&_this->reqwrap);
+  IOTJS_RELEASE(write_reqwrap);
 }
 
 
-uv_write_t* iotjs_writereqwrap_req(THIS) {
-  IOTJS_VALIDATED_STRUCT_METHOD(iotjs_writereqwrap_t, writereqwrap);
+void iotjs_write_reqwrap_dispatched(THIS) {
+  IOTJS_VALIDATED_STRUCT_METHOD(iotjs_write_reqwrap_t, write_reqwrap);
+  iotjs_write_reqwrap_destroy(write_reqwrap);
+}
+
+
+uv_write_t* iotjs_write_reqwrap_req(THIS) {
+  IOTJS_VALIDATED_STRUCT_METHOD(iotjs_write_reqwrap_t, write_reqwrap);
   return &_this->req;
 }
 
 
-const iotjs_jval_t* iotjs_writereqwrap_jcallback(THIS) {
-  IOTJS_VALIDATED_STRUCT_METHOD(iotjs_writereqwrap_t, writereqwrap);
+const iotjs_jval_t* iotjs_write_reqwrap_jcallback(THIS) {
+  IOTJS_VALIDATED_STRUCT_METHOD(iotjs_write_reqwrap_t, write_reqwrap);
   return iotjs_reqwrap_jcallback(&_this->reqwrap);
 }
 
 #undef THIS
 
 
-typedef struct {
-  iotjs_reqwrap_t reqwrap;
-  uv_shutdown_t req;
-} IOTJS_VALIDATED_STRUCT(iotjs_shutdownreqwrap_t);
+#define THIS iotjs_shutdown_reqwrap_t* shutdown_reqwrap
 
 
-#define THIS iotjs_shutdownreqwrap_t* shutdownreqwrap
+static void iotjs_shutdown_reqwrap_destroy(THIS);
 
-void iotjs_shutdownreqwrap_initialize(THIS, const iotjs_jval_t* jcallback) {
-  IOTJS_VALIDATED_STRUCT_CONSTRUCTOR(iotjs_shutdownreqwrap_t, shutdownreqwrap);
-  iotjs_reqwrap_initialize(&_this->reqwrap, jcallback, (uv_req_t*)&_this->req,
-                           shutdownreqwrap);
+
+iotjs_shutdown_reqwrap_t* iotjs_shutdown_reqwrap_create(
+    const iotjs_jval_t* jcallback) {
+  iotjs_shutdown_reqwrap_t* shutdown_reqwrap =
+      IOTJS_ALLOC(iotjs_shutdown_reqwrap_t);
+  IOTJS_VALIDATED_STRUCT_CONSTRUCTOR(iotjs_shutdown_reqwrap_t,
+                                     shutdown_reqwrap);
+  iotjs_reqwrap_initialize(&_this->reqwrap, jcallback, (uv_req_t*)&_this->req);
+  return shutdown_reqwrap;
 }
 
 
-void iotjs_shutdownreqwrap_destroy(THIS) {
-  IOTJS_VALIDATED_STRUCT_DESTRUCTOR(iotjs_shutdownreqwrap_t, shutdownreqwrap);
+static void iotjs_shutdown_reqwrap_destroy(THIS) {
+  IOTJS_VALIDATED_STRUCT_DESTRUCTOR(iotjs_shutdown_reqwrap_t, shutdown_reqwrap);
   iotjs_reqwrap_destroy(&_this->reqwrap);
+  IOTJS_RELEASE(shutdown_reqwrap);
 }
 
 
-uv_shutdown_t* iotjs_shutdownreqwrap_req(THIS) {
-  IOTJS_VALIDATED_STRUCT_METHOD(iotjs_shutdownreqwrap_t, shutdownreqwrap);
+void iotjs_shutdown_reqwrap_dispatched(THIS) {
+  IOTJS_VALIDATED_STRUCT_METHOD(iotjs_shutdown_reqwrap_t, shutdown_reqwrap);
+  iotjs_shutdown_reqwrap_destroy(shutdown_reqwrap);
+}
+
+
+uv_shutdown_t* iotjs_shutdown_reqwrap_req(THIS) {
+  IOTJS_VALIDATED_STRUCT_METHOD(iotjs_shutdown_reqwrap_t, shutdown_reqwrap);
   return &_this->req;
 }
 
 
-const iotjs_jval_t* iotjs_shutdownreqwrap_jcallback(THIS) {
-  IOTJS_VALIDATED_STRUCT_METHOD(iotjs_shutdownreqwrap_t, shutdownreqwrap);
+const iotjs_jval_t* iotjs_shutdown_reqwrap_jcallback(THIS) {
+  IOTJS_VALIDATED_STRUCT_METHOD(iotjs_shutdown_reqwrap_t, shutdown_reqwrap);
   return iotjs_reqwrap_jcallback(&_this->reqwrap);
 }
 
@@ -265,12 +276,12 @@ JHANDLER_FUNCTION(Bind) {
 
 // Connection request result handler.
 static void AfterConnect(uv_connect_t* req, int status) {
-  iotjs_connectreqwrap_t* req_wrap = (iotjs_connectreqwrap_t*)(req->data);
+  iotjs_connect_reqwrap_t* req_wrap = (iotjs_connect_reqwrap_t*)(req->data);
   IOTJS_ASSERT(req_wrap != NULL);
 
   // Take callback function object.
   // function afterConnect(status)
-  const iotjs_jval_t* jcallback = iotjs_connectreqwrap_jcallback(req_wrap);
+  const iotjs_jval_t* jcallback = iotjs_connect_reqwrap_jcallback(req_wrap);
   IOTJS_ASSERT(iotjs_jval_is_function(jcallback));
 
   // Only parameter is status code.
@@ -284,8 +295,7 @@ static void AfterConnect(uv_connect_t* req, int status) {
   iotjs_jargs_destroy(&args);
 
   // Release request wrapper.
-  iotjs_connectreqwrap_destroy(req_wrap);
-  IOTJS_RELEASE(req_wrap);
+  iotjs_connect_reqwrap_dispatched(req_wrap);
 }
 
 
@@ -310,17 +320,15 @@ JHANDLER_FUNCTION(Connect) {
     iotjs_tcpwrap_t* tcp_wrap = iotjs_tcpwrap_from_jobject(jtcp);
 
     // Create connection request wrapper.
-    iotjs_connectreqwrap_t* req_wrap = IOTJS_ALLOC(iotjs_connectreqwrap_t);
-    iotjs_connectreqwrap_initialize(req_wrap, jcallback);
+    iotjs_connect_reqwrap_t* req_wrap = iotjs_connect_reqwrap_create(jcallback);
 
     // Create connection request.
-    err = uv_tcp_connect(iotjs_connectreqwrap_req(req_wrap),
+    err = uv_tcp_connect(iotjs_connect_reqwrap_req(req_wrap),
                          iotjs_tcpwrap_tcp_handle(tcp_wrap),
                          (const sockaddr*)(&addr), AfterConnect);
 
     if (err) {
-      iotjs_connectreqwrap_destroy(req_wrap);
-      IOTJS_RELEASE(req_wrap);
+      iotjs_connect_reqwrap_dispatched(req_wrap);
     }
   }
 
@@ -401,13 +409,13 @@ JHANDLER_FUNCTION(Listen) {
 
 
 void AfterWrite(uv_write_t* req, int status) {
-  iotjs_writereqwrap_t* req_wrap = (iotjs_writereqwrap_t*)(req->data);
+  iotjs_write_reqwrap_t* req_wrap = (iotjs_write_reqwrap_t*)(req->data);
   iotjs_tcpwrap_t* tcp_wrap = (iotjs_tcpwrap_t*)(req->handle->data);
   IOTJS_ASSERT(req_wrap != NULL);
   IOTJS_ASSERT(tcp_wrap != NULL);
 
   // Take callback function object.
-  const iotjs_jval_t* jcallback = iotjs_writereqwrap_jcallback(req_wrap);
+  const iotjs_jval_t* jcallback = iotjs_write_reqwrap_jcallback(req_wrap);
 
   // Only parameter is status code.
   iotjs_jargs_t args = iotjs_jargs_create(1);
@@ -420,8 +428,7 @@ void AfterWrite(uv_write_t* req, int status) {
   iotjs_jargs_destroy(&args);
 
   // Release request wrapper.
-  iotjs_writereqwrap_destroy(req_wrap);
-  IOTJS_RELEASE(req_wrap);
+  iotjs_write_reqwrap_dispatched(req_wrap);
 }
 
 
@@ -442,16 +449,14 @@ JHANDLER_FUNCTION(Write) {
   buf.len = len;
 
   const iotjs_jval_t* arg1 = JHANDLER_GET_ARG(1, object);
-  iotjs_writereqwrap_t* req_wrap = IOTJS_ALLOC(iotjs_writereqwrap_t);
-  iotjs_writereqwrap_initialize(req_wrap, arg1);
+  iotjs_write_reqwrap_t* req_wrap = iotjs_write_reqwrap_create(arg1);
 
-  int err = uv_write(iotjs_writereqwrap_req(req_wrap),
+  int err = uv_write(iotjs_write_reqwrap_req(req_wrap),
                      (uv_stream_t*)(iotjs_tcpwrap_tcp_handle(tcp_wrap)), &buf,
                      1, AfterWrite);
 
   if (err) {
-    iotjs_writereqwrap_destroy(req_wrap);
-    IOTJS_RELEASE(req_wrap);
+    iotjs_write_reqwrap_dispatched(req_wrap);
   }
 
   iotjs_jhandler_return_number(jhandler, err);
@@ -531,13 +536,13 @@ JHANDLER_FUNCTION(ReadStart) {
 
 
 static void AfterShutdown(uv_shutdown_t* req, int status) {
-  iotjs_shutdownreqwrap_t* req_wrap = (iotjs_shutdownreqwrap_t*)(req->data);
+  iotjs_shutdown_reqwrap_t* req_wrap = (iotjs_shutdown_reqwrap_t*)(req->data);
   iotjs_tcpwrap_t* tcp_wrap = (iotjs_tcpwrap_t*)(req->handle->data);
   IOTJS_ASSERT(req_wrap != NULL);
   IOTJS_ASSERT(tcp_wrap != NULL);
 
   // function onShutdown(status)
-  const iotjs_jval_t* jonshutdown = iotjs_shutdownreqwrap_jcallback(req_wrap);
+  const iotjs_jval_t* jonshutdown = iotjs_shutdown_reqwrap_jcallback(req_wrap);
   IOTJS_ASSERT(iotjs_jval_is_function(jonshutdown));
 
   iotjs_jargs_t args = iotjs_jargs_create(1);
@@ -547,8 +552,7 @@ static void AfterShutdown(uv_shutdown_t* req, int status) {
 
   iotjs_jargs_destroy(&args);
 
-  iotjs_shutdownreqwrap_destroy(req_wrap);
-  IOTJS_RELEASE(req_wrap);
+  iotjs_shutdown_reqwrap_dispatched(req_wrap);
 }
 
 
@@ -560,16 +564,14 @@ JHANDLER_FUNCTION(Shutdown) {
   iotjs_tcpwrap_t* tcp_wrap = iotjs_tcpwrap_from_jobject(jtcp);
 
   const iotjs_jval_t* arg0 = JHANDLER_GET_ARG(0, object);
-  iotjs_shutdownreqwrap_t* req_wrap = IOTJS_ALLOC(iotjs_shutdownreqwrap_t);
-  iotjs_shutdownreqwrap_initialize(req_wrap, arg0);
+  iotjs_shutdown_reqwrap_t* req_wrap = iotjs_shutdown_reqwrap_create(arg0);
 
-  int err = uv_shutdown(iotjs_shutdownreqwrap_req(req_wrap),
+  int err = uv_shutdown(iotjs_shutdown_reqwrap_req(req_wrap),
                         (uv_stream_t*)(iotjs_tcpwrap_tcp_handle(tcp_wrap)),
                         AfterShutdown);
 
   if (err) {
-    iotjs_shutdownreqwrap_destroy(req_wrap);
-    IOTJS_RELEASE(req_wrap);
+    iotjs_shutdown_reqwrap_dispatched(req_wrap);
   }
 
   iotjs_jhandler_return_number(jhandler, err);

--- a/src/module/iotjs_module_tcp.h
+++ b/src/module/iotjs_module_tcp.h
@@ -17,13 +17,73 @@
 #ifndef IOTJS_MODULE_TCP_H
 #define IOTJS_MODULE_TCP_H
 
+
 #include "iotjs_binding.h"
+#include "iotjs_handlewrap.h"
+#include "iotjs_reqwrap.h"
 
 
 typedef struct sockaddr sockaddr;
 typedef struct sockaddr_in sockaddr_in;
 typedef struct sockaddr_in6 sockaddr_in6;
 typedef struct sockaddr_storage sockaddr_storage;
+
+
+typedef struct {
+  iotjs_handlewrap_t handlewrap;
+  uv_tcp_t handle;
+} IOTJS_VALIDATED_STRUCT(iotjs_tcpwrap_t);
+
+
+iotjs_tcpwrap_t* iotjs_tcpwrap_create(const iotjs_jval_t* jtcp);
+
+iotjs_tcpwrap_t* iotjs_tcpwrap_from_handle(uv_tcp_t* handle);
+iotjs_tcpwrap_t* iotjs_tcpwrap_from_jobject(const iotjs_jval_t* jtcp);
+
+uv_tcp_t* iotjs_tcpwrap_tcp_handle(iotjs_tcpwrap_t* tcpwrap);
+iotjs_jval_t* iotjs_tcpwrap_jobject(iotjs_tcpwrap_t* tcpwrap);
+
+
+typedef struct {
+  iotjs_reqwrap_t reqwrap;
+  uv_connect_t req;
+} IOTJS_VALIDATED_STRUCT(iotjs_connect_reqwrap_t);
+
+#define THIS iotjs_connect_reqwrap_t* connect_reqwrap
+iotjs_connect_reqwrap_t* iotjs_connect_reqwrap_create(
+    const iotjs_jval_t* jcallback);
+void iotjs_connect_reqwrap_dispatched(THIS);
+uv_connect_t* iotjs_connect_reqwrap_req(THIS);
+const iotjs_jval_t* iotjs_connect_reqwrap_jcallback(THIS);
+#undef THIS
+
+
+typedef struct {
+  iotjs_reqwrap_t reqwrap;
+  uv_write_t req;
+} IOTJS_VALIDATED_STRUCT(iotjs_write_reqwrap_t);
+
+#define THIS iotjs_write_reqwrap_t* write_reqwrap
+iotjs_write_reqwrap_t* iotjs_write_reqwrap_create(
+    const iotjs_jval_t* jcallback);
+void iotjs_write_reqwrap_dispatched(THIS);
+uv_write_t* iotjs_write_reqwrap_req(THIS);
+const iotjs_jval_t* iotjs_write_reqwrap_jcallback(THIS);
+#undef THIS
+
+
+typedef struct {
+  iotjs_reqwrap_t reqwrap;
+  uv_shutdown_t req;
+} IOTJS_VALIDATED_STRUCT(iotjs_shutdown_reqwrap_t);
+
+#define THIS iotjs_shutdown_reqwrap_t* shutdown_reqwrap
+iotjs_shutdown_reqwrap_t* iotjs_shutdown_reqwrap_create(
+    const iotjs_jval_t* jcallback);
+void iotjs_shutdown_reqwrap_dispatched(THIS);
+uv_shutdown_t* iotjs_shutdown_reqwrap_req(THIS);
+const iotjs_jval_t* iotjs_shutdown_reqwrap_jcallback(THIS);
+#undef THIS
 
 
 void AddressToJS(const iotjs_jval_t* obj, const sockaddr* addr);

--- a/src/module/iotjs_module_timer.c
+++ b/src/module/iotjs_module_timer.c
@@ -17,6 +17,7 @@
 #include "iotjs_module_timer.h"
 
 
+static void iotjs_timerwrap_destroy(iotjs_timerwrap_t* timerwrap);
 static void iotjs_timerwrap_on_timeout(iotjs_timerwrap_t* timerwrap);
 
 
@@ -36,7 +37,7 @@ iotjs_timerwrap_t* iotjs_timerwrap_create(const iotjs_jval_t* jtimer) {
 }
 
 
-void iotjs_timerwrap_destroy(iotjs_timerwrap_t* timerwrap) {
+static void iotjs_timerwrap_destroy(iotjs_timerwrap_t* timerwrap) {
   IOTJS_VALIDATED_STRUCT_DESTRUCTOR(iotjs_timerwrap_t, timerwrap);
   iotjs_handlewrap_destroy(&_this->handlewrap);
 

--- a/src/module/iotjs_module_timer.h
+++ b/src/module/iotjs_module_timer.h
@@ -28,7 +28,6 @@ typedef struct {
 
 
 iotjs_timerwrap_t* iotjs_timerwrap_create(const iotjs_jval_t* jtimer);
-void iotjs_timerwrap_destroy(iotjs_timerwrap_t* timerwrap);
 
 iotjs_timerwrap_t* iotjs_timerwrap_from_jobject(const iotjs_jval_t* jtimer);
 iotjs_timerwrap_t* iotjs_timerwrap_from_handle(uv_timer_t* timer_handle);

--- a/src/module/iotjs_module_udp.h
+++ b/src/module/iotjs_module_udp.h
@@ -1,0 +1,60 @@
+/* Copyright 2015-2016 Samsung Electronics Co., Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+#ifndef IOTJS_MODULE_UDP_H
+#define IOTJS_MODULE_UDP_H
+
+
+#include "iotjs_def.h"
+#include "iotjs_handlewrap.h"
+#include "iotjs_reqwrap.h"
+
+
+typedef struct {
+  iotjs_handlewrap_t handlewrap;
+  uv_udp_t handle;
+} IOTJS_VALIDATED_STRUCT(iotjs_udpwrap_t);
+
+
+iotjs_udpwrap_t* iotjs_udpwrap_create(const iotjs_jval_t* judp);
+
+iotjs_udpwrap_t* iotjs_udpwrap_from_handle(uv_udp_t* handle);
+iotjs_udpwrap_t* iotjs_udpwrap_from_jobject(const iotjs_jval_t* judp);
+
+uv_udp_t* iotjs_udpwrap_udp_handle(iotjs_udpwrap_t* udpwrap);
+iotjs_jval_t* iotjs_udpwrap_jobject(iotjs_udpwrap_t* udpwrap);
+
+
+typedef struct {
+  iotjs_reqwrap_t reqwrap;
+  uv_udp_send_t req;
+  size_t msg_size;
+} IOTJS_VALIDATED_STRUCT(iotjs_send_reqwrap_t);
+
+#define THIS iotjs_send_reqwrap_t* send_reqwrap
+
+iotjs_send_reqwrap_t* iotjs_send_reqwrap_create(const iotjs_jval_t* jcallback,
+                                                const size_t msg_size);
+
+void iotjs_send_reqwrap_dispatched(THIS);
+
+uv_udp_send_t* iotjs_send_reqwrap_req(THIS);
+const iotjs_jval_t* iotjs_send_reqwrap_jcallback(THIS);
+
+#undef THIS
+
+
+#endif /* IOTJS_MODULE_UDP_H */

--- a/src/platform/arm-nuttx/iotjs_module_gpio-arm-nuttx-stm32.inl.h
+++ b/src/platform/arm-nuttx/iotjs_module_gpio-arm-nuttx-stm32.inl.h
@@ -60,10 +60,10 @@ uint32_t gpioMode[6] = {
 };
 
 
-#define GPIO_WORKER_INIT_TEMPLATE(initialized)                              \
-  IOTJS_ASSERT(iotjs_gpio_initialized() == initialized);                    \
-  iotjs_gpioreqwrap_t* req_wrap = iotjs_gpioreqwrap_from_request(work_req); \
-  iotjs_gpioreqdata_t* req_data = iotjs_gpioreqwrap_data(req_wrap);
+#define GPIO_WORKER_INIT_TEMPLATE(initialized)                                \
+  IOTJS_ASSERT(iotjs_gpio_initialized() == initialized);                      \
+  iotjs_gpio_reqwrap_t* req_wrap = iotjs_gpio_reqwrap_from_request(work_req); \
+  iotjs_gpio_reqdata_t* req_data = iotjs_gpio_reqwrap_data(req_wrap);
 
 
 void InitializeGpioWorker(uv_work_t* work_req) {

--- a/src/platform/arm-nuttx/iotjs_module_pwm-arm-nuttx.c
+++ b/src/platform/arm-nuttx/iotjs_module_pwm-arm-nuttx.c
@@ -20,7 +20,7 @@
 #include "module/iotjs_module_pwm.h"
 
 
-int PwmInitializePwmPath(iotjs_pwmreqdata_t* req_data) {
+int PwmInitializePwmPath(iotjs_pwm_reqdata_t* req_data) {
   IOTJS_ASSERT(!"Not implemented");
   return 0;
 }

--- a/src/platform/iotjs_module_gpio-linux-general.inl.h
+++ b/src/platform/iotjs_module_gpio-linux-general.inl.h
@@ -92,10 +92,10 @@ bool SetPinMode(int32_t pin, GpioMode mode) {
 }
 
 
-#define GPIO_WORKER_INIT_TEMPLATE(initialized)                              \
-  IOTJS_ASSERT(iotjs_gpio_initialized() == initialized);                    \
-  iotjs_gpioreqwrap_t* req_wrap = iotjs_gpioreqwrap_from_request(work_req); \
-  iotjs_gpioreqdata_t* req_data = iotjs_gpioreqwrap_data(req_wrap);
+#define GPIO_WORKER_INIT_TEMPLATE(initialized)                                \
+  IOTJS_ASSERT(iotjs_gpio_initialized() == initialized);                      \
+  iotjs_gpio_reqwrap_t* req_wrap = iotjs_gpio_reqwrap_from_request(work_req); \
+  iotjs_gpio_reqdata_t* req_data = iotjs_gpio_reqwrap_data(req_wrap);
 
 
 void InitializeGpioWorker(uv_work_t* work_req) {

--- a/src/platform/iotjs_module_i2c-linux-general.inl.h
+++ b/src/platform/iotjs_module_i2c-linux-general.inl.h
@@ -163,9 +163,9 @@ int I2cSmbusReadI2cBlockData(int fd, uint8_t command, uint8_t* values,
 }
 
 
-#define I2C_WORKER_INIT_TEMPLATE                                          \
-  iotjs_i2creqwrap_t* req_wrap = iotjs_i2creqwrap_from_request(work_req); \
-  iotjs_i2creqdata_t* req_data = iotjs_i2creqwrap_data(req_wrap);
+#define I2C_WORKER_INIT_TEMPLATE                                            \
+  iotjs_i2c_reqwrap_t* req_wrap = iotjs_i2c_reqwrap_from_request(work_req); \
+  iotjs_i2c_reqdata_t* req_data = iotjs_i2c_reqwrap_data(req_wrap);
 
 
 void I2cSetAddress(uint8_t address) {

--- a/src/platform/iotjs_module_pwm-linux-general.inl.h
+++ b/src/platform/iotjs_module_pwm-linux-general.inl.h
@@ -41,7 +41,7 @@
 
 
 // Set PWM period.
-bool SetPwmPeriod(iotjs_pwmreqdata_t* req_data) {
+bool SetPwmPeriod(iotjs_pwm_reqdata_t* req_data) {
   IOTJS_ASSERT(!iotjs_string_is_empty(&req_data->device));
 
   char path_buff[64] = { 0 };
@@ -63,7 +63,7 @@ bool SetPwmPeriod(iotjs_pwmreqdata_t* req_data) {
 
 
 // Set PWM Duty-Cycle.
-bool SetPwmDutyCycle(iotjs_pwmreqdata_t* req_data) {
+bool SetPwmDutyCycle(iotjs_pwm_reqdata_t* req_data) {
   IOTJS_ASSERT(!iotjs_string_is_empty(&req_data->device));
 
   char path_buff[64] = { 0 };
@@ -85,12 +85,12 @@ bool SetPwmDutyCycle(iotjs_pwmreqdata_t* req_data) {
 }
 
 
-#define PWM_WORKER_INIT_TEMPLATE                                          \
-  iotjs_pwmreqwrap_t* req_wrap = iotjs_pwmreqwrap_from_request(work_req); \
-  iotjs_pwmreqdata_t* req_data = iotjs_pwmreqwrap_data(req_wrap);
+#define PWM_WORKER_INIT_TEMPLATE                                            \
+  iotjs_pwm_reqwrap_t* req_wrap = iotjs_pwm_reqwrap_from_request(work_req); \
+  iotjs_pwm_reqdata_t* req_data = iotjs_pwm_reqwrap_data(req_wrap);
 
 
-int PwmInitializePwmPath(iotjs_pwmreqdata_t* req_data) {
+int PwmInitializePwmPath(iotjs_pwm_reqdata_t* req_data) {
   int32_t chip_number, pwm_number;
   const char* path = iotjs_string_data(&req_data->device);
   char buffer[64] = { 0 };

--- a/test/run_pass/test_pwm.js
+++ b/test/run_pass/test_pwm.js
@@ -36,7 +36,7 @@ var pwm0 = new pwm(0, option, function (err) {
 
   pwm0.setEnable(1, callback);
 
-s  test1();
+  test1();
 });
 
 function test1() {


### PR DESCRIPTION
Related issue: https://github.com/Samsung/iotjs/issues/439

On translating ReqWrap into iotjs_reqwrap_t, `delete reqwrap;` was changed into `iotjs_reqwrap_destroy(reqwrap); IOTJS_RELEASE(reqwrap);`.
Since this style would be hard to write and understand, I changed it into `iotjs_reqwrap_dispatched()`, following `ReqWrap::Dispatched()` of Node.js. This made it possible to hide more destructors of iotjs_*wrap_t.