### PR TITLE
Add Buffer.prototype.toString('hex') and fill

### DIFF
--- a/docs/api/IoT.js-API-Buffer.md
+++ b/docs/api/IoT.js-API-Buffer.md
@@ -98,6 +98,11 @@ Returns a number indicating which buffer comes first between `this` and `otherBu
 
 Returns whether `this` and `otherBuffer` have the same bytes.
 
+#### buf.fill(value)
+* `value: Integer` The value to fill `buf` with
+* Return: `Buffer` A reference to buffer
+
+Fills buf with the specified value.
 
 #### buf.slice([start[,end]])
 * `start: Number`, Default: `0
@@ -109,7 +114,8 @@ Returns new buffer containing the same bytes of original buffer cropped by the g
 Copies data from `buf[sourceStart..sourceEnd-1]` to `targetBuffer[targetStart..]`.
 
 
-#### buf.toString([,start[,end]])
+#### buf.toString([encoding,[,start[,end]]])
+* `encoding: String`, The character encoding to decode to. Currently `hex` is supported.
 * `start: Number`, Default: `0`
 * `end: Number`, Default: `buffer.length`
 * Return: `String`

--- a/src/js/buffer.js
+++ b/src/js/buffer.js
@@ -208,13 +208,17 @@ Buffer.prototype.slice = function(start, end) {
 };
 
 
-// buff.toString([,start[, end]])
+// buff.toString([encoding,[,start[, end]]])
 // [1] buff.toString()
 // [2] buff.toString(start)
 // [3] buff.toString(start, end)
+// [4] buff.toString('hex')
 // * start - default to 0
 // * end - default to buff.length
 Buffer.prototype.toString = function(start, end) {
+  if (util.isString(start) && start === "hex" && util.isUndefined(end)) {
+      return this._builtin.toHexString();
+  }
   start = util.isUndefined(start) ? 0 : ~~start;
   end = util.isUndefined(end) ? this.length : ~~end;
 
@@ -297,6 +301,18 @@ Buffer.prototype.readUInt16LE = function(offset, noAssert) {
     checkOffset(offset, 2, this.length);
   return this._builtin.readUInt8(offset) |
          (this._builtin.readUInt8(offset + 1) << 8);
+};
+
+
+// buff.fill(value)
+Buffer.prototype.fill = function(value) {
+  if (util.isNumber(value)) {
+    value = value & 255;
+    for (var i = 0; i < this.length; i++) {
+      this._builtin.writeUInt8(value, i);
+    }
+  }
+  return this;
 };
 
 

--- a/src/module/iotjs_module_buffer.c
+++ b/src/module/iotjs_module_buffer.c
@@ -449,6 +449,26 @@ JHANDLER_FUNCTION(ToString) {
 }
 
 
+JHANDLER_FUNCTION(ToHexString) {
+  JHANDLER_CHECK_THIS(object);
+
+  const iotjs_jval_t* jbuiltin = JHANDLER_GET_THIS(object);
+  iotjs_bufferwrap_t* buffer_wrap = iotjs_bufferwrap_from_jbuiltin(jbuiltin);
+
+  int length = iotjs_bufferwrap_length(buffer_wrap);
+  const char* data = iotjs_bufferwrap_buffer(buffer_wrap);
+
+  iotjs_string_t str = iotjs_string_create("");
+  iotjs_string_reserve(&str, length * 2);
+  for (int i = 0; i < length; i++) {
+    iotjs_string_append(&str, &"0123456789abcdef"[data[i] >> 4 & 0xF], 1);
+    iotjs_string_append(&str, &"0123456789abcdef"[data[i] >> 0 & 0xF], 1);
+  }
+  iotjs_jhandler_return_string(jhandler, &str);
+  iotjs_string_destroy(&str);
+}
+
+
 JHANDLER_FUNCTION(ByteLength) {
   JHANDLER_CHECK_THIS(object);
   JHANDLER_CHECK_ARGS(1, string);
@@ -479,6 +499,7 @@ iotjs_jval_t InitBuffer() {
   iotjs_jval_set_method(&prototype, "readUInt8", ReadUInt8);
   iotjs_jval_set_method(&prototype, "slice", Slice);
   iotjs_jval_set_method(&prototype, "toString", ToString);
+  iotjs_jval_set_method(&prototype, "toHexString", ToHexString);
 
   iotjs_jval_destroy(&prototype);
   iotjs_jval_destroy(&byte_length);

--- a/test/run_pass/test_buffer.js
+++ b/test/run_pass/test_buffer.js
@@ -118,3 +118,24 @@ assert.equal(buff14.readUInt8(0), 0x01);
 assert.equal(buff14.readUInt8(1), 0xa1);
 assert.equal(buff14.readUInt8(2), 0xfb);
 assert.equal(buff14.readInt8(2), -5);
+assert.equal(buff14.toString('hex'), '01a1fb');
+
+var buff15 = new Buffer('7456a9', 'hex');
+assert.equal(buff15.length, 3);
+assert.equal(buff15.readUInt8(0), 0x74);
+assert.equal(buff15.readUInt8(1), 0x56);
+assert.equal(buff15.readUInt8(2), 0xa9);
+assert.equal(buff15.toString('hex'), '7456a9');
+
+var buff16 = new Buffer(4);
+var ret = buff16.fill(7);
+assert.equal(buff16.readInt8(0), 7);
+assert.equal(buff16.readInt8(1), 7);
+assert.equal(buff16.readInt8(2), 7);
+assert.equal(buff16.readInt8(3), 7);
+assert.equal(buff16, ret);
+buff16.fill(13+1024);
+assert.equal(buff16.readInt8(0), 13);
+assert.equal(buff16.readInt8(1), 13);
+assert.equal(buff16.readInt8(2), 13);
+assert.equal(buff16.readInt8(3), 13);


### PR DESCRIPTION
Implements toString('hex') and fill() for selected types.

IoT.js-DCO-1.0-Signed-off-by: Sanggyu Lee sg5.lee@samsung.com