### PR TITLE
Update zlib dependency to 1.2.10

### DIFF
--- a/tools/install-bluez-arm.sh
+++ b/tools/install-bluez-arm.sh
@@ -27,9 +27,9 @@ sudo apt-get install -q -y \
     g++-arm-linux-gnueabihf cmake libglib2.0-dev
 
 # Download & install zlib for GLib.
-wget http://zlib.net/zlib-1.2.8.tar.gz
-tar -xzf zlib-1.2.8.tar.gz
-cd zlib-1.2.8/
+wget http://zlib.net/zlib-1.2.10.tar.gz
+tar -xzf zlib-1.2.10.tar.gz
+cd zlib-1.2.10/
 ./configure --prefix=/usr/arm-linux-gnueabihf
 patch -p0 < $DIR/zlib-Makefile.patch
 make


### PR DESCRIPTION
Updated zlib to **1.2.10** since **1.2.8** is not available on the zlib main page.