### PR TITLE
Improve check_tidy script

### DIFF
--- a/tools/common_py/system/executor.py
+++ b/tools/common_py/system/executor.py
@@ -51,12 +51,11 @@ class Executor(object):
             Executor.fail("[Failed - %s] %s" % (cmd, e.strerror))
 
     @staticmethod
-    def run_cmd_output(cmd, quiet=False):
+    def run_cmd_output(cmd, args=[], quiet=False):
         if not quiet:
-            Executor.print_cmd_line(cmd)
-        cmd_list = cmd.split()
+            Executor.print_cmd_line(cmd, args)
         try:
-            return subprocess.check_output(cmd_list)
+            return subprocess.check_output([cmd] + args)
         except OSError as e:
             Executor.fail("[Failed - %s] %s" % (cmd, e.strerror))
 


### PR DESCRIPTION
List of improvements:
* Now works with both 3.x and 2.7+ Python versions.
* Separate classes for general style and clang-format checks.
* Allowed CMakeLists.txt for style checks.
* The diff for clang-format uses temp files.
* The diff for clang-format is now a unified diff.
* Uses clang-format if clang-format-3.8 is not found.
* If no clang-format found still run the other checks.
* Executor.run_cmd_output now accepts an list instead of a string.

IoT.js-DCO-1.0-Signed-off-by: Peter Gal pgal.u-szeged@partner.samsung.com