### PR TITLE
Add exception handling for Python's 'subprocess' methods

### DIFF
--- a/tools/common_py/system/executor.py
+++ b/tools/common_py/system/executor.py
@@ -43,14 +43,20 @@ class Executor(object):
     def run_cmd(cmd, args=[], quiet=False):
         if not quiet:
             Executor.print_cmd_line(cmd, args)
-        return subprocess.call([cmd] + args)
+        try:
+            return subprocess.call([cmd] + args)
+        except OSError as e:
+            Executor.fail("[Failed - %s] %s" % (cmd, e.strerror))
 
     @staticmethod
     def run_cmd_output(cmd, quiet=False):
         if not quiet:
             Executor.print_cmd_line(cmd)
         cmd_list = cmd.split()
-        return subprocess.check_output(cmd_list)
+        try:
+            return subprocess.check_output(cmd_list)
+        except OSError as e:
+            Executor.fail("[Failed - %s] %s" % (cmd, e.strerror))
 
     @staticmethod
     def check_run_cmd(cmd, args=[], quiet=False):


### PR DESCRIPTION
Currently, if you don't have **valgrind** and you would like to run valgrind test, an unhandled exception happens:

Traceback (most recent call last):
  File "tools/build.py", line 809, in <module>
    if not run_checktest(option):
  File "tools/build.py", line 736, in run_checktest
    path.CHECKTEST_PATH] + build_args)
  File "/home/rtakacs/iotjs/tools/common_py/system/executor.py", line 46, in run_cmd
    return subprocess.call([cmd] + args)
  File "/usr/lib/python2.7/subprocess.py", line 522, in call
    return Popen(*popenargs, **kwargs).wait()
  File "/usr/lib/python2.7/subprocess.py", line 710, in __init__
    errread, errwrite)
  File "/usr/lib/python2.7/subprocess.py", line 1327, in _execute_child
    raise child_exception
OSError: [Errno 2] No such file or directory

The fix will catch the exception and handle it.