### PR TITLE
Replace process.JSONParse with JSON.parse

### DIFF
--- a/src/js/iotjs.js
+++ b/src/js/iotjs.js
@@ -218,12 +218,6 @@
     fn(this.exports, Native.require, this);
   };
 
-
-  // temp impl. before JSON.parse is done
-  process.JSONParse = function(text) {
-    return JSON.parse(text);
-  };
-
   startIoTjs();
 
 });

--- a/src/js/module.js
+++ b/src/js/module.js
@@ -97,7 +97,7 @@ iotjs_module_t.resolveFilepath = function(id, directories) {
     filepath = iotjs_module_t.tryPath(jsonpath);
     if(filepath){
       var pkgSrc = process.readSource(jsonpath);
-      var pkgMainFile = process.JSONParse(pkgSrc).main;
+      var pkgMainFile = JSON.parse(pkgSrc).main;
       filepath = iotjs_module_t.tryPath(packagepath + "/" + pkgMainFile);
       if(filepath){
         return filepath;

--- a/test/run_pass/require1/test_require.js
+++ b/test/run_pass/require1/test_require.js
@@ -22,7 +22,7 @@ var x = require("require_add");
 assert.equal(x.add(1,4), 5);
 
 var str = process.readSource("package.json");
-var json = process.JSONParse(str);
+var json = JSON.parse(str);
 
 assert.equal(json.version, "2.9.1");
 assert.equal(json.name, "npm");


### PR DESCRIPTION
process.JSONParse is now obsolete as JerryScript has full JSON support.
We can simply use JSON.parse instead.

IoT.js-DCO-1.0-Signed-off-by: Peter Gal pgal.u-szeged@partner.samsung.com