### PR TITLE
Set fs.write max buffer size to 1023 for nuttx

### DIFF
--- a/docs/IoT.js-API-File-System.md
+++ b/docs/IoT.js-API-File-System.md
@@ -12,19 +12,22 @@ The following shows fs module APIs available for each platform.
 | fs.openSync | O | O | O |
 | fs.read | O | O | O |
 | fs.readSync | O | O | O |
+| fs.readDir | O | O | X |
+| fs.readDirSync | O | O | X |
 | fs.readFile | O | O | O |
 | fs.readFileSync | O | O | O |
-| fs.rename | O | O | X |
-| fs.stat | O | O | X |
-| fs.statSync | O | O | X |
+| fs.rename | O | O | O |
+| fs.renameSync | O | O | O |
+| fs.stat | O | O | O |
+| fs.statSync | O | O | O |
 | fs.fstat | O | O | O |
 | fs.fstatSync | O | O | O |
 | fs.write | O | O | O |
 | fs.writeSync | O | O | O |
 | fs.writeFile | O | O | O |
 | fs.writeFileSync | O | O | O |
-| fs.unlink | O | O | X |
-| fs.unlinkSync | O | O | X |
+| fs.unlink | O | O | O |
+| fs.unlinkSync | O | O | O |
 
 ※ On `nuttx` path should be passed with a form of **absolute path**.
 

--- a/src/js/fs.js
+++ b/src/js/fs.js
@@ -297,7 +297,8 @@ fs.writeFile = function(path, data, callback) {
   });
 
   var write = function() {
-    fs.write(fd, data, bytesWritten, len - bytesWritten, 0, afterWrite);
+    var tryN = (len - bytesWritten) >= 1024 ? 1023 : (len - bytesWritten);
+    fs.write(fd, data, bytesWritten, tryN, bytesWritten, afterWrite);
   };
 
   var afterWrite = function(err, n) {
@@ -331,7 +332,8 @@ fs.writeFileSync = function(path, data) {
 
   while (true) {
     try {
-      var n = fs.writeSync(fd, data, bytesWritten, len - bytesWritten, 0);
+      var tryN = (len - bytesWritten) >= 1024 ? 1023 : (len - bytesWritten);
+      var n = fs.writeSync(fd, data, bytesWritten, tryN, bytesWritten);
       bytesWritten += n;
       if (bytesWritten == len) {
         break;


### PR DESCRIPTION
When I run testcase fs.writeFile on nuttx, I found it hangs.
fs.writeFiles fails to create file when the data source is about 1.5KB.
It makes zero-size file.
It is similar issue to #434. On nuttx, OS does not suppport writing
large buffer at once. This commit tries to divide writing request
to several write requests with max 1023 bytes.

Also, I run fs tests on nuttx. I update the related API document with the result.

IoT.js-DCO-1.0-Signed-off-by: Sanggyu Lee sg5.lee@samsung.com