### PR TITLE
Arrange whether to include module in build

### DIFF
--- a/build.config
+++ b/build.config
@@ -85,8 +85,7 @@
   },
   "module": {
     "always": ["buffer", "console", "events", "fs", "module", "timers"],
-    "optional" : ["assert", "dgram", "dns", "gpio", "http", "i2c", "net",
-                  "pin", "pwm", "stream", "testdriver"],
-    "exclude": []
+    "include" : ["assert", "dns", "http", "net", "stream", "testdriver"],
+    "exclude": ["dgram", "gpio", "i2c", "pin", "pwm"]
   }
 }

--- a/docs/Build-for-Linux.md
+++ b/docs/Build-for-Linux.md
@@ -76,6 +76,8 @@ link_flag
 external-include-dir
 external-static-lib
 external-shared-lib
+iotjs-include-module
+iotjs-exclude-module
 jerry-cmake-param
 jerry-compile-flag
 jerry-link-flag
@@ -103,6 +105,19 @@ Options that may need explanations.
 * nuttx-home: it's NuttX platform specific, to tell where the NuttX configuration and header files are.
 
 If you want to know more details about options, please check the [Build Script](https://github.com/Samsung/iotjs/wiki/Build%20Script) page.
+
+
+#### Include extended module
+There are two ways to include [extended module](IoT.js-API-reference.md).
+
+The first way is to modify a property value of module in `build.config` file. You can move a module name from 'exclude' to 'include'.
+
+The second way is by using build options which is `--iotjs-include-module`.
+If you enter several modules, separate them with a comma.
+
+```
+./tools/build.py --iotjs-include-module=dgram,pin,gpio
+```
 
 
 #### Options example

--- a/docs/Getting-Started.md
+++ b/docs/Getting-Started.md
@@ -52,6 +52,7 @@ Existing test options are listed as follows;
 start-from
 quiet=yes|no (default is yes)
 output-file
+skip-module
 ```
 
 To give options, please use two dashes '--' **once** before the option name as described in the following sections.
@@ -60,6 +61,7 @@ Options that may need explanations.
 * start-from: a test case file name where the driver starts.
 * quiet: a flag that indicates if the driver suppresses console outputs of test case.
 * output-file: a file name where the driver leaves output.
+* skip-module: a module list to skip test of specific modules.
 
 ##### Options example
 

--- a/test/run_pass/attrs.js
+++ b/test/run_pass/attrs.js
@@ -94,17 +94,9 @@
       skip: ['nuttx'],
       reason: "not implemented for nuttx"
     },
-    'test_gpio1.js': {
-      skip: ['all'],
-      reason: "not implemented"
-    },
     'test_gpio2.js': {
       skip: ['all'],
-      reason: "not implemented"
-    },
-    'test_gpio3.js': {
-      skip: ['all'],
-      reason: "not implemented"
+      reason: "need user input"
     },
     'test_i2c.js': {
       skip: ['all'],

--- a/test/testsets.js
+++ b/test/testsets.js
@@ -47,7 +47,6 @@ function testsets() {
       'test_fs2.js',
       'test_gpio1.js',
       'test_gpio2.js',
-      'test_gpio3.js',
       'test_http_get.js',
       'test_http_header.js',
       'test_httpclient_timeout.js',

--- a/tools/check_test.js
+++ b/tools/check_test.js
@@ -78,6 +78,8 @@ Driver.prototype.config = function() {
     "console outputs of test case");
   parser.addOption('output-file', "", "",
     "a file name where the driver leaves output");
+  parser.addOption('skip-module', "", "",
+    "a module list to skip test of specific modules");
 
   var options = parser.parse();
 
@@ -95,6 +97,10 @@ Driver.prototype.config = function() {
     }
     fs.writeFileSync(path, new Buffer(''));
   }
+  var skipModule = options['skip-module'];
+  if (skipModule) {
+    this.skipModule = skipModule.split(',');
+  }
 
   this.logger = new Logger(path);
 
@@ -109,7 +115,7 @@ Driver.prototype.config = function() {
 
   this.nextTestSet(skipped);
   return true;
-}
+};
 
 Driver.prototype.getAttrs = function() {
   var content = fs.readFileSync(util.absolutePath('attrs.js')).toString();
@@ -169,7 +175,7 @@ Driver.prototype.skipTestSet = function(filename) {
   }
 
   return false;
-}
+};
 
 Driver.prototype.nextTestSet = function(skipped) {
   if (!skipped) {
@@ -182,7 +188,7 @@ Driver.prototype.nextTestSet = function(skipped) {
   this.attrs = this.getAttrs();
   this.logger.message("\n");
   this.logger.message(">>>> " + dirname, "summary");
-}
+};
 
 Driver.prototype.dirname = function() {
   return Object.keys(this.tests)[this.dIdx]
@@ -192,7 +198,7 @@ Driver.prototype.filename = function() {
   var dirname = this.dirname();
   var filename = this.tests[dirname][this.fIdx];
   return filename;
-}
+};
 
 Driver.prototype.test = function() {
   var filename = this.filename();
@@ -212,7 +218,7 @@ Driver.prototype.finish = function() {
   if (this.results.fail > 0 || this.results.timeout > 0) {
     originalExit(1);
   }
-}
+};
 
 var driver = new Driver();
 
@@ -243,7 +249,7 @@ process.exit = function(code) {
       driver.runner.finish('pass');
     }
   }
-}
+};
 
 var conf = driver.config();
 if (conf) {


### PR DESCRIPTION
- Do not build extended API as default.
  - To build extended API, use command line arguments(`--iotjs-include-module`).
- Skip test of excluded module.
- Include test of all module when Travis run.

IoT.js-DCO-1.0-Signed-off-by: Hosung Kim hs852.kim@samsung.com