### PR TITLE
Fix an error of misc test in tools/precommit.py

### DIFF
--- a/tools/precommit.py
+++ b/tools/precommit.py
@@ -137,6 +137,7 @@ for test in option.test:
         args = []
         if os.getenv('TRAVIS') != None:
             args = ['--travis']
+        fs.chdir(path.PROJECT_ROOT)
         ex.check_run_cmd('tools/check_signed_off.sh', args)
 
         if not check_tidy(path.PROJECT_ROOT):


### PR DESCRIPTION
When I run ```tools/precommit.py``` in my _local PC_, it makes _"No such file or directory" error_ on ```check_run_cmd('tools/check_signed_off.sh')``` function as following.

```
tools/check_signed_off.sh

Traceback (most recent call last):
  File "./tools/precommit.py", line 140, in <module>
    ex.check_run_cmd('tools/check_signed_off.sh', args)
  File "/home/redcarrottt/repository/iotjs-original/tools/common_py/system/executor.py", line 57, in check_run_cmd
    retcode = Executor.run_cmd(cmd, args, quiet)
  File "/home/redcarrottt/repository/iotjs-original/tools/common_py/system/executor.py", line 46, in run_cmd
    return subprocess.call([cmd] + args)
  File "/usr/lib/python2.7/subprocess.py", line 522, in call
    return Popen(*popenargs, **kwargs).wait()
  File "/usr/lib/python2.7/subprocess.py", line 710, in __init__
    errread, errwrite)
  File "/usr/lib/python2.7/subprocess.py", line 1327, in _execute_child
    raise child_exception
OSError: [Errno 2] No such file or directory
```

It is because 'current directory' is not set as the IoT.js project's root.
Therefore, I added one line that changes directory to the IoT.js project's root before executing ```check_run_cmd('tools/check_signed_off.sh')```.

IoT.js-DCO-1.0-Signed-off-by: Gyeonghwan Hong redcarrottt@gmail.com