### PR TITLE
Update build.py to disable valgrind test on RPi2.

### DIFF
--- a/docs/Build-for-RPi2.md
+++ b/docs/Build-for-RPi2.md
@@ -87,8 +87,16 @@ ssh pi@(your RPi2 IP)
 
 ### Build IoT.js on Raspberry Pi 2
 
+#### Prerequisite
+Install cmake.
+```bash
+sudo apt-get update
+sudo apt-get install cmake
+```
+
+#### Build IoT.js
 Executing below command will build IoT.js and run our testsuite.
 
 ``` bash
-./tools/build.py --target-board rpi2
+./tools/build.py --target-board=rpi2
 ```

--- a/tools/build.py
+++ b/tools/build.py
@@ -150,6 +150,8 @@ def adjust_option(option):
         option.target_arch = 'i686'
     if option.target_arch == 'x64':
         option.target_arch = 'x86_64'
+    if option.target_board == 'rpi2':
+        option.no_check_valgrind = True
     if option.cmake_param is None:
         option.cmake_param = []
     if option.compile_flag is None:


### PR DESCRIPTION
- Need to check valgrind environment. (#552)
- Update Build for RPi2 document.

IoT.js-DCO-1.0-Signed-off-by: Jaechul Yang jc08.yang@samsung.com