### PR TITLE
Update submodule tuv (#58) and Use uv API and convention

### DIFF
--- a/src/module/iotjs_module_i2c.c
+++ b/src/module/iotjs_module_i2c.c
@@ -180,7 +180,7 @@ void AfterI2CWork(uv_work_t* work_req, int status) {
           iotjs_jval_destroy(&result);
 
           if (req_data->delay > 0) {
-            tuv_usleep(req_data->delay * 1000);
+            uv_sleep(req_data->delay);
           }
 
           if (req_data->buf_data != NULL) {

--- a/src/module/iotjs_module_process.c
+++ b/src/module/iotjs_module_process.c
@@ -144,7 +144,7 @@ JHANDLER_FUNCTION(Chdir) {
   JHANDLER_CHECK_ARGS(1, string);
 
   iotjs_string_t path = JHANDLER_GET_ARG(0, string);
-  int err = uv_cd(iotjs_string_data(&path));
+  int err = uv_chdir(iotjs_string_data(&path));
 
   if (err) {
     iotjs_string_destroy(&path);

--- a/src/module/iotjs_module_testdriver.c
+++ b/src/module/iotjs_module_testdriver.c
@@ -37,7 +37,7 @@ JHANDLER_FUNCTION(IsAliveExceptFor) {
     iotjs_timerwrap_t* timer_wrap = iotjs_timerwrap_from_jobject(&jtimer);
     iotjs_jval_destroy(&jtimer);
 
-    bool has_active_reqs = uv__has_active_reqs(loop);
+    bool has_active_reqs = uv_loop_has_active_reqs(loop);
     bool has_closing_handler = loop->closing_handles != NULL;
 
     bool ret = true;


### PR DESCRIPTION
- Update submodule tuv (#58)
- Use uv API and follow the convention
 : Use uv_chdir, rather than uv_cd
 : Use uv_sleep, rather than tuv_usleep
 : Don't use uv's private method directly in testdriver

IoT.js-DCO-1.0-Signed-off-by: Sanggyu Lee sg5.lee@samsung.com