### PR TITLE
Fix i2c.writeBytes() and remove the duplicate of I2C_SMBUS_BLOCK_MAX

### DIFF
--- a/src/platform/iotjs_module_i2c-linux-general.inl.h
+++ b/src/platform/iotjs_module_i2c-linux-general.inl.h
@@ -64,7 +64,6 @@
 
 #define I2C_SLAVE_FORCE 0x0706
 #define I2C_SMBUS 0x0720
-#define I2C_SMBUS_BLOCK_MAX 32
 #define I2C_SMBUS_READ 1
 #define I2C_SMBUS_WRITE 0
 #define I2C_NOCMD 0
@@ -125,7 +124,7 @@ int I2cSmbusWriteI2cBlockData(int fd, uint8_t command, uint8_t* values,
   }
   data.block[0] = length;
 
-  return I2cSmbusAccess(fd, I2C_SMBUS_WRITE, command, I2C_SMBUS_BLOCK_DATA,
+  return I2cSmbusAccess(fd, I2C_SMBUS_WRITE, command, I2C_SMBUS_I2C_BLOCK_DATA,
                         &data);
 }
 

--- a/test/run_pass/test_i2c.js
+++ b/test/run_pass/test_i2c.js
@@ -31,6 +31,11 @@ wire.writeByte(0x10, function(err) {
   console.log('writeByte done');
 });
 
+wire.writeBytes(0x10, [0x10], function(err) {
+  assert.equal(err, null);
+  console.log('writeBytes done');
+})
+
 wire.read(2, function(err, res) {
   assert.equal(err, null);
   assert.equal(res.length, 2, 'I2C read failed.(length is not equal)');


### PR DESCRIPTION
IoT.js-DCO-1.0-Signed-off-by: Zsolt Borbély zsborbely.u-szeged@partner.samsung.com