### PR TITLE
Specify project language as C

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
-language: cpp
+language: c
 
 os: linux
 dist: trusty

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,7 +14,7 @@
 
 cmake_minimum_required(VERSION 2.8)
 
-project(IOTJS)
+project(IOTJS C)
 
 set(IOTJS_VERSION_MAJOR 0)
 set(IOTJS_VERSION_MINOR 1)


### PR DESCRIPTION
cmake try to validate C++ compiler. However, we don't need
the check anymore since we had migrated from C++ to C.
Also, I set travis language as C.

IoT.js-DCO-1.0-Signed-off-by: Sanggyu Lee sg5.lee@samsung.com