### PR TITLE
Add platform support table in Timer document

### DIFF
--- a/docs/IoT.js-API-Timers.md
+++ b/docs/IoT.js-API-Timers.md
@@ -1,4 +1,15 @@
-## class: Timers
+## Module: timers
+
+### Platform Support
+
+The following shows timers module APIs available for each platform.
+
+|  | Linux<br/>(Ubuntu) | Raspbian<br/>(Raspberry Pi) | Nuttx<br/>(STM32F4-Discovery) |
+| :---: | :---: | :---: | :---: |
+| setTimeout | O | O | O |
+| clearTimeout | O | O | O |
+| setInterval | O | O | O |
+| clearInterval | O | O | O |
 
 ### Methods
 
@@ -21,7 +32,7 @@ Disables timeout call from `setTimeout` method.
 
 Schedules to call periodic to `callback` function after every `delay` milliseconds.
 
-#### clearInterval(intervalObject) 
+#### clearInterval(intervalObject)
 * `intervalObject: intervalObject` - A `intervalObject` returned from `setInterval`
 
 Disables timeout call from `setInterval` method.


### PR DESCRIPTION
I checked Timer APIs on x86 linux (desktop), arm-linux (RPI2)
and nuttx (STM32F4Discovery) using testcases in test directory.

IoT.js-DCO-1.0-Signed-off-by: Sanggyu Lee sg5.lee@samsung.com