### PR TITLE
Remove add_custom_xxx in cmake/http-parser/jerry/libtuv.cmake

### DIFF
--- a/cmake/http-parser.cmake
+++ b/cmake/http-parser.cmake
@@ -17,8 +17,3 @@ cmake_minimum_required(VERSION 2.8)
 set(HTTPPARSER_ROOT ${DEP_ROOT}/http-parser)
 set(HTTPPARSER_INCDIR ${HTTPPARSER_ROOT})
 set(HTTPPARSER_LIB ${LIB_ROOT}/libhttpparser.a)
-
-add_custom_command(OUTPUT ${HTTPPARSER_LIB}
-                   COMMAND touch ${HTTPPARSER_LIB})
-
-add_custom_target(targetHttpparser DEPENDS ${HTTPPARSER_LIB})

--- a/cmake/jerry.cmake
+++ b/cmake/jerry.cmake
@@ -20,9 +20,3 @@ set(JERRY_PORT_ROOT ${JERRY_ROOT}/targets/default)
 set(JERRY_INCDIR ${JERRY_CORE_ROOT} ${JERRY_PORT_ROOT})
 set(JERRY_BIN ${BIN_ROOT}/deps/jerry)
 set(JERRY_LIB ${LIB_ROOT}/libjerrycore.a)
-
-
-add_custom_command(OUTPUT ${JERRY_LIB}
-                   COMMAND touch ${JERRY_LIB})
-
-add_custom_target(targetJerry DEPENDS ${JERRY_LIB})

--- a/cmake/libtuv.cmake
+++ b/cmake/libtuv.cmake
@@ -19,9 +19,3 @@ set(LIBTUV_INCDIR ${LIBTUV_ROOT}/include
                   ${LIBTUV_ROOT}/source
                   ${LIBTUV_ROOT}/source/${TARGET_OS})
 set(LIBTUV_LIB ${LIB_ROOT}/libtuv.a)
-
-
-add_custom_command(OUTPUT ${LIBTUV_LIB}
-                   COMMAND touch ${LIBTUV_LIB})
-
-add_custom_target(targetLibtuv DEPENDS ${LIBTUV_LIB})


### PR DESCRIPTION
Each add_custom_command is intended to execute touch external libraries.
I think nothing depends on the custom targets (i.e., targetJerry, targetHttpParser, targetLibtuv) so `touch` statement seems dead-code.

IoT.js-DCO-1.0-Signed-off-by: Sanggyu Lee sg5.lee@samsung.com