### PR TITLE
Provide patch file to activate additional features on Nuttx

### DIFF
--- a/docs/IoT.js-API-UART.md
+++ b/docs/IoT.js-API-UART.md
@@ -109,3 +109,13 @@ But as our default config option sets SDIO to be on, it makes conflict with UART
 | USART6_RX | PC7 |
 
 * Different from other system IO such as GPIO, ADC, PWM, you can't find the name of the UART device easily by `stm32f4dis.pin` module. It's because the name of the uart device can be changed according to your Nuttx config option. You can find '/dev/ttyS[0-3]' according to your environment.
+
+### Enable more ports using patch file
+
+Current version of Nuttx doesn't support USART1 and UART4 as the ports for stm32f4-discovery board. But if you want to enable more ports other than above, you can modify Nuttx code by referring to a part of `targets/nuttx-stm32f4/nuttx/patch` file.
+
+To apply whole patch,
+```bash
+~/workspace/nuttx$ patch -p1 < ../iotjs/targets/nuttx-stm32f4/nuttx/patch
+```
+Make sure it is your responsibility to enable the ports only when they do not make any conflicts.

--- a/targets/nuttx-stm32f4/nuttx/patch
+++ b/targets/nuttx-stm32f4/nuttx/patch
@@ -1,0 +1,24 @@
+--- a/configs/stm32f4discovery/include/board.h
++++ b/configs/stm32f4discovery/include/board.h
+@@ -253,6 +253,13 @@
+ #  define GPIO_CAN2_TX GPIO_CAN2_TX_1
+ #endif
+
+# Patch code to enable UART1:
+# It maps pin PB6 and pin PB7 to USART1_TX and USART2_RX respectively.
+#
++
++#define GPIO_USART1_RX GPIO_USART1_RX_2
++#define GPIO_USART1_TX GPIO_USART1_TX_2
++
+# Patch code to enable UART4:
+# It maps pin PA0 and pin PA1 to UART4_TX and UART4_RX respectively.
+# Because it makes conflict with pins of USART2,
+# you have to disable USART2 to use this port.
+#
++#define GPIO_UART4_RX GPIO_UART4_RX_1
++#define GPIO_UART4_TX GPIO_UART4_TX_1
++
+ /* UART2:
+  *
+  * The STM32F4 Discovery has no on-board serial devices, but the console is


### PR DESCRIPTION
Stm32f4-discovery board has 6 uart ports but Nuttx code supports only 4 of them.
So, this commit will provide patch file which can support activating the other 2 ports.
This patch file will be also used by other modules than UART.

IoT.js-DCO-1.0-Signed-off-by: Saebom Kim sae-bom.kim@samsung.com