### PR TITLE
Use compiler predefined macros instead of defining them ourselves

### DIFF
--- a/build.config
+++ b/build.config
@@ -28,10 +28,8 @@
   },
   "compile_flags": {
     "os": {
-      "linux": ["-D__LINUX__",
-                "-fno-builtin"],
-      "darwin": ["-D__DARWIN__",
-                 "-fno-builtin"],
+      "linux": ["-fno-builtin"],
+      "darwin": ["-fno-builtin"],
       "nuttx": ["-D__NUTTX__",
                 "-Os",
                 "-fno-strict-aliasing",
@@ -39,17 +37,10 @@
                 "-fomit-frame-pointer"]
     },
     "arch": {
-      "i686": ["-D__i686__",
-               "-D__x86__",
-               "-D__I686__",
-               "-D__X86__",
-               "-march=i686",
+      "i686": ["-march=i686",
                "-m32"],
-      "x86_64": ["-D__x86_64__",
-                 "-D__X86_64__"],
-      "arm": ["-D__ARM__",
-              "-D__arm__",
-              "-mthumb",
+      "x86_64": [],
+      "arm": ["-mthumb",
               "-fno-short-enums",
               "-mlittle-endian"]
     },

--- a/src/iotjs_debuglog.c
+++ b/src/iotjs_debuglog.c
@@ -30,10 +30,10 @@ void init_debug_settings() {
   const char* dbglevel = NULL;
   const char* dbglogfile = NULL;
 
-#if defined(__LINUX__)
+#if defined(__linux__)
   dbglevel = getenv("IOTJS_DEBUG_LEVEL");
   dbglogfile = getenv("IOTJS_DEBUG_LOGFILE");
-#endif // defined(__LINUX__)
+#endif // defined(__linux__)
   if (dbglevel) {
     iotjs_debug_level = atoi(dbglevel);
     if (iotjs_debug_level < 0)

--- a/src/iotjs_def.h
+++ b/src/iotjs_def.h
@@ -38,7 +38,7 @@
 #endif
 
 
-#if defined(__ARM__)
+#if defined(__arm__)
 #define TARGET_ARCH "arm"
 #elif defined(__i686__)
 #define TARGET_ARCH "ia32"
@@ -49,11 +49,11 @@
 #endif
 
 
-#if defined(__LINUX__)
+#if defined(__linux__)
 #define TARGET_OS "linux"
 #elif defined(__NUTTX__)
 #define TARGET_OS "nuttx"
-#elif defined(__DARWIN__)
+#elif defined(__APPLE__)
 #define TARGET_OS "darwin"
 #else
 #define TARGET_OS "unknown"

--- a/src/module/iotjs_module_i2c.c
+++ b/src/module/iotjs_module_i2c.c
@@ -31,7 +31,7 @@ iotjs_i2c_reqwrap_t* iotjs_i2c_reqwrap_create(const iotjs_jval_t* jcallback,
   iotjs_reqwrap_initialize(&_this->reqwrap, jcallback, (uv_req_t*)&_this->req);
 
   _this->req_data.op = op;
-#if defined(__LINUX__)
+#if defined(__linux__)
   _this->req_data.device = iotjs_string_create("");
 #endif
   _this->i2c_data = iotjs_i2c_instance_from_jval(ji2c);
@@ -42,7 +42,7 @@ iotjs_i2c_reqwrap_t* iotjs_i2c_reqwrap_create(const iotjs_jval_t* jcallback,
 static void iotjs_i2c_reqwrap_destroy(THIS) {
   IOTJS_VALIDATED_STRUCT_DESTRUCTOR(iotjs_i2c_reqwrap_t, i2c_reqwrap);
   iotjs_reqwrap_destroy(&_this->reqwrap);
-#if defined(__LINUX__)
+#if defined(__linux__)
   iotjs_string_destroy(&_this->req_data.device);
 #endif
   IOTJS_RELEASE(i2c_reqwrap);
@@ -254,7 +254,7 @@ static void GetI2cArray(const iotjs_jval_t* jarray,
 
 JHANDLER_FUNCTION(I2cCons) {
   JHANDLER_CHECK_THIS(object);
-#if defined(__LINUX__)
+#if defined(__linux__)
   JHANDLER_CHECK_ARGS(2, string, function);
   iotjs_string_t device = JHANDLER_GET_ARG(0, string);
 #elif defined(__NUTTX__)
@@ -274,7 +274,7 @@ JHANDLER_FUNCTION(I2cCons) {
       iotjs_i2c_reqwrap_create(jcallback, ji2c, kI2cOpOpen);
 
   iotjs_i2c_reqdata_t* req_data = iotjs_i2c_reqwrap_data(req_wrap);
-#if defined(__LINUX__)
+#if defined(__linux__)
   iotjs_string_append(&req_data->device, iotjs_string_data(&device),
                       iotjs_string_size(&device));
 #elif defined(__NUTTX__)

--- a/src/module/iotjs_module_i2c.h
+++ b/src/module/iotjs_module_i2c.h
@@ -48,7 +48,7 @@ typedef enum {
 
 
 typedef struct {
-#if defined(__LINUX__)
+#if defined(__linux__)
   iotjs_string_t device;
 #elif defined(__NUTTX__)
   uint32_t device;

--- a/src/platform/arm-linux/iotjs_module_adc-arm-linux.c
+++ b/src/platform/arm-linux/iotjs_module_adc-arm-linux.c
@@ -14,7 +14,7 @@
  */
 
 
-#if defined(__LINUX__)
+#if defined(__linux__)
 
 #include "../iotjs_module_adc-linux-general.inl.h"
 

--- a/src/platform/arm-linux/iotjs_module_ble-arm-linux.c
+++ b/src/platform/arm-linux/iotjs_module_ble-arm-linux.c
@@ -14,7 +14,7 @@
  */
 
 
-#if defined(__LINUX__)
+#if defined(__linux__)
 
 #include "../iotjs_module_ble-linux-general.inl.h"
 

--- a/src/platform/arm-linux/iotjs_module_gpio-arm-linux.c
+++ b/src/platform/arm-linux/iotjs_module_gpio-arm-linux.c
@@ -14,7 +14,7 @@
  */
 
 
-#if defined(__LINUX__)
+#if defined(__linux__)
 
 #include "iotjs_def.h"
 #include "../iotjs_module_gpio-linux-general.inl.h"

--- a/src/platform/arm-linux/iotjs_module_i2c-arm-linux.c
+++ b/src/platform/arm-linux/iotjs_module_i2c-arm-linux.c
@@ -14,7 +14,7 @@
  */
 
 
-#if defined(__LINUX__)
+#if defined(__linux__)
 
 #include "../iotjs_module_i2c-linux-general.inl.h"
 

--- a/src/platform/arm-linux/iotjs_module_pin-arm-linux.c
+++ b/src/platform/arm-linux/iotjs_module_pin-arm-linux.c
@@ -14,7 +14,7 @@
  */
 
 
-#if defined(__LINUX__)
+#if defined(__linux__)
 
 #include "iotjs_def.h"
 

--- a/src/platform/arm-linux/iotjs_module_pwm-arm-linux.c
+++ b/src/platform/arm-linux/iotjs_module_pwm-arm-linux.c
@@ -14,7 +14,7 @@
  */
 
 
-#if defined(__LINUX__)
+#if defined(__linux__)
 
 #include "iotjs_def.h"
 #include "../iotjs_module_pwm-linux-general.inl.h"

--- a/src/platform/arm-linux/iotjs_module_spi-arm-linux.c
+++ b/src/platform/arm-linux/iotjs_module_spi-arm-linux.c
@@ -14,7 +14,7 @@
  */
 
 
-#if defined(__LINUX__)
+#if defined(__linux__)
 
 #include "iotjs_def.h"
 #include "../iotjs_module_spi-linux-general.inl.h"

--- a/src/platform/arm-linux/iotjs_module_uart-arm-linux.c
+++ b/src/platform/arm-linux/iotjs_module_uart-arm-linux.c
@@ -14,8 +14,8 @@
  */
 
 
-#if defined(__LINUX__)
+#if defined(__linux__)
 
 #include "../iotjs_module_uart-linux-general.inl.h"
 
-#endif // __LINUX__
+#endif // __linux__

--- a/src/platform/i686-linux/iotjs_module_adc-i686-linux.c
+++ b/src/platform/i686-linux/iotjs_module_adc-i686-linux.c
@@ -14,7 +14,7 @@
  */
 
 
-#if defined(__LINUX__)
+#if defined(__linux__)
 
 #include "../iotjs_module_adc-linux-general.inl.h"
 

--- a/src/platform/i686-linux/iotjs_module_ble-i686-linux.c
+++ b/src/platform/i686-linux/iotjs_module_ble-i686-linux.c
@@ -14,7 +14,7 @@
  */
 
 
-#if defined(__LINUX__)
+#if defined(__linux__)
 
 #include "../iotjs_module_ble-linux-general.inl.h"
 

--- a/src/platform/i686-linux/iotjs_module_gpio-i686-linux.c
+++ b/src/platform/i686-linux/iotjs_module_gpio-i686-linux.c
@@ -14,7 +14,7 @@
  */
 
 
-#if defined(__LINUX__)
+#if defined(__linux__)
 
 #include "iotjs_def.h"
 #include "../iotjs_module_gpio-linux-general.inl.h"

--- a/src/platform/i686-linux/iotjs_module_i2c-i686-linux.c
+++ b/src/platform/i686-linux/iotjs_module_i2c-i686-linux.c
@@ -14,7 +14,7 @@
  */
 
 
-#if defined(__LINUX__)
+#if defined(__linux__)
 
 #include "../iotjs_module_i2c-linux-general.inl.h"
 

--- a/src/platform/i686-linux/iotjs_module_pin-i686-linux.c
+++ b/src/platform/i686-linux/iotjs_module_pin-i686-linux.c
@@ -14,7 +14,7 @@
  */
 
 
-#if defined(__LINUX__)
+#if defined(__linux__)
 
 #include "iotjs_def.h"
 

--- a/src/platform/i686-linux/iotjs_module_pwm-i686-linux.c
+++ b/src/platform/i686-linux/iotjs_module_pwm-i686-linux.c
@@ -14,7 +14,7 @@
  */
 
 
-#if defined(__LINUX__)
+#if defined(__linux__)
 
 #include "iotjs_def.h"
 #include "../iotjs_module_pwm-linux-general.inl.h"

--- a/src/platform/i686-linux/iotjs_module_spi-i686-linux.c
+++ b/src/platform/i686-linux/iotjs_module_spi-i686-linux.c
@@ -14,7 +14,7 @@
  */
 
 
-#if defined(__LINUX__)
+#if defined(__linux__)
 
 #include "iotjs_def.h"
 #include "../iotjs_module_spi-linux-general.inl.h"

--- a/src/platform/x86_64-linux/iotjs_module_adc-x86_64-linux.c
+++ b/src/platform/x86_64-linux/iotjs_module_adc-x86_64-linux.c
@@ -14,7 +14,7 @@
  */
 
 
-#if defined(__LINUX__)
+#if defined(__linux__)
 
 #include "../iotjs_module_adc-linux-general.inl.h"
 

--- a/src/platform/x86_64-linux/iotjs_module_ble-x86_64-linux.c
+++ b/src/platform/x86_64-linux/iotjs_module_ble-x86_64-linux.c
@@ -14,7 +14,7 @@
  */
 
 
-#if defined(__LINUX__)
+#if defined(__linux__)
 
 #include "../iotjs_module_ble-linux-general.inl.h"
 

--- a/src/platform/x86_64-linux/iotjs_module_gpio-x86_64-linux.c
+++ b/src/platform/x86_64-linux/iotjs_module_gpio-x86_64-linux.c
@@ -14,7 +14,7 @@
  */
 
 
-#if defined(__LINUX__)
+#if defined(__linux__)
 
 #include "iotjs_def.h"
 #include "../iotjs_module_gpio-linux-general.inl.h"

--- a/src/platform/x86_64-linux/iotjs_module_i2c-x86_64-linux.c
+++ b/src/platform/x86_64-linux/iotjs_module_i2c-x86_64-linux.c
@@ -14,7 +14,7 @@
  */
 
 
-#if defined(__LINUX__)
+#if defined(__linux__)
 
 #include "../iotjs_module_i2c-linux-general.inl.h"
 

--- a/src/platform/x86_64-linux/iotjs_module_pin-x86_64-linux.c
+++ b/src/platform/x86_64-linux/iotjs_module_pin-x86_64-linux.c
@@ -14,7 +14,7 @@
  */
 
 
-#if defined(__LINUX__)
+#if defined(__linux__)
 
 #include "iotjs_def.h"
 

--- a/src/platform/x86_64-linux/iotjs_module_pwm-x86_64-linux.c
+++ b/src/platform/x86_64-linux/iotjs_module_pwm-x86_64-linux.c
@@ -14,7 +14,7 @@
  */
 
 
-#if defined(__LINUX__)
+#if defined(__linux__)
 
 #include "iotjs_def.h"
 #include "../iotjs_module_pwm-linux-general.inl.h"

--- a/src/platform/x86_64-linux/iotjs_module_spi-x86_64-linux.c
+++ b/src/platform/x86_64-linux/iotjs_module_spi-x86_64-linux.c
@@ -14,7 +14,7 @@
  */
 
 
-#if defined(__LINUX__)
+#if defined(__linux__)
 
 #include "../iotjs_module_spi-linux-general.inl.h"
 

--- a/src/platform/x86_64-linux/iotjs_module_uart-x86_64-linux.c
+++ b/src/platform/x86_64-linux/iotjs_module_uart-x86_64-linux.c
@@ -14,8 +14,8 @@
  */
 
 
-#if defined(__LINUX__)
+#if defined(__linux__)
 
 #include "../iotjs_module_uart-linux-general.inl.h"
 
-#endif // __LINUX__
+#endif // __linux__


### PR DESCRIPTION
Architecture specific macros are already defined by the compiler, so no need to add them in the build config.