### PR TITLE
Implement Pin module and modify build system

### DIFF
--- a/build.config
+++ b/build.config
@@ -86,7 +86,7 @@
   "module": {
     "always": ["buffer", "console", "events", "fs", "module", "timers"],
     "optional" : ["assert", "dgram", "dns", "gpio", "http", "i2c", "net",
-                  "pwm", "stream", "testdriver"],
+                  "pin", "pwm", "stream", "testdriver"],
     "exclude": []
   }
 }

--- a/cmake/iotjs.cmake
+++ b/cmake/iotjs.cmake
@@ -24,27 +24,41 @@ foreach(module ${IOTJS_MODULES_ALL})
     set(IOTJS_CFLAGS "${IOTJS_CFLAGS} -DENABLE_MODULE_${IOTJS_MODULENAME}=0")
 endforeach()
 
-# Module Configuration - enable only selected modules
+# Module Configuration - enable only selected modules and board
+if(DEFINED CMAKE_TARGET_BOARD)
+    set(BOARD_DESCRIPT "")
+    string(TOLOWER ${CMAKE_TARGET_BOARD} BOARD_DESCRIPT)
+endif()
 set(IOTJS_MODULE_SRC "")
 separate_arguments(IOTJS_MODULES)
+set(PLATFORM_SRC "${SRC_ROOT}/platform/${PLATFORM_DESCRIPT}/iotjs_module")
 foreach(module ${IOTJS_MODULES})
     list(APPEND IOTJS_MODULE_SRC ${SRC_ROOT}/module/iotjs_module_${module}.c)
-    set(PLATFORM_SRC "${SRC_ROOT}/platform/${PLATFORM_DESCRIPT}/iotjs_module")
-    set(PLATFORM_SRC "${PLATFORM_SRC}_${module}-${PLATFORM_DESCRIPT}.c")
-    if(EXISTS "${PLATFORM_SRC}")
-        list(APPEND IOTJS_MODULE_SRC ${PLATFORM_SRC})
+    set(MODULE_SRC "${PLATFORM_SRC}_${module}-${PLATFORM_DESCRIPT}.c")
+    if(EXISTS "${MODULE_SRC}")
+        list(APPEND IOTJS_MODULE_SRC ${MODULE_SRC})
+    endif()
+    if(DEFINED BOARD_DESCRIPT)
+        set(MODULE_SRC "${PLATFORM_SRC}_${module}-")
+        set(MODULE_SRC "${MODULE_SRC}${PLATFORM_DESCRIPT}-${BOARD_DESCRIPT}.c")
+        if(EXISTS "${MODULE_SRC}")
+            list(APPEND IOTJS_MODULE_SRC ${MODULE_SRC})
+        endif()
     endif()
     string(TOUPPER ${module} module)
     set(IOTJS_CFLAGS "${IOTJS_CFLAGS} -UENABLE_MODULE_${module}")
     set(IOTJS_CFLAGS "${IOTJS_CFLAGS} -DENABLE_MODULE_${module}=1")
 endforeach()
 
+# System Configuration
+set(IOTJS_PLATFORM_SRC "")
 if(${CMAKE_SYSTEM_NAME} MATCHES "Linux")
-    list(APPEND IOTJS_MODULE_SRC ${SRC_ROOT}/platform/iotjs_*-linux.c)
+    list(APPEND IOTJS_PLATFORM_SRC ${SRC_ROOT}/platform/iotjs_*-linux.c)
 endif()
 
 file(GLOB LIB_IOTJS_SRC ${SRC_ROOT}/*.c
-                        ${IOTJS_MODULE_SRC})
+                        ${IOTJS_MODULE_SRC}
+                        ${IOTJS_PLATFORM_SRC})
 
 string(REPLACE ";" " " IOTJS_CFLAGS_STR "${IOTJS_CFLAGS}")
 string(REPLACE ";" " " IOTJS_LINK_FLAGS_STR "${IOTJS_LINK_FLAGS}")

--- a/docs/Build-for-NuttX.md
+++ b/docs/Build-for-NuttX.md
@@ -6,7 +6,7 @@ We work on STM32F4 board for NuttX and the detail of the reference board is well
 ### Relation with STM board?
 We do not have any business relation with STM board. It is selected because it has enough RAM and Flash ROM, so that development can be more comfortable. And it has lots of pins to play with.
 
-When IoT.js is built up and optimised, it may work in devices having smaller resource.
+When IoT.js is built up and optimized, it may work in devices having smaller resource.
 
 
 ### 1. Prepare for prerequisite
@@ -76,7 +76,7 @@ Library files will be generated like below when build is successful.
 
 ```bash
 $ ls build/arm-nuttx/release/lib
-libhttparser.a libiotjs.a libjerrycore.a libtuv.a
+libhttpparser.a libiotjs.a libjerrycore.a libtuv.a
 ```
 
 ### 4. Build NuttX

--- a/docs/IoT.js-API-Buffer.md
+++ b/docs/IoT.js-API-Buffer.md
@@ -1,5 +1,4 @@
-IoT.js provides Buffer to compensate the lack of pure JavaScript's capability of manipulating binary data, JavaScript string is only suitable for Unicode string. Buffer allows you to handle sequence of binary data in Javascript world.
-
+IoT.js provides Buffer to compensate the lack of pure JavaScript's capability of manipulating binary data, JavaScript string is only suitable for Unicode string. Buffer allows you to handle sequence of binary data in JavaScript world.
 
 ## Class: Buffer
 Buffer class is a global type. you can create a buffer object in several way.

--- a/docs/IoT.js-API-File-System.md
+++ b/docs/IoT.js-API-File-System.md
@@ -157,7 +157,7 @@ Renames `oldPath` to `newPath` synchronously.
 
  ### Class: fs.Stats
 
- fs.Stats class is a object returned from ```fs.stats()```,```fs.fstats()``` and their synchronous counterparts.
+ fs.Stats class is a object returned from ```fs.stat()```,```fs.fstat()``` and their synchronous counterparts.
 
  ### Methods
 

--- a/docs/IoT.js-Package-(outdated).md
+++ b/docs/IoT.js-Package-(outdated).md
@@ -5,7 +5,7 @@ IoT.js follows the practice of node.js npm to provide module development communi
 * To see what it actually is, please visit [www.npmjs.com](https://www.npmjs.com/), and also [docs.npmjs.com](https://docs.npmjs.com/).
 * To avoid confusion with the original server, we'll call it "ipm", for IoT.js Package Manager.
 * Current status of "ipm" is started and it's for developers so has no separate web page. We need to develop them.
-* "npm" program is used for publish and download modules. We may fork when customisation is needed.
+* "npm" program is used for publish and download modules. We may fork when customization is needed.
 
 ### Installing "npm"
 ```

--- a/src/iotjs_binding.h
+++ b/src/iotjs_binding.h
@@ -150,7 +150,7 @@ void iotjs_jargs_replace(iotjs_jargs_t* jargs, uint16_t index,
 const iotjs_jval_t* iotjs_jargs_get(const iotjs_jargs_t* jargs, uint16_t index);
 
 
-// Calls javascript function.
+// Calls JavaScript function.
 iotjs_jval_t iotjs_jhelper_call(const iotjs_jval_t* jfunc,
                                 const iotjs_jval_t* jthis,
                                 const iotjs_jargs_t* jargs, bool* throws);

--- a/src/iotjs_module.h
+++ b/src/iotjs_module.h
@@ -42,6 +42,7 @@ typedef iotjs_jval_t (*register_func)();
   E(F, GPIO, Gpio, gpio)                   \
   E(F, HTTPPARSER, Httpparser, httpparser) \
   E(F, I2C, I2c, i2c)                      \
+  E(F, PIN, Pin, pin)                      \
   E(F, PROCESS, Process, process)          \
   E(F, PWM, Pwm, pwm)                      \
   E(F, TESTDRIVER, Testdriver, testdriver) \

--- a/src/iotjs_reqwrap.h
+++ b/src/iotjs_reqwrap.h
@@ -23,9 +23,9 @@
 
 
 // UV request wrapper.
-// Wrapping UV request and javascript callback.
+// Wrapping UV request and JavaScript callback.
 // When an instance of request wrapper is created. it will increase ref count
-// for javascript callback function to prevent it from reclaimed by GC. The
+// for JavaScript callback function to prevent it from reclaimed by GC. The
 // reference count will decrease back when wrapper is being freed.
 typedef struct {
   iotjs_jval_t jcallback;

--- a/src/js/buffer.js
+++ b/src/js/buffer.js
@@ -172,7 +172,7 @@ Buffer.prototype.slice = function(start, end) {
 // [2] buff.toString(start)
 // [3] buff.toString(start, end)
 // * start - default to 0
-// * end - default to buff.lengfth
+// * end - default to buff.length
 Buffer.prototype.toString = function(start, end) {
   start = util.isUndefined(start) ? 0 : ~~start;
   end = util.isUndefined(end) ? this.length : ~~end;

--- a/src/js/dns.js
+++ b/src/js/dns.js
@@ -35,7 +35,7 @@ exports.lookup = function lookup(hostname, options, callback) {
 
   // Parse arguments
   if (!util.isString(hostname)) {
-    throw TypeError('invalid argument: hostname must be a string or falsey');
+    throw TypeError('invalid argument: hostname must be a string');
   }
   if (util.isFunction(options)) {
     callback = options;

--- a/src/js/gpio.js
+++ b/src/js/gpio.js
@@ -39,7 +39,7 @@ function CreateGpioError(operation, errno) {
 
   switch (errno) {
     case gpio.kGpioErrInitialize:
-      return new GpioError(errno, operation, 'Failed to initilize GPIO');
+      return new GpioError(errno, operation, 'Failed to initialize GPIO');
     case gpio.kGpioErrNotInitialized:
       return new GpioError(errno, operation, 'GPIO not initialized');
     case gpio.kGpioErrWrongUse:

--- a/src/js/net.js
+++ b/src/js/net.js
@@ -478,7 +478,7 @@ Server.prototype.listen = function() {
     throw new Error('invalid argument - need port number');
   }
 
-  // register listening event linstener.
+  // register listening event listener.
   if (util.isFunction(callback)) {
     self.once('listening', callback);
   }

--- a/src/js/pin.js
+++ b/src/js/pin.js
@@ -13,17 +13,4 @@
  * limitations under the License.
  */
 
-function absolutePath(path) {
-  // FIXME: On NuttX side, when dealing with file, path should be absolute.
-  // So workaround this problem, test driver converts relative path
-  // to absolute one.
-  return process.cwd() + '/' + path;
-}
-
-function join() {
-  var path = Array.prototype.join.call(arguments, '/');
-  return path;
-}
-
-module.exports.absolutePath = absolutePath;
-module.exports.join = join;
+module.exports = process.binding(process.binding.pin);

--- a/src/module/iotjs_module_gpio.c
+++ b/src/module/iotjs_module_gpio.c
@@ -286,8 +286,6 @@ iotjs_jval_t InitGpio() {
   iotjs_jval_t jgpio = iotjs_jval_create_object();
 
   iotjs_jval_set_method(&jgpio, "initialize", Initialize);
-
-  iotjs_jval_set_method(&jgpio, "initialize", Initialize);
   iotjs_jval_set_method(&jgpio, "release", Release);
   iotjs_jval_set_method(&jgpio, "open", Open);
   iotjs_jval_set_method(&jgpio, "write", Write);

--- a/src/module/iotjs_module_pin.c
+++ b/src/module/iotjs_module_pin.c
@@ -13,17 +13,14 @@
  * limitations under the License.
  */
 
-function absolutePath(path) {
-  // FIXME: On NuttX side, when dealing with file, path should be absolute.
-  // So workaround this problem, test driver converts relative path
-  // to absolute one.
-  return process.cwd() + '/' + path;
-}
+#include "iotjs_def.h"
+#include "iotjs_module_pin.h"
 
-function join() {
-  var path = Array.prototype.join.call(arguments, '/');
-  return path;
-}
 
-module.exports.absolutePath = absolutePath;
-module.exports.join = join;
+iotjs_jval_t InitPin() {
+  iotjs_jval_t pin = iotjs_jval_create_object();
+
+  iotjs_pin_initialize(&pin);
+
+  return pin;
+}

--- a/src/module/iotjs_module_pin.h
+++ b/src/module/iotjs_module_pin.h
@@ -13,17 +13,20 @@
  * limitations under the License.
  */
 
-function absolutePath(path) {
-  // FIXME: On NuttX side, when dealing with file, path should be absolute.
-  // So workaround this problem, test driver converts relative path
-  // to absolute one.
-  return process.cwd() + '/' + path;
-}
+#ifndef IOTJS_MODULE_PIN_H
+#define IOTJS_MODULE_PIN_H
 
-function join() {
-  var path = Array.prototype.join.call(arguments, '/');
-  return path;
-}
 
-module.exports.absolutePath = absolutePath;
-module.exports.join = join;
+#if defined(__NUTTX__) && defined(ENABLE_MODULE_PWM)
+
+#define TIMER_PIN_SHIFT 21 /* Bits 21-24: Timer number */
+#define TIMER_PIN_MASK 15
+#define TIMER_NUM(n) ((n) << TIMER_PIN_SHIFT)
+
+#endif
+
+
+void iotjs_pin_initialize(const iotjs_jval_t* jobj);
+
+
+#endif /* IOTJS_MODULE_PIN_H */

--- a/src/platform/arm-linux/iotjs_module_pin-arm-linux.c
+++ b/src/platform/arm-linux/iotjs_module_pin-arm-linux.c
@@ -13,17 +13,13 @@
  * limitations under the License.
  */
 
-function absolutePath(path) {
-  // FIXME: On NuttX side, when dealing with file, path should be absolute.
-  // So workaround this problem, test driver converts relative path
-  // to absolute one.
-  return process.cwd() + '/' + path;
+
+#if defined(__LINUX__)
+
+#include "iotjs_def.h"
+
+void iotjs_pin_initialize(const iotjs_jval_t* jobj) {
+  IOTJS_ASSERT(!"Not implemented");
 }
 
-function join() {
-  var path = Array.prototype.join.call(arguments, '/');
-  return path;
-}
-
-module.exports.absolutePath = absolutePath;
-module.exports.join = join;
+#endif

--- a/src/platform/arm-nuttx/iotjs_module_pin-arm-nuttx-stm32.c
+++ b/src/platform/arm-nuttx/iotjs_module_pin-arm-nuttx-stm32.c
@@ -1,0 +1,154 @@
+/* Copyright 2016 Samsung Electronics Co., Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#if defined(__NUTTX__) && TARGET_BOARD == STM32F4DIS
+
+
+#include "iotjs_def.h"
+#include "module/iotjs_module_pin.h"
+#include "stm32_gpio.h"
+
+
+#if defined(ENABLE_MODULE_GPIO)
+
+void iotjs_pin_initialize_gpio(const iotjs_jval_t* jobj) {
+  iotjs_jval_t jgpio = iotjs_jval_create_object();
+  iotjs_jval_set_property_jval(jobj, "GPIO", &jgpio);
+
+// Set GPIO pin from configuration bits of nuttx.
+// GPIO pin name is P(port)(pin)
+#define SET_GPIO_CONSTANAT(port, pin)                    \
+  iotjs_jval_set_property_number(&jgpio, "P" #port #pin, \
+                                 (GPIO_PORT##port | GPIO_PIN##pin));
+
+#define SET_GPIO_CONSTANAT_PORT(port) \
+  SET_GPIO_CONSTANAT(port, 0);        \
+  SET_GPIO_CONSTANAT(port, 1);        \
+  SET_GPIO_CONSTANAT(port, 2);        \
+  SET_GPIO_CONSTANAT(port, 3);        \
+  SET_GPIO_CONSTANAT(port, 4);        \
+  SET_GPIO_CONSTANAT(port, 5);        \
+  SET_GPIO_CONSTANAT(port, 6);        \
+  SET_GPIO_CONSTANAT(port, 7);        \
+  SET_GPIO_CONSTANAT(port, 8);        \
+  SET_GPIO_CONSTANAT(port, 9);        \
+  SET_GPIO_CONSTANAT(port, 10);       \
+  SET_GPIO_CONSTANAT(port, 11);       \
+  SET_GPIO_CONSTANAT(port, 12);       \
+  SET_GPIO_CONSTANAT(port, 13);       \
+  SET_GPIO_CONSTANAT(port, 14);       \
+  SET_GPIO_CONSTANAT(port, 15);
+
+  SET_GPIO_CONSTANAT_PORT(A);
+  SET_GPIO_CONSTANAT_PORT(B);
+  SET_GPIO_CONSTANAT_PORT(C);
+  SET_GPIO_CONSTANAT_PORT(D);
+  SET_GPIO_CONSTANAT_PORT(E);
+
+  SET_GPIO_CONSTANAT(H, 0);
+  SET_GPIO_CONSTANAT(H, 1);
+
+#undef SET_GPIO_CONSTANAT_PORT
+#undef SET_GPIO_CONSTANAT
+
+  iotjs_jval_destroy(&jgpio);
+}
+
+#endif /* ENABLE_MODULE_GPIO */
+
+
+#if defined(ENABLE_MODULE_PWM)
+
+void iotjs_pin_initialize_pwm(const iotjs_jval_t* jobj) {
+  iotjs_jval_t jpwm = iotjs_jval_create_object();
+  iotjs_jval_set_property_jval(jobj, "PWM", &jpwm);
+  unsigned int timer_bit;
+
+// Set PWM pin from configuration bits of nuttx.
+// PWM pin name is "TIM(timer).CH(channel)_(n)"
+#define SET_GPIO_CONSTANAT(timer, channel, order)                        \
+  timer_bit = (GPIO_TIM##timer##_CH##channel##OUT_##order);              \
+  timer_bit |= (TIMER_NUM(timer));                                       \
+  iotjs_jval_set_property_number(&jtim##timer, "CH" #channel "_" #order, \
+                                 timer_bit);
+
+#define SET_GPIO_CONSTANAT_CHANNEL(timer, channel) \
+  SET_GPIO_CONSTANAT(timer, channel, 1);           \
+  SET_GPIO_CONSTANAT(timer, channel, 2);
+
+#define SET_GPIO_CONSTANAT_TIM(timer)                    \
+  iotjs_jval_t jtim##timer = iotjs_jval_create_object(); \
+  iotjs_jval_set_property_jval(&jpwm, "TIM" #timer, &jtim##timer);
+
+#define SET_GPIO_CONSTANAT_TIM_1(timer) \
+  SET_GPIO_CONSTANAT_TIM(timer);        \
+  SET_GPIO_CONSTANAT_CHANNEL(timer, 1); \
+  iotjs_jval_destroy(&jtim##timer);
+
+#define SET_GPIO_CONSTANAT_TIM_2(timer) \
+  SET_GPIO_CONSTANAT_TIM(timer);        \
+  SET_GPIO_CONSTANAT_CHANNEL(timer, 1); \
+  SET_GPIO_CONSTANAT_CHANNEL(timer, 2); \
+  iotjs_jval_destroy(&jtim##timer);
+
+#define SET_GPIO_CONSTANAT_TIM_4(timer) \
+  SET_GPIO_CONSTANAT_TIM(timer);        \
+  SET_GPIO_CONSTANAT_CHANNEL(timer, 1); \
+  SET_GPIO_CONSTANAT_CHANNEL(timer, 2); \
+  SET_GPIO_CONSTANAT_CHANNEL(timer, 3); \
+  SET_GPIO_CONSTANAT_CHANNEL(timer, 4); \
+  iotjs_jval_destroy(&jtim##timer);
+
+  SET_GPIO_CONSTANAT_TIM_4(1); // PA8, PE9, PA9, PE11, PA10, PE13, PA11, PE14
+  SET_GPIO_CONSTANAT_TIM_4(2); // PA0, PA15, PA1, PB3, PA2, PB10, PA3, PB11
+  iotjs_jval_set_property_number(&jtim2, "CH1_3", GPIO_TIM2_CH1OUT_3); // PA5
+  SET_GPIO_CONSTANAT_TIM_4(3); // PA6, PB4, PA7, PB5, PB0, PC8, PB1, PC9
+  iotjs_jval_set_property_number(&jtim3, "CH1_3", GPIO_TIM3_CH1OUT_3); // PC6
+  iotjs_jval_set_property_number(&jtim3, "CH2_3", GPIO_TIM3_CH2OUT_3); // PC7
+  SET_GPIO_CONSTANAT_TIM_4(4);  // PB6, PD12, PB7, PD13, PB8, PD14, PB9, PD15
+  SET_GPIO_CONSTANAT_TIM_4(5);  // PA0, PH10, PA1, PH11, PA2, PH12, PA3, PI0
+  SET_GPIO_CONSTANAT_TIM_4(8);  // PC6, PI5, PC7, PI6, PC8, PI7, PC9, PI2
+  SET_GPIO_CONSTANAT_TIM_2(9);  // PA2, PE5, PA3, PE6
+  SET_GPIO_CONSTANAT_TIM_1(10); // PB8, PF6
+  SET_GPIO_CONSTANAT_TIM_1(11); // PB9, PF7
+  SET_GPIO_CONSTANAT_TIM_2(12); // PH6, PB14, PB15, PH9
+  SET_GPIO_CONSTANAT_TIM_1(13); // PA6, PF8
+  SET_GPIO_CONSTANAT_TIM_1(14); // PA7, PF9
+
+#undef SET_GPIO_CONSTANAT_TIM_4
+#undef SET_GPIO_CONSTANAT_TIM_2
+#undef SET_GPIO_CONSTANAT_TIM_1
+#undef SET_GPIO_CONSTANAT_TIM
+#undef SET_GPIO_CONSTANAT_CHANNEL
+#undef SET_GPIO_CONSTANAT
+
+  iotjs_jval_destroy(&jpwm);
+}
+
+#endif /* ENABLE_MODULE_PWM */
+
+
+void iotjs_pin_initialize(const iotjs_jval_t* jobj) {
+#if defined(ENABLE_MODULE_GPIO)
+  iotjs_pin_initialize_gpio(jobj);
+#endif /* ENABLE_MODULE_GPIO */
+
+#if defined(ENABLE_MODULE_PWM)
+  iotjs_pin_initialize_pwm(jobj);
+#endif /* ENABLE_MODULE_PWM */
+}
+
+
+#endif // __NUTTX__

--- a/src/platform/i686-linux/iotjs_module_pin-i686-linux.c
+++ b/src/platform/i686-linux/iotjs_module_pin-i686-linux.c
@@ -13,17 +13,13 @@
  * limitations under the License.
  */
 
-function absolutePath(path) {
-  // FIXME: On NuttX side, when dealing with file, path should be absolute.
-  // So workaround this problem, test driver converts relative path
-  // to absolute one.
-  return process.cwd() + '/' + path;
+
+#if defined(__LINUX__)
+
+#include "iotjs_def.h"
+
+void iotjs_pin_initialize(const iotjs_jval_t* jobj) {
+  IOTJS_ASSERT(!"Not implemented");
 }
 
-function join() {
-  var path = Array.prototype.join.call(arguments, '/');
-  return path;
-}
-
-module.exports.absolutePath = absolutePath;
-module.exports.join = join;
+#endif

--- a/src/platform/iotjs_module_i2c-linux-general.inl.h
+++ b/src/platform/iotjs_module_i2c-linux-general.inl.h
@@ -1,7 +1,7 @@
 /* The MIT License (MIT)
  *
  * Copyright (c) 2005-2014 RoadNarrows LLC.
- * htpt://roadnarrows.com
+ * http://roadnarrows.com
  * All Rights Reserved
  *
  * Permission is hereby granted, free of charge, to any person obtaining

--- a/src/platform/x86_64-linux/iotjs_module_pin-x86_64-linux.c
+++ b/src/platform/x86_64-linux/iotjs_module_pin-x86_64-linux.c
@@ -13,17 +13,13 @@
  * limitations under the License.
  */
 
-function absolutePath(path) {
-  // FIXME: On NuttX side, when dealing with file, path should be absolute.
-  // So workaround this problem, test driver converts relative path
-  // to absolute one.
-  return process.cwd() + '/' + path;
+
+#if defined(__LINUX__)
+
+#include "iotjs_def.h"
+
+void iotjs_pin_initialize(const iotjs_jval_t* jobj) {
+  IOTJS_ASSERT(!"Not implemented");
 }
 
-function join() {
-  var path = Array.prototype.join.call(arguments, '/');
-  return path;
-}
-
-module.exports.absolutePath = absolutePath;
-module.exports.join = join;
+#endif

--- a/test/run_pass/attrs.js
+++ b/test/run_pass/attrs.js
@@ -19,7 +19,7 @@
       skip: ['all'],
       reason: "this test had @STDOUT=COMMAND[pwd], but there's no way to " +
       "check out current directory path with js driver. So it skips " +
-      "temoporalily."
+      "temporarily."
     },
     'test_dgram_address.js': {
       skip: ['nuttx'],

--- a/tools/build.py
+++ b/tools/build.py
@@ -316,6 +316,9 @@ def inflate_cmake_option(cmake_opt, option, for_jerry=False):
     include_dirs.extend(option.external_include_dir)
     cmake_opt.append('-DEXTERNAL_INCLUDE_DIR=' + ' '.join(include_dirs))
 
+    # set target board
+    if option.target_board == 'stm32f4dis':
+        cmake_opt.append('-DCMAKE_TARGET_BOARD=STM32')
 
 def build_tuv(option):
     # Check if libtuv submodule exists.

--- a/tools/check_tidy.py
+++ b/tools/check_tidy.py
@@ -106,7 +106,7 @@ def check_tidy(src_dir):
                 if not CheckLicenser.check(fileinput.filename()):
                     report_error_name_line(fileinput.filename(),
                                            None,
-                                           'incorrent license')
+                                           'incorrect license')
 
             count_lines += 1
             if not line.strip():


### PR DESCRIPTION
It is difficult to know pin number when you use system IO module.
I want to offer pin module in order to improve usablility.

For example, use PE10 pin in stm32f-discovery board

current ways : 
`gpio.open(16 * 4 + 10);`

proposing ways : 
`gpio.open(GPIO.PE10);`

And This patch also include build system for board.


IoT.js-DCO-1.0-Signed-off-by: Hosung Kim hs852.kim@samsung.com