### PR TITLE
add /deps/nuttx at .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,9 @@ nbproject
 **.sublime-workspace
 .idea
 
+# deps files
+/deps/nuttx/*
+
 # Random Trash
 *.swp
 *.swo


### PR DESCRIPTION
When I run the ./tools/precommit.py, nuttx sources were downloaded at /deps/nuttx.

But .gitignore file didn't consider about this, thus git recognized this source files as modified and un committed data.

I think, this single line should be added into .gitignore to prevent confusion.

IoT.js-DCO-1.0-Signed-off-by: Kim, Hyukjoong wangmir@gmail.com