### PR TITLE
Add BLE js and implement bindRaw, emit('data')

### DIFF
--- a/src/js/ble.js
+++ b/src/js/ble.js
@@ -1,27 +1,3 @@
-/* The MIT License (MIT)
- *
- * Copyright (c) 2013 Sandeep Mistry
- *
- * Permission is hereby granted, free of charge, to any person obtaining
- * a copy of this software and associated documentation files
- * (the "Software"), to deal in the Software without restriction, including
- * without limitation the rights to use, copy, modify, merge, publish,
- * distribute, sublicense, and/or sell copies of the Software, and to permit
- * persons to whom the Software is furnished to do so, subject to the following
- * conditions:
- *
- * The above copyright notice and this permission notice shall be included in
- * all copies or substantial portions of the Software.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
- * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
- * THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
- * DEALINGS IN THE SOFTWARE.
- */
-
 /* Copyright 2016-present Samsung Electronics Co., Ltd. and other contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -37,187 +13,258 @@
  * limitations under the License.
  */
 
-/* This file include some APIs in 'bleno'.
- * (https://github.com/sandeepmistry/bleno)
+/* Copyright (C) 2015 Sandeep Mistry sandeep.mistry@gmail.com
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
  */
 
-var EventEmiter = require('events').EventEmitter;
+var debug = console.log; //requir('debug')('ble');
+
+var events = require('events');
 var util = require('util');
 
-var ble = process.binding(process.binding.ble);
+var UuidUtil = require('ble_uuid_util');
 
-// TODO: Implement PrimaryService
-/* function PrimaryService(options) {
-  this.uuid = options.uuid;
-  this.characteristics = options.characteristics || [];
-} */
+var PrimaryService = require('ble_primary_service');
+var Characteristic = require('ble_characteristic');
+var Descriptor = require('ble_descriptor');
 
-function BLE() {
-  this.state = 'unknown';
-  // this.address = 'unknown';
-  this._advertiseState = null;
-  // this.rssi = 0;
-  // this.mtu = 20;
+var bindings = null;
 
-  EventEmiter.call(this);
+var platform = process.platform;
 
-  this.on('stateChange', (function(_this) {
-    return function(state) {
-      _this.state = state;
-
-      if (state == 'unauthorized') {
-        console.log('ble warning: adapter state unauthorized.');
-        console.log('             please run as root or with sudo.');
-      }
-    };
-  })(this));
-
-  // TODO: implement more events.
-  // ...
-
-  ble.init((function(_this) {
-    return function(state) {
-      _this.emit('stateChange', state);
-    };
-  })(this));
-
-  process.on('exit', (function(_this) {
-    return function() {
-      if (_this._advertiseState != 'stoped') {
-        _this.stopAdvertising();
-      }
-    };
-  })(this));
-
+if (platform === 'darwin') {
+  // `requir` is intentional errta  to avoid pre-build module dependency analyzer error
+  // The analyzer does not understand comment
+  // bindings = requir('./mac/bindings');
+} else if (platform === 'linux' || platform === 'win32' || platform === 'android') {
+  bindings = require('ble_hci_socket_bindings');
+} else {
+  throw new Error('Unsupported platform');
 }
 
-util.inherits(BLE, EventEmiter);
+function Bleno() {
+  this.platform = 'unknown';
+  this.state = 'unknown';
+  this.address = 'unknown';
+  this.rssi = 0;
+  this.mtu = 20;
 
-BLE.prototype._runBleLoop = function() {
-  if (this._advertiseState == 'started') {
-    ble.runBleLoop((function(_this) {
-      return function(curState) {
-        if (curState != _this.state) {
-          _this.emit('stateChange', curState);
-        }
-        setTimeout(_this._runBleLoop.bind(_this), 1000);
-      };
-    })(this));
+  this._bindings = bindings;
+
+  this._bindings.on('stateChange', this.onStateChange.bind(this));
+  this._bindings.on('platform', this.onPlatform.bind(this));
+  this._bindings.on('addressChange', this.onAddressChange.bind(this));
+  this._bindings.on('advertisingStart', this.onAdvertisingStart.bind(this));
+  this._bindings.on('advertisingStop', this.onAdvertisingStop.bind(this));
+  this._bindings.on('servicesSet', this.onServicesSet.bind(this));
+  this._bindings.on('accept', this.onAccept.bind(this));
+  this._bindings.on('mtuChange', this.onMtuChange.bind(this));
+  this._bindings.on('disconnect', this.onDisconnect.bind(this));
+
+  this._bindings.on('rssiUpdate', this.onRssiUpdate.bind(this));
+
+  this._bindings.init();
+}
+
+util.inherits(Bleno, events.EventEmitter);
+
+Bleno.prototype.PrimaryService = PrimaryService;
+Bleno.prototype.Characteristic = Characteristic;
+Bleno.prototype.Descriptor = Descriptor;
+
+Bleno.prototype.onPlatform = function(platform) {
+  debug('platform ' + platform);
+
+  this.platform = platform;
+};
+
+Bleno.prototype.onStateChange = function(state) {
+  debug('stateChange ' + state);
+
+  this.state = state;
+
+  this.emit('stateChange', state);
+};
+
+Bleno.prototype.onAddressChange = function(address) {
+  debug('addressChange ' + address);
+
+  this.address = address;
+};
+
+Bleno.prototype.onAccept = function(clientAddress) {
+  debug('accept ' + clientAddress);
+  this.emit('accept', clientAddress);
+};
+
+Bleno.prototype.onMtuChange = function(mtu) {
+  debug('mtu ' + mtu);
+
+  this.mtu = mtu;
+
+  this.emit('mtuChange', mtu);
+};
+
+Bleno.prototype.onDisconnect = function(clientAddress) {
+  debug('disconnect' + clientAddress);
+  this.emit('disconnect', clientAddress);
+};
+
+Bleno.prototype.startAdvertising = function(name, serviceUuids, callback) {
+  if (this.state !== 'poweredOn') {
+    var error = new Error('Could not start advertising, state is ' + this.state + ' (not poweredOn)');
+
+    if (typeof callback === 'function') {
+      callback(error);
+    } else {
+      throw error;
+    }
+  } else {
+    if (callback) {
+      this.once('advertisingStart', callback);
+    }
+
+    var undashedServiceUuids = [];
+
+    if (serviceUuids && serviceUuids.length) {
+      for (var i = 0; i < serviceUuids.length; i++) {
+        undashedServiceUuids[i] = UuidUtil.removeDashes(serviceUuids[i]);
+      }
+    }
+
+    this._bindings.startAdvertising(name, undashedServiceUuids);
   }
 };
 
-BLE.prototype.startAdvertising = function(name, serviceUuids, callback) {
-  var advertisementDataLength = 3;
-  var scanDataLength = 0;
+Bleno.prototype.startAdvertisingIBeacon = function(uuid, major, minor, measuredPower, callback) {
+  if (this.state !== 'poweredOn') {
+    var error = new Error('Could not start advertising, state is ' + this.state + ' (not poweredOn)');
 
-  var serviceUuids16bit = [];
-  var serviceUuids128bit = [];
-  var i = 0;
-  var j = 0;
-  var k = 0;
-
-  if (name && name.length) {
-    scanDataLength += 2 + name.length;
-  }
-
-  if (serviceUuids && serviceUuids.length) {
-    for (i = 0; i < serviceUuids.length; i++) {
-      var convertedUuid = serviceUuids[i].match(/.{1,2}/g).reverse().join('');
-      var serviceUuid = [];
-      while (convertedUuid.length >= 2) {
-        serviceUuid.push(parseInt(convertedUuid.substring(0, 2), 16));
-        convertedUuid = convertedUuid.substring(2, convertedUuid.length);
-      }
-
-      if (serviceUuid.length === 2) {
-        serviceUuids16bit.push(serviceUuid);
-      } else if (serviceUuid.length === 16) {
-        serviceUuids128bit.push(serviceUuid);
-      }
+    if (typeof callback === 'function') {
+      callback(error);
+    } else {
+      throw error;
     }
-  }
+  } else {
+    var undashedUuid =  UuidUtil.removeDashes(uuid);
+    var uuidData = new Buffer(undashedUuid, 'hex');
+    var uuidDataLength = uuidData.length;
+    var iBeaconData = new Buffer(uuidData.length + 5);
 
-  if (serviceUuids16bit.length) {
-    advertisementDataLength += 2 + 2 * serviceUuids16bit.length;
-  }
-
-  if (serviceUuids128bit.length) {
-    advertisementDataLength += 2 + 16 * serviceUuids128bit.length;
-  }
-
-  i = 0;
-  var advertisementData = [];
-
-  // flags
-  advertisementData[i++] = 2;
-  advertisementData[i++] = 0x01;
-  advertisementData[i++] = 0x06;
-
-  if (serviceUuids16bit.length) {
-    advertisementData[i++] = 1 + 2 * serviceUuids16bit.length;
-    advertisementData[i++] = 0x03;
-    for (j = 0; j < serviceUuids16bit.length; j++) {
-      for (k = 0; k < serviceUuids16bit[j].length; k++) {
-        advertisementData[i++] = serviceUuids16bit[j][k];
-      }
+    for (var i = 0; i < uuidDataLength; i++) {
+      iBeaconData[i] = uuidData[i];
     }
-  }
 
-  if (serviceUuids128bit.length) {
-    advertisementData[i++] = 1 + 16 * serviceUuids128bit.length;
-    advertisementData[i++] = 0x06;
-    for (j = 0; j < serviceUuids128bit.length; j++) {
-      for (k = 0; k < serviceUuids128bit[j].length; k++) {
-        advertisementData[i++] = serviceUuids128bit[j][k];
-      }
+    iBeaconData.writeUInt16BE(major, uuidDataLength);
+    iBeaconData.writeUInt16BE(minor, uuidDataLength + 2);
+    iBeaconData.writeInt8(measuredPower, uuidDataLength + 4);
+
+    if (callback) {
+      this.once('advertisingStart', callback);
     }
+
+    debug('iBeacon data = ' + iBeaconData.toString('hex'));
+
+    this._bindings.startAdvertisingIBeacon(iBeaconData);
+  }
+};
+
+Bleno.prototype.onAdvertisingStart = function(error) {
+  debug('advertisingStart: ' + error);
+
+  if (error) {
+    this.emit('advertisingStartError', error);
   }
 
-  i = 0;
-  var scanData = [];
+  this.emit('advertisingStart', error);
+};
 
-  // name
-  if (name && name.length) {
-    scanData[i++] = name.length + 1;
-    scanData[i++] = 0x08;
-    for (j = 0; j < name.length; j++) {
-      scanData[i++] = name[j].charCodeAt(0);
+Bleno.prototype.startAdvertisingWithEIRData = function(advertisementData, scanData, callback) {
+  if (typeof scanData === 'function') {
+    callback = scanData;
+    scanData = null;
+  }
+
+  if (this.state !== 'poweredOn') {
+    var error = new Error('Could not advertising scanning, state is ' + this.state + ' (not poweredOn)');
+
+    if (typeof callback === 'function') {
+      callback(error);
+    } else {
+      throw error;
     }
+  } else {
+    if (callback) {
+      this.once('advertisingStart', callback);
+    }
+
+    this._bindings.startAdvertisingWithEIRData(advertisementData, scanData);
+  }
+};
+
+Bleno.prototype.stopAdvertising = function(callback) {
+  if (callback) {
+    this.once('advertisingStop', callback);
+  }
+  this._bindings.stopAdvertising();
+};
+
+Bleno.prototype.onAdvertisingStop = function() {
+  debug('advertisingStop');
+  this.emit('advertisingStop');
+};
+
+Bleno.prototype.setServices = function(services, callback) {
+  if (callback) {
+    this.once('servicesSet', callback);
+  }
+  this._bindings.setServices(services);
+};
+
+Bleno.prototype.onServicesSet = function(error) {
+  debug('servicesSet');
+
+  if (error) {
+    this.emit('servicesSetError', error);
   }
 
-  this._advertiseState = 'started';
+  this.emit('servicesSet', error);
+};
 
-  ble.startAdvertising(advertisementData, scanData, function(err) {
-    return process.nextTick(function() {
-      return callback(err);
+Bleno.prototype.disconnect = function() {
+  debug('disconnect');
+  this._bindings.disconnect();
+};
+
+Bleno.prototype.updateRssi = function(callback) {
+  if (callback) {
+    this.once('rssiUpdate', function(rssi) {
+      callback(null, rssi);
     });
-  });
+  }
 
-  setTimeout(this._runBleLoop.bind(this), 1000);
+  this._bindings.updateRssi();
 };
 
-BLE.prototype.stopAdvertising = function(callback) {
-  this._advertiseState = 'stoped';
-
-  ble.stopAdvertising(function(err) {
-    return process.nextTick(function() {
-      return callback(err);
-    });
-  });
+Bleno.prototype.onRssiUpdate = function(rssi) {
+  this.emit('rssiUpdate', rssi);
 };
 
-// TODO: Impelemnt setServices function.
-BLE.prototype.setServices = function(services, callback) {
-  ble.setServices(services, function(err) {
-    return process.nextTick(function() {
-      return callback(err);
-    });
-  });
-};
-
-// TODO: Implement these constructors.
-// BLE.prototype.PrimaryService = PrimaryService;
-// BLE.prototype.Characteristic = characteristic;
-// BLE.prototype.Descriptor = descriptor;
-
-module.exports = new BLE();
+module.exports = new Bleno();

--- a/src/js/ble_characteristic.js
+++ b/src/js/ble_characteristic.js
@@ -1,0 +1,129 @@
+/* Copyright 2016-present Samsung Electronics Co., Ltd. and other contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/* Copyright (C) 2015 Sandeep Mistry sandeep.mistry@gmail.com
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+var events = require('events');
+var util = require('util');
+
+var debug = console.log; //requir('debug')('ble_characteristic');
+
+var UuidUtil = require('ble_uuid_util');
+
+function Characteristic(options) {
+  this.uuid = UuidUtil.removeDashes(options.uuid);
+  this.properties = options.properties || [];
+  this.secure = options.secure || [];
+  this.value = options.value || null;
+  this.descriptors = options.descriptors || [];
+
+  if (this.value && (this.properties.length !== 1 || this.properties[0] !== 'read')) {
+    throw new Error('Characteristics with value can be read only!');
+  }
+
+  if (options.onReadRequest) {
+    this.onReadRequest = options.onReadRequest;
+  }
+
+  if (options.onWriteRequest) {
+    this.onWriteRequest = options.onWriteRequest;
+  }
+
+  if (options.onSubscribe) {
+    this.onSubscribe = options.onSubscribe;
+  }
+
+  if (options.onUnsubscribe) {
+    this.onUnsubscribe = options.onUnsubscribe;
+  }
+
+  if (options.onNotify) {
+    this.onNotify = options.onNotify;
+  }
+
+  if (options.onIndicate) {
+    this.onIndicate = options.onIndicate;
+  }
+
+  this.on('readRequest', this.onReadRequest.bind(this));
+  this.on('writeRequest', this.onWriteRequest.bind(this));
+  this.on('subscribe', this.onSubscribe.bind(this));
+  this.on('unsubscribe', this.onUnsubscribe.bind(this));
+  this.on('notify', this.onNotify.bind(this));
+  this.on('indicate', this.onIndicate.bind(this));
+}
+
+util.inherits(Characteristic, events.EventEmitter);
+
+Characteristic.RESULT_SUCCESS                  = Characteristic.prototype.RESULT_SUCCESS                  = 0x00;
+Characteristic.RESULT_INVALID_OFFSET           = Characteristic.prototype.RESULT_INVALID_OFFSET           = 0x07;
+Characteristic.RESULT_ATTR_NOT_LONG            = Characteristic.prototype.RESULT_ATTR_NOT_LONG            = 0x0b;
+Characteristic.RESULT_INVALID_ATTRIBUTE_LENGTH = Characteristic.prototype.RESULT_INVALID_ATTRIBUTE_LENGTH = 0x0d;
+Characteristic.RESULT_UNLIKELY_ERROR           = Characteristic.prototype.RESULT_UNLIKELY_ERROR           = 0x0e;
+
+Characteristic.prototype.toString = function() {
+  return JSON.stringify({
+    uuid: this.uuid,
+    properties: this.properties,
+    secure: this.secure,
+    value: this.value,
+    descriptors: this.descriptors
+  });
+};
+
+Characteristic.prototype.onReadRequest = function(offset, callback) {
+  callback(this.RESULT_UNLIKELY_ERROR, null);
+};
+
+Characteristic.prototype.onWriteRequest = function(data, offset, withoutResponse, callback) {
+  callback(this.RESULT_UNLIKELY_ERROR);
+};
+
+Characteristic.prototype.onSubscribe = function(maxValueSize, updateValueCallback) {
+  this.maxValueSize = maxValueSize;
+  this.updateValueCallback = updateValueCallback;
+};
+
+Characteristic.prototype.onUnsubscribe = function() {
+  this.maxValueSize = null;
+  this.updateValueCallback = null;
+};
+
+Characteristic.prototype.onNotify = function() {
+};
+
+Characteristic.prototype.onIndicate = function() {
+};
+
+module.exports = Characteristic;

--- a/src/js/ble_descriptor.js
+++ b/src/js/ble_descriptor.js
@@ -1,0 +1,53 @@
+/* Copyright 2016-present Samsung Electronics Co., Ltd. and other contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/* Copyright (C) 2015 Sandeep Mistry sandeep.mistry@gmail.com
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+var debug = console.log; //requir('debug')('descriptor');
+
+var UuidUtil = require('ble_uuid_util');
+
+function Descriptor(options) {
+  this.uuid = UuidUtil.removeDashes(options.uuid);
+  this.value = options.value || new Buffer(0);
+}
+
+Descriptor.prototype.toString = function() {
+  return JSON.stringify({
+    uuid: this.uuid,
+    value: Buffer.isBuffer(this.value) ? this.value.toString('hex') : this.value
+  });
+};
+
+module.exports = Descriptor;

--- a/src/js/ble_hci_socket.js
+++ b/src/js/ble_hci_socket.js
@@ -1,0 +1,50 @@
+/* Copyright 2016-present Samsung Electronics Co., Ltd. and other contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/* Copyright (C) 2015 Sandeep Mistry sandeep.mistry@gmail.com
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+var events = require('events');
+
+var BluetoothHciSocket= process.binding(process.binding.ble_hci_socket);
+
+inherits(BluetoothHciSocket, events.EventEmitter);
+
+// extend prototype
+function inherits(target, source) {
+  for (var k in source.prototype) {
+    target.prototype[k] = source.prototype[k];
+  }
+}
+
+module.exports = BluetoothHciSocket;

--- a/src/js/ble_hci_socket_acl_stream.js
+++ b/src/js/ble_hci_socket_acl_stream.js
@@ -1,0 +1,78 @@
+/* Copyright 2016-present Samsung Electronics Co., Ltd. and other contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/* Copyright (C) 2015 Sandeep Mistry sandeep.mistry@gmail.com
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+var debug = console.log; //requir('debug')('acl-att-stream');
+
+var events = require('events');
+var util = require('util');
+
+var crypto = require('ble_hci_socket_crypto');
+var Smp = require('ble_hci_socket_smp');
+
+var AclStream = function(hci, handle, localAddressType, localAddress, remoteAddressType, remoteAddress) {
+  this._hci = hci;
+  this._handle = handle;
+  this.encypted = false;
+
+  this._smp = new Smp(this, localAddressType, localAddress, remoteAddressType, remoteAddress);
+};
+
+util.inherits(AclStream, events.EventEmitter);
+
+
+AclStream.prototype.write = function(cid, data) {
+  this._hci.writeAclDataPkt(this._handle, cid, data);
+};
+
+AclStream.prototype.push = function(cid, data) {
+  if (data) {
+    this.emit('data', cid, data);
+  } else {
+    this.emit('end');
+  }
+};
+
+AclStream.prototype.pushEncrypt = function(encrypt) {
+  this.encrypted = encrypt ? true : false;
+
+  this.emit('encryptChange', this.encrypted);
+};
+
+AclStream.prototype.pushLtkNegReply = function() {
+  this.emit('ltkNegReply');
+};
+
+module.exports = AclStream;

--- a/src/js/ble_hci_socket_bindings.js
+++ b/src/js/ble_hci_socket_bindings.js
@@ -1,0 +1,253 @@
+/* Copyright 2016-present Samsung Electronics Co., Ltd. and other contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/* Copyright (C) 2015 Sandeep Mistry sandeep.mistry@gmail.com
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+var debug = console.log; //requir('debug')('ble_hci-socket_bindings');
+
+var events = require('events');
+var util = require('util');
+
+var AclStream = require('ble_hci_socket_acl_stream');
+var Hci = require('ble_hci_socket_hci');
+var Gap = require('ble_hci_socket_gap');
+var Gatt = require('ble_hci_socket_gatt');
+
+var BlenoBindings = function() {
+  this._state = null;
+
+  this._advertising = false;
+
+  this._hci = new Hci();
+  this._gap = new Gap(this._hci);
+  this._gatt = new Gatt(this._hci);
+
+  this._address = null;
+  this._handle = null;
+  this._aclStream = null;
+};
+
+util.inherits(BlenoBindings, events.EventEmitter);
+
+BlenoBindings.prototype.startAdvertising = function(name, serviceUuids) {
+  this._advertising = true;
+
+  this._gap.startAdvertising(name, serviceUuids);
+};
+
+BlenoBindings.prototype.startAdvertisingIBeacon = function(data) {
+  this._advertising = true;
+
+  this._gap.startAdvertisingIBeacon(data);
+};
+
+BlenoBindings.prototype.startAdvertisingWithEIRData = function(advertisementData, scanData) {
+  this._advertising = true;
+
+  this._gap.startAdvertisingWithEIRData(advertisementData, scanData);
+};
+
+BlenoBindings.prototype.stopAdvertising = function() {
+  this._advertising = false;
+
+  this._gap.stopAdvertising();
+};
+
+BlenoBindings.prototype.setServices = function(services) {
+  this._gatt.setServices(services);
+
+  this.emit('servicesSet');
+};
+
+BlenoBindings.prototype.disconnect = function() {
+  if (this._handle) {
+    debug('disconnect by server');
+
+    this._hci.disconnect(this._handle);
+  }
+};
+
+BlenoBindings.prototype.updateRssi = function() {
+  if (this._handle) {
+    this._hci.readRssi(this._handle);
+  }
+};
+
+BlenoBindings.prototype.init = function() {
+  this.onSigIntBinded = this.onSigInt.bind(this);
+
+  process.on('SIGINT', this.onSigIntBinded);
+  process.on('exit', this.onExit.bind(this));
+
+  this._gap.on('advertisingStart', this.onAdvertisingStart.bind(this));
+  this._gap.on('advertisingStop', this.onAdvertisingStop.bind(this));
+
+  this._gatt.on('mtuChange', this.onMtuChange.bind(this));
+
+  this._hci.on('stateChange', this.onStateChange.bind(this));
+  this._hci.on('addressChange', this.onAddressChange.bind(this));
+  this._hci.on('readLocalVersion', this.onReadLocalVersion.bind(this));
+
+  this._hci.on('leConnComplete', this.onLeConnComplete.bind(this));
+  this._hci.on('leConnUpdateComplete', this.onLeConnUpdateComplete.bind(this));
+  this._hci.on('rssiRead', this.onRssiRead.bind(this));
+  this._hci.on('disconnComplete', this.onDisconnComplete.bind(this));
+  this._hci.on('encryptChange', this.onEncryptChange.bind(this));
+  this._hci.on('leLtkNegReply', this.onLeLtkNegReply.bind(this));
+  this._hci.on('aclDataPkt', this.onAclDataPkt.bind(this));
+
+  this.emit('platform', process.platform);
+
+  this._hci.init();
+};
+
+BlenoBindings.prototype.onStateChange = function(state) {
+  if (this._state === state) {
+    return;
+  }
+  this._state = state;
+
+  if (state === 'unauthorized') {
+    console.log('bleno warning: adapter state unauthorized, please run as root or with sudo');
+    console.log('               or see README for information on running without root/sudo:');
+    console.log('               https://github.com/sandeepmistry/bleno#running-on-linux');
+  } else if (state === 'unsupported') {
+    console.log('bleno warning: adapter does not support Bluetooth Low Energy (BLE, Bluetooth Smart).');
+    console.log('               Try to run with environment variable:');
+    console.log('               [sudo] BLENO_HCI_DEVICE_ID=x node ...');
+  }
+
+  this.emit('stateChange', state);
+};
+
+BlenoBindings.prototype.onAddressChange = function(address) {
+  this.emit('addressChange', address);
+};
+
+BlenoBindings.prototype.onReadLocalVersion = function(hciVer, hciRev, lmpVer, manufacturer, lmpSubVer) {
+  if (manufacturer === 93) {
+    // Realtek Semiconductor Corporation
+    this._gatt.maxMtu = 23;
+  }
+};
+
+BlenoBindings.prototype.onAdvertisingStart = function(error) {
+  this.emit('advertisingStart', error);
+};
+
+BlenoBindings.prototype.onAdvertisingStop = function() {
+  this.emit('advertisingStop');
+};
+
+BlenoBindings.prototype.onLeConnComplete = function(status, handle, role, addressType, address, interval, latency, supervisionTimeout, masterClockAccuracy) {
+  if (role !== 1) {
+    // not slave, ignore
+    return;
+  }
+
+  this._address = address;
+  this._handle = handle;
+  this._aclStream = new AclStream(this._hci, handle, this._hci.addressType, this._hci.address, addressType, address);
+  this._gatt.setAclStream(this._aclStream);
+
+  this.emit('accept', address);
+};
+
+BlenoBindings.prototype.onLeConnUpdateComplete = function(handle, interval, latency, supervisionTimeout) {
+  // no-op
+};
+
+BlenoBindings.prototype.onDisconnComplete = function(handle, reason) {
+  if (this._aclStream) {
+    this._aclStream.push(null, null);
+  }
+
+  var address = this._address;
+
+  this._address = null;
+  this._handle = null;
+  this._aclStream = null;
+
+  if (address) {
+    this.emit('disconnect', address); // TODO: use reason
+  }
+
+  if (this._advertising) {
+    this._gap.restartAdvertising();
+  }
+};
+
+BlenoBindings.prototype.onEncryptChange = function(handle, encrypt) {
+  if (this._handle === handle && this._aclStream) {
+    this._aclStream.pushEncrypt(encrypt);
+  }
+};
+
+BlenoBindings.prototype.onLeLtkNegReply = function(handle) {
+  if (this._handle === handle && this._aclStream) {
+    this._aclStream.pushLtkNegReply();
+  }
+};
+
+BlenoBindings.prototype.onMtuChange = function(mtu) {
+  this.emit('mtuChange', mtu);
+};
+
+BlenoBindings.prototype.onRssiRead = function(handle, rssi) {
+  this.emit('rssiUpdate', rssi);
+};
+
+BlenoBindings.prototype.onAclDataPkt = function(handle, cid, data) {
+  if (this._handle === handle && this._aclStream) {
+    this._aclStream.push(cid, data);
+  }
+};
+
+BlenoBindings.prototype.onSigInt = function() {
+  var sigIntListeners = process.listeners('SIGINT');
+
+  if (sigIntListeners[sigIntListeners.length - 1] === this.onSigIntBinded) {
+    // we are the last listener, so exit
+    // this will trigger onExit, and clean up
+    process.exit(1);
+  }
+};
+
+BlenoBindings.prototype.onExit = function() {
+  this._gap.stopAdvertising();
+
+  this.disconnect();
+};
+
+module.exports = new BlenoBindings();

--- a/src/js/ble_hci_socket_crypto.js
+++ b/src/js/ble_hci_socket_crypto.js
@@ -1,0 +1,112 @@
+/* Copyright 2016-present Samsung Electronics Co., Ltd. and other contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/* Copyright (C) 2015 Sandeep Mistry sandeep.mistry@gmail.com
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+var crypto = require('ble_hci_socket_crypto');
+
+function r() {
+  return crypto.randomBytes(16);
+}
+
+function c1(k, r, pres, preq, iat, ia, rat, ra) {
+  var p1 = Buffer.concat([
+    iat,
+    rat,
+    preq,
+    pres
+  ]);
+
+  var p2 = Buffer.concat([
+    ra,
+    ia,
+    new Buffer('00000000', 'hex')
+  ]);
+
+  var res = xor(r, p1);
+  res = e(k, res);
+  res = xor(res, p2);
+  res = e(k, res);
+
+  return res;
+}
+
+function s1(k, r1, r2) {
+  return e(k, Buffer.concat([
+    r2.slice(0, 8),
+    r1.slice(0, 8)
+  ]));
+}
+
+function e(key, data) {
+  key = swap(key);
+  data = swap(data);
+
+  var cipher = crypto.createCipheriv('aes-128-ecb', key, '');
+  cipher.setAutoPadding(false);
+
+  return swap(Buffer.concat([
+    cipher.update(data),
+    cipher.final()
+  ]));
+}
+
+function xor(b1, b2) {
+  var result = new Buffer(b1.length);
+
+  for (var i = 0; i < b1.length; i++) {
+    //result[i] = b1[i] ^ b2[i];
+    result.writeUInt8(b1.readUInt8(i) ^ b2.readUInt8(i), i);
+  }
+
+  return result;
+}
+
+function swap(input) {
+  var output = new Buffer(input.length);
+
+  for (var i = 0; i < output.length; i++) {
+    //output[i] = input[input.length - i - 1];
+    output.writeUInt8(input.readUInt8(input.length - i - 1), i);
+  }
+
+  return output;
+}
+
+module.exports = {
+  r: r,
+  c1: c1,
+  s1: s1,
+  e: e
+};

--- a/src/js/ble_hci_socket_gap.js
+++ b/src/js/ble_hci_socket_gap.js
@@ -1,0 +1,247 @@
+/* Copyright 2016-present Samsung Electronics Co., Ltd. and other contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/* Copyright (C) 2015 Sandeep Mistry sandeep.mistry@gmail.com
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+var debug = console.log; //requir('debug')('gap');
+
+var events = require('events');
+var util = require('util');
+
+var Hci = require('ble_hci_socket_hci');
+
+var isLinux = (process.platform === 'linux');
+var isIntelEdison = false; // isLinux && (os.release().indexOf('edison') !== -1);
+var isYocto = false; //TODO isLinux && (os.release().indexOf('yocto') !== -1);
+
+function Gap(hci) {
+  this._hci = hci;
+
+  this._advertiseState = null;
+
+  this._hci.on('error', this.onHciError.bind(this));
+
+  this._hci.on('leAdvertisingParametersSet', this.onHciLeAdvertisingParametersSet.bind(this));
+  this._hci.on('leAdvertisingDataSet', this.onHciLeAdvertisingDataSet.bind(this));
+  this._hci.on('leScanResponseDataSet', this.onHciLeScanResponseDataSet.bind(this));
+  this._hci.on('leAdvertiseEnableSet', this.onHciLeAdvertiseEnableSet.bind(this));
+}
+
+util.inherits(Gap, events.EventEmitter);
+
+Gap.prototype.startAdvertising = function(name, serviceUuids) {
+  debug('startAdvertising: name = ' + name + ', serviceUuids = ' + JSON.stringify(serviceUuids, null, 2));
+
+  var advertisementDataLength = 3;
+  var scanDataLength = 0;
+
+  var serviceUuids16bit = [];
+  var serviceUuids128bit = [];
+  var i = 0;
+
+  if (name && name.length) {
+    scanDataLength += 2 + name.length;
+  }
+
+  if (serviceUuids && serviceUuids.length) {
+    for (i = 0; i < serviceUuids.length; i++) {
+      var serviceUuid = new Buffer(serviceUuids[i].match(/.{1,2}/g).reverse().join(''), 'hex');
+
+      if (serviceUuid.length === 2) {
+        serviceUuids16bit.push(serviceUuid);
+      } else if (serviceUuid.length === 16) {
+        serviceUuids128bit.push(serviceUuid);
+      }
+    }
+  }
+
+  if (serviceUuids16bit.length) {
+    advertisementDataLength += 2 + 2 * serviceUuids16bit.length;
+  }
+
+  if (serviceUuids128bit.length) {
+    advertisementDataLength += 2 + 16 * serviceUuids128bit.length;
+  }
+
+  var advertisementData = new Buffer(advertisementDataLength);
+  var scanData = new Buffer(scanDataLength);
+
+  // flags
+  advertisementData.writeUInt8(2, 0);
+  advertisementData.writeUInt8(0x01, 1);
+  advertisementData.writeUInt8(0x06, 2);
+
+  var advertisementDataOffset = 3;
+
+  if (serviceUuids16bit.length) {
+    advertisementData.writeUInt8(1 + 2 * serviceUuids16bit.length, advertisementDataOffset);
+    advertisementDataOffset++;
+
+    advertisementData.writeUInt8(0x03, advertisementDataOffset);
+    advertisementDataOffset++;
+
+    for (i = 0; i < serviceUuids16bit.length; i++) {
+      serviceUuids16bit[i].copy(advertisementData, advertisementDataOffset);
+      advertisementDataOffset += serviceUuids16bit[i].length;
+    }
+  }
+
+  if (serviceUuids128bit.length) {
+    advertisementData.writeUInt8(1 + 16 * serviceUuids128bit.length, advertisementDataOffset);
+    advertisementDataOffset++;
+
+    advertisementData.writeUInt8(0x06, advertisementDataOffset);
+    advertisementDataOffset++;
+
+    for (i = 0; i < serviceUuids128bit.length; i++) {
+      serviceUuids128bit[i].copy(advertisementData, advertisementDataOffset);
+      advertisementDataOffset += serviceUuids128bit[i].length;
+    }
+  }
+
+  // name
+  if (name && name.length) {
+    var nameBuffer = new Buffer(name);
+
+    scanData.writeUInt8(1 + nameBuffer.length, 0);
+    scanData.writeUInt8(0x08, 1);
+    nameBuffer.copy(scanData, 2);
+  }
+
+  this.startAdvertisingWithEIRData(advertisementData, scanData);
+};
+
+
+Gap.prototype.startAdvertisingIBeacon = function(data) {
+  debug('startAdvertisingIBeacon: data = ' + data.toString('hex'));
+
+  var dataLength = data.length;
+  var manufacturerDataLength = 4 + dataLength;
+  var advertisementDataLength = 5 + manufacturerDataLength;
+  var scanDataLength = 0;
+
+  var advertisementData = new Buffer(advertisementDataLength);
+  var scanData = new Buffer(0);
+
+  // flags
+  advertisementData.writeUInt8(2, 0);
+  advertisementData.writeUInt8(0x01, 1);
+  advertisementData.writeUInt8(0x06, 2);
+
+  advertisementData.writeUInt8(manufacturerDataLength + 1, 3);
+  advertisementData.writeUInt8(0xff, 4);
+  advertisementData.writeUInt16LE(0x004c, 5); // Apple Company Identifier LE (16 bit)
+  advertisementData.writeUInt8(0x02, 7); // type, 2 => iBeacon
+  advertisementData.writeUInt8(dataLength, 8);
+
+  data.copy(advertisementData, 9);
+
+  this.startAdvertisingWithEIRData(advertisementData, scanData);
+};
+
+Gap.prototype.startAdvertisingWithEIRData = function(advertisementData, scanData) {
+  advertisementData = advertisementData || new Buffer(0);
+  scanData = scanData || new Buffer(0);
+
+  debug('startAdvertisingWithEIRData: advertisement data = ' + advertisementData.toString('hex') + ', scan data = ' + scanData.toString('hex'));
+
+  var error = null;
+
+  if (advertisementData.length > 31) {
+    error = new Error('Advertisement data is over maximum limit of 31 bytes');
+  } else if (scanData.length > 31) {
+    error = new Error('Scan data is over maximum limit of 31 bytes');
+  }
+
+  if (error) {
+    this.emit('advertisingStart', error);
+  } else {
+    this._advertiseState = 'starting';
+
+    if (isIntelEdison || isYocto) {
+      // work around for Intel Edison
+      debug('skipping first set of scan response and advertisement data');
+    } else {
+      this._hci.setScanResponseData(scanData);
+      this._hci.setAdvertisingData(advertisementData);
+    }
+    this._hci.setAdvertiseEnable(true);
+    this._hci.setScanResponseData(scanData);
+    this._hci.setAdvertisingData(advertisementData);
+  }
+};
+
+Gap.prototype.restartAdvertising = function() {
+  this._advertiseState = 'restarting';
+
+  this._hci.setAdvertiseEnable(true);
+};
+
+Gap.prototype.stopAdvertising = function() {
+  this._advertiseState = 'stopping';
+
+  this._hci.setAdvertiseEnable(false);
+};
+
+Gap.prototype.onHciError = function(error) {
+};
+
+Gap.prototype.onHciLeAdvertisingParametersSet = function(status) {
+};
+
+Gap.prototype.onHciLeAdvertisingDataSet = function(status) {
+};
+
+Gap.prototype.onHciLeScanResponseDataSet = function(status) {
+};
+
+Gap.prototype.onHciLeAdvertiseEnableSet = function(status) {
+  if (this._advertiseState === 'starting') {
+    this._advertiseState = 'started';
+
+    var error = null;
+
+    if (status) {
+      error = new Error(Hci.STATUS_MAPPER[status] || ('Unknown (' + status + ')'));
+    }
+
+    this.emit('advertisingStart', error);
+  } else if (this._advertiseState === 'stopping') {
+    this._advertiseState = 'stopped';
+
+    this.emit('advertisingStop');
+  }
+};
+
+module.exports = Gap;

--- a/src/js/ble_hci_socket_gatt.js
+++ b/src/js/ble_hci_socket_gatt.js
@@ -1,0 +1,1090 @@
+/* Copyright 2016-present Samsung Electronics Co., Ltd. and other contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/* Copyright (C) 2015 Sandeep Mistry sandeep.mistry@gmail.com
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+/*jshint loopfunc: true */
+
+var debug = console.log; //requir('debug')('ble_hci_socket_gatt');
+
+var events = require('events');
+var util = require('util');
+
+var ATT_OP_ERROR                    = 0x01;
+var ATT_OP_MTU_REQ                  = 0x02;
+var ATT_OP_MTU_RESP                 = 0x03;
+var ATT_OP_FIND_INFO_REQ            = 0x04;
+var ATT_OP_FIND_INFO_RESP           = 0x05;
+var ATT_OP_FIND_BY_TYPE_REQ         = 0x06;
+var ATT_OP_FIND_BY_TYPE_RESP        = 0x07;
+var ATT_OP_READ_BY_TYPE_REQ         = 0x08;
+var ATT_OP_READ_BY_TYPE_RESP        = 0x09;
+var ATT_OP_READ_REQ                 = 0x0a;
+var ATT_OP_READ_RESP                = 0x0b;
+var ATT_OP_READ_BLOB_REQ            = 0x0c;
+var ATT_OP_READ_BLOB_RESP           = 0x0d;
+var ATT_OP_READ_MULTI_REQ           = 0x0e;
+var ATT_OP_READ_MULTI_RESP          = 0x0f;
+var ATT_OP_READ_BY_GROUP_REQ        = 0x10;
+var ATT_OP_READ_BY_GROUP_RESP       = 0x11;
+var ATT_OP_WRITE_REQ                = 0x12;
+var ATT_OP_WRITE_RESP               = 0x13;
+var ATT_OP_WRITE_CMD                = 0x52;
+var ATT_OP_PREP_WRITE_REQ           = 0x16;
+var ATT_OP_PREP_WRITE_RESP          = 0x17;
+var ATT_OP_EXEC_WRITE_REQ           = 0x18;
+var ATT_OP_EXEC_WRITE_RESP          = 0x19;
+var ATT_OP_HANDLE_NOTIFY            = 0x1b;
+var ATT_OP_HANDLE_IND               = 0x1d;
+var ATT_OP_HANDLE_CNF               = 0x1e;
+var ATT_OP_SIGNED_WRITE_CMD         = 0xd2;
+
+var GATT_PRIM_SVC_UUID              = 0x2800;
+var GATT_INCLUDE_UUID               = 0x2802;
+var GATT_CHARAC_UUID                = 0x2803;
+
+var GATT_CLIENT_CHARAC_CFG_UUID     = 0x2902;
+var GATT_SERVER_CHARAC_CFG_UUID     = 0x2903;
+
+var ATT_ECODE_SUCCESS               = 0x00;
+var ATT_ECODE_INVALID_HANDLE        = 0x01;
+var ATT_ECODE_READ_NOT_PERM         = 0x02;
+var ATT_ECODE_WRITE_NOT_PERM        = 0x03;
+var ATT_ECODE_INVALID_PDU           = 0x04;
+var ATT_ECODE_AUTHENTICATION        = 0x05;
+var ATT_ECODE_REQ_NOT_SUPP          = 0x06;
+var ATT_ECODE_INVALID_OFFSET        = 0x07;
+var ATT_ECODE_AUTHORIZATION         = 0x08;
+var ATT_ECODE_PREP_QUEUE_FULL       = 0x09;
+var ATT_ECODE_ATTR_NOT_FOUND        = 0x0a;
+var ATT_ECODE_ATTR_NOT_LONG         = 0x0b;
+var ATT_ECODE_INSUFF_ENCR_KEY_SIZE  = 0x0c;
+var ATT_ECODE_INVAL_ATTR_VALUE_LEN  = 0x0d;
+var ATT_ECODE_UNLIKELY              = 0x0e;
+var ATT_ECODE_INSUFF_ENC            = 0x0f;
+var ATT_ECODE_UNSUPP_GRP_TYPE       = 0x10;
+var ATT_ECODE_INSUFF_RESOURCES      = 0x11;
+
+var ATT_CID = 0x0004;
+
+var Gatt = function() {
+  this.maxMtu = 256;
+  this._mtu = 23;
+  this._preparedWriteRequest = null;
+
+  this.setServices([]);
+
+  this.onAclStreamDataBinded = this.onAclStreamData.bind(this);
+  this.onAclStreamEndBinded = this.onAclStreamEnd.bind(this);
+};
+
+util.inherits(Gatt, events.EventEmitter);
+
+Gatt.prototype.setServices = function(services) {
+  var deviceName = process.env.BLENO_DEVICE_NAME || process.platform;
+
+  // base services and characteristics
+  var allServices = [
+    {
+      uuid: '1800',
+      characteristics: [
+        {
+          uuid: '2a00',
+          properties: ['read'],
+          secure: [],
+          value: new Buffer(deviceName),
+          descriptors: []
+        },
+        {
+          uuid: '2a01',
+          properties: ['read'],
+          secure: [],
+          value: new Buffer([0x80, 0x00]),
+          descriptors: []
+        }
+      ]
+    },
+    {
+      uuid: '1801',
+      characteristics: [
+        {
+          uuid: '2a05',
+          properties: ['indicate'],
+          secure: [],
+          value: new Buffer([0x00, 0x00, 0x00, 0x00]),
+          descriptors: []
+        }
+      ]
+    }
+  ].concat(services);
+
+  this._handles = [];
+
+  var handle = 0;
+  var i;
+  var j;
+
+  for (i = 0; i < allServices.length; i++) {
+    var service = allServices[i];
+
+    handle++;
+    var serviceHandle = handle;
+
+    this._handles[serviceHandle] = {
+      type: 'service',
+      uuid: service.uuid,
+      attribute: service,
+      startHandle: serviceHandle
+      // endHandle filled in below
+    };
+
+    for (j = 0; j < service.characteristics.length; j++) {
+      var characteristic = service.characteristics[j];
+
+      var properties = 0;
+      var secure = 0;
+
+      if (characteristic.properties.indexOf('read') !== -1) {
+        properties |= 0x02;
+
+        if (characteristic.secure.indexOf('read') !== -1) {
+          secure |= 0x02;
+        }
+      }
+
+      if (characteristic.properties.indexOf('writeWithoutResponse') !== -1) {
+        properties |= 0x04;
+
+        if (characteristic.secure.indexOf('writeWithoutResponse') !== -1) {
+          secure |= 0x04;
+        }
+      }
+
+      if (characteristic.properties.indexOf('write') !== -1) {
+        properties |= 0x08;
+
+        if (characteristic.secure.indexOf('write') !== -1) {
+          secure |= 0x08;
+        }
+      }
+
+      if (characteristic.properties.indexOf('notify') !== -1) {
+        properties |= 0x10;
+
+        if (characteristic.secure.indexOf('notify') !== -1) {
+          secure |= 0x10;
+        }
+      }
+
+      if (characteristic.properties.indexOf('indicate') !== -1) {
+        properties |= 0x20;
+
+        if (characteristic.secure.indexOf('indicate') !== -1) {
+          secure |= 0x20;
+        }
+      }
+
+      handle++;
+      var characteristicHandle = handle;
+
+      handle++;
+      var characteristicValueHandle = handle;
+
+      this._handles[characteristicHandle] = {
+        type: 'characteristic',
+        uuid: characteristic.uuid,
+        properties: properties,
+        secure: secure,
+        attribute: characteristic,
+        startHandle: characteristicHandle,
+        valueHandle: characteristicValueHandle
+      };
+
+      this._handles[characteristicValueHandle] = {
+        type: 'characteristicValue',
+        handle: characteristicValueHandle,
+        value: characteristic.value
+      };
+
+      if (properties & 0x30) { // notify or indicate
+        // add client characteristic configuration descriptor
+
+        handle++;
+        var clientCharacteristicConfigurationDescriptorHandle = handle;
+        this._handles[clientCharacteristicConfigurationDescriptorHandle] = {
+          type: 'descriptor',
+          handle: clientCharacteristicConfigurationDescriptorHandle,
+          uuid: '2902',
+          attribute: characteristic,
+          properties: (0x02 | 0x04 | 0x08), // read/write
+          secure: (secure & 0x10) ? (0x02 | 0x04 | 0x08) : 0,
+          value: new Buffer([0x00, 0x00])
+        };
+      }
+
+      for (var k = 0; k < characteristic.descriptors.length; k++) {
+        var descriptor = characteristic.descriptors[k];
+
+        handle++;
+        var descriptorHandle = handle;
+
+        this._handles[descriptorHandle] = {
+          type: 'descriptor',
+          handle: descriptorHandle,
+          uuid: descriptor.uuid,
+          attribute: descriptor,
+          properties: 0x02, // read only
+          secure: 0x00,
+          value: descriptor.value
+        };
+      }
+    }
+
+    this._handles[serviceHandle].endHandle = handle;
+  }
+
+  var debugHandles = [];
+  for (i = 0; i < this._handles.length; i++) {
+    handle = this._handles[i];
+
+    debugHandles[i] = {};
+    for(j in handle) {
+      if (Buffer.isBuffer(handle[j])) {
+        debugHandles[i][j] = handle[j] ? 'Buffer(\'' + handle[j].toString('hex') + '\', \'hex\')' : null;
+      } else if (j !== 'attribute') {
+        debugHandles[i][j] = handle[j];
+      }
+    }
+  }
+
+  debug('handles = ' + JSON.stringify(debugHandles, null, 2));
+};
+
+Gatt.prototype.setAclStream = function(aclStream) {
+  this._mtu = 23;
+  this._preparedWriteRequest = null;
+
+  this._aclStream = aclStream;
+
+  this._aclStream.on('data', this.onAclStreamDataBinded);
+  this._aclStream.on('end', this.onAclStreamEndBinded);
+};
+
+Gatt.prototype.onAclStreamData = function(cid, data) {
+  if (cid !== ATT_CID) {
+    return;
+  }
+
+  this.handleRequest(data);
+};
+
+Gatt.prototype.onAclStreamEnd = function() {
+  this._aclStream.removeListener('data', this.onAclStreamDataBinded);
+  this._aclStream.removeListener('end', this.onAclStreamEndBinded);
+};
+
+Gatt.prototype.send = function(data) {
+  debug('send: ' + data.toString('hex'));
+  this._aclStream.write(ATT_CID, data);
+};
+
+Gatt.prototype.errorResponse = function(opcode, handle, status) {
+  var buf = new Buffer(5);
+
+  buf.writeUInt8(ATT_OP_ERROR, 0);
+  buf.writeUInt8(opcode, 1);
+  buf.writeUInt16LE(handle, 2);
+  buf.writeUInt8(status, 4);
+
+  return buf;
+};
+
+Gatt.prototype.handleRequest = function(request) {
+  debug('handing request: ' + request.toString('hex'));
+
+  var requestType = request.readUInt8(0); //buf[0];
+  var response = null;
+
+  switch(requestType) {
+    case ATT_OP_MTU_REQ:
+      response = this.handleMtuRequest(request);
+      break;
+
+    case ATT_OP_FIND_INFO_REQ:
+      response = this.handleFindInfoRequest(request);
+      break;
+
+    case ATT_OP_FIND_BY_TYPE_REQ:
+      response = this.handleFindByTypeRequest(request);
+      break;
+
+    case ATT_OP_READ_BY_TYPE_REQ:
+      response = this.handleReadByTypeRequest(request);
+      break;
+
+    case ATT_OP_READ_REQ:
+    case ATT_OP_READ_BLOB_REQ:
+      response = this.handleReadOrReadBlobRequest(request);
+      break;
+
+    case ATT_OP_READ_BY_GROUP_REQ:
+      response = this.handleReadByGroupRequest(request);
+      break;
+
+    case ATT_OP_WRITE_REQ:
+    case ATT_OP_WRITE_CMD:
+      response = this.handleWriteRequestOrCommand(request);
+      break;
+
+    case ATT_OP_PREP_WRITE_REQ:
+      response = this.handlePrepareWriteRequest(request);
+      break;
+
+    case ATT_OP_EXEC_WRITE_REQ:
+      response = this.handleExecuteWriteRequest(request);
+      break;
+
+    case ATT_OP_HANDLE_CNF:
+      response = this.handleConfirmation(request);
+      break;
+
+    default:
+    case ATT_OP_READ_MULTI_REQ:
+    case ATT_OP_SIGNED_WRITE_CMD:
+      response = this.errorResponse(requestType, 0x0000, ATT_ECODE_REQ_NOT_SUPP);
+      break;
+  }
+
+  if (response) {
+    debug('response: ' + response.toString('hex'));
+
+    this.send(response);
+  }
+};
+
+Gatt.prototype.handleMtuRequest = function(request) {
+  var mtu = request.readUInt16LE(1);
+
+  if (mtu < 23) {
+    mtu = 23;
+  } else if (mtu > this.maxMtu) {
+    mtu = this.maxMtu;
+  }
+
+  this._mtu = mtu;
+
+  this.emit('mtuChange', this._mtu);
+
+  var response = new Buffer(3);
+
+  response.writeUInt8(ATT_OP_MTU_RESP, 0);
+  response.writeUInt16LE(mtu, 1);
+
+  return response;
+};
+
+Gatt.prototype.handleFindInfoRequest = function(request) {
+  var response = null;
+
+  var startHandle = request.readUInt16LE(1);
+  var endHandle = request.readUInt16LE(3);
+
+  var infos = [];
+  var uuid = null;
+
+  for (i = startHandle; i <= endHandle; i++) {
+    var handle = this._handles[i];
+
+    if (!handle) {
+      break;
+    }
+
+    uuid = null;
+
+    if ('service' === handle.type) {
+      uuid = '2800';
+    } else if ('includedService' === handle.type) {
+      uuid = '2802';
+    } else if ('characteristic' === handle.type) {
+      uuid = '2803';
+    } else if ('characteristicValue' === handle.type) {
+      uuid = this._handles[i - 1].uuid;
+    } else if ('descriptor' === handle.type) {
+      uuid = handle.uuid;
+    }
+
+    if (uuid) {
+      infos.push({
+        handle: i,
+        uuid: uuid
+      });
+    }
+  }
+
+  if (infos.length) {
+    var uuidSize = infos[0].uuid.length / 2;
+    var numInfo = 1;
+
+    for (i = 1; i < infos.length; i++) {
+      if (infos[0].uuid.length !== infos[i].uuid.length) {
+        break;
+      }
+      numInfo++;
+    }
+
+    var lengthPerInfo = (uuidSize === 2) ? 4 : 18;
+    var maxInfo = Math.floor((this._mtu - 2) / lengthPerInfo);
+    numInfo = Math.min(numInfo, maxInfo);
+
+    response = new Buffer(2 + numInfo * lengthPerInfo);
+
+    //response[0] = ATT_OP_FIND_INFO_RESP;
+    //response[1] = (uuidSize === 2) ? 0x01 : 0x2;
+    response.writeUInt8(ATT_OP_FIND_INFO_RESP, 0);
+    response.writeUInt8((uuidSize === 2) ? 0x01 : 0x2, 1);
+
+    for (i = 0; i < numInfo; i++) {
+      var info = infos[i];
+
+      response.writeUInt16LE(info.handle, 2 + i * lengthPerInfo);
+
+      uuid = new Buffer(info.uuid.match(/.{1,2}/g).reverse().join(''), 'hex');
+      for (var j = 0; j < uuid.length; j++) {
+        //response[2 + i * lengthPerInfo + 2 + j] = uuid[j];
+        response.writeUInt8(uuid[j], 2 + i * lengthPerInfo + 2 + j);
+      }
+    }
+  } else {
+    response = this.errorResponse(ATT_OP_FIND_INFO_REQ, startHandle, ATT_ECODE_ATTR_NOT_FOUND);
+  }
+
+  return response;
+};
+
+Gatt.prototype.handleFindByTypeRequest = function(request) {
+  var response = null;
+
+  var startHandle = request.readUInt16LE(1);
+  var endHandle = request.readUInt16LE(3);
+  var uuid = request.slice(5, 7).toString('hex').match(/.{1,2}/g).reverse().join('');
+  var value = request.slice(7).toString('hex').match(/.{1,2}/g).reverse().join('');
+
+  var handles = [];
+  var handle;
+
+  for (var i = startHandle; i <= endHandle; i++) {
+    handle = this._handles[i];
+
+    if (!handle) {
+      break;
+    }
+
+    if ('2800' === uuid && handle.type === 'service' && handle.uuid === value) {
+      handles.push({
+        start: handle.startHandle,
+        end: handle.endHandle
+      });
+    }
+  }
+
+  if (handles.length) {
+    var lengthPerHandle = 4;
+    var numHandles = handles.length;
+    var maxHandles = Math.floor((this._mtu - 1) / lengthPerHandle);
+
+    numHandles = Math.min(numHandles, maxHandles);
+
+    response = new Buffer(1 + numHandles * lengthPerHandle);
+
+    //response[0] = ATT_OP_FIND_BY_TYPE_RESP;
+    response.writeUInt8(ATT_OP_FIND_BY_TYPE_RESP, 0);
+
+    for (i = 0; i < numHandles; i++) {
+      handle = handles[i];
+
+      response.writeUInt16LE(handle.start, 1 + i * lengthPerHandle);
+      response.writeUInt16LE(handle.end, 1 + i * lengthPerHandle + 2);
+    }
+  } else {
+    response = this.errorResponse(ATT_OP_FIND_BY_TYPE_REQ, startHandle, ATT_ECODE_ATTR_NOT_FOUND);
+  }
+
+  return response;
+};
+
+Gatt.prototype.handleReadByGroupRequest = function(request) {
+  var response = null;
+
+  var startHandle = request.readUInt16LE(1);
+  var endHandle = request.readUInt16LE(3);
+  var uuid = request.slice(5).toString('hex').match(/.{1,2}/g).reverse().join('');
+
+  debug('read by group: startHandle = 0x' + startHandle.toString(16) + ', endHandle = 0x' + endHandle.toString(16) + ', uuid = 0x' + uuid.toString(16));
+
+  if ('2800' === uuid || '2802' === uuid) {
+    var services = [];
+    var type = ('2800' === uuid) ? 'service' : 'includedService';
+    var i;
+
+    for (i = startHandle; i <= endHandle; i++) {
+      var handle = this._handles[i];
+
+      if (!handle) {
+        break;
+      }
+
+      if (handle.type === type) {
+        services.push(handle);
+      }
+    }
+
+    if (services.length) {
+      var uuidSize = services[0].uuid.length / 2;
+      var numServices = 1;
+
+      for (i = 1; i < services.length; i++) {
+        if (services[0].uuid.length !== services[i].uuid.length) {
+          break;
+        }
+        numServices++;
+      }
+
+      var lengthPerService = (uuidSize === 2) ? 6 : 20;
+      var maxServices = Math.floor((this._mtu - 2) / lengthPerService);
+      numServices = Math.min(numServices, maxServices);
+
+      response = new Buffer(2 + numServices * lengthPerService);
+
+      //response[0] = ATT_OP_READ_BY_GROUP_RESP;
+      //response[1] = lengthPerService;
+      response.writeUInt8(ATT_OP_READ_BY_GROUP_RESP, 0);
+      response.writeUInt8(lengthPerService, 1);
+
+      for (i = 0; i < numServices; i++) {
+        var service = services[i];
+
+        response.writeUInt16LE(service.startHandle, 2 + i * lengthPerService);
+        response.writeUInt16LE(service.endHandle, 2 + i * lengthPerService + 2);
+
+        var serviceUuid = new Buffer(service.uuid.match(/.{1,2}/g).reverse().join(''), 'hex');
+        for (var j = 0; j < serviceUuid.length; j++) {
+          //response[2 + i * lengthPerService + 4 + j] = serviceUuid[j];
+          response.writeUInt8(serviceUuid.readUInt8(j), 2 + i * lengthPerService + 4 + j);
+        }
+      }
+    } else {
+      response = this.errorResponse(ATT_OP_READ_BY_GROUP_REQ, startHandle, ATT_ECODE_ATTR_NOT_FOUND);
+    }
+  } else {
+    response = this.errorResponse(ATT_OP_READ_BY_GROUP_REQ, startHandle, ATT_ECODE_UNSUPP_GRP_TYPE);
+  }
+
+  return response;
+};
+
+Gatt.prototype.handleReadByTypeRequest = function(request) {
+  var response = null;
+
+  var startHandle = request.readUInt16LE(1);
+  var endHandle = request.readUInt16LE(3);
+  var uuid = request.slice(5).toString('hex').match(/.{1,2}/g).reverse().join('');
+  var i;
+  var handle;
+
+  debug('read by type: startHandle = 0x' + startHandle.toString(16) + ', endHandle = 0x' + endHandle.toString(16) + ', uuid = 0x' + uuid.toString(16));
+
+  if ('2803' === uuid) {
+    var characteristics = [];
+
+    for (i = startHandle; i <= endHandle; i++) {
+      handle = this._handles[i];
+
+      if (!handle) {
+        break;
+      }
+
+      if (handle.type === 'characteristic') {
+        characteristics.push(handle);
+      }
+    }
+
+    if (characteristics.length) {
+      var uuidSize = characteristics[0].uuid.length / 2;
+      var numCharacteristics = 1;
+
+      for (i = 1; i < characteristics.length; i++) {
+        if (characteristics[0].uuid.length !== characteristics[i].uuid.length) {
+          break;
+        }
+        numCharacteristics++;
+      }
+
+      var lengthPerCharacteristic = (uuidSize === 2) ? 7 : 21;
+      var maxCharacteristics = Math.floor((this._mtu - 2) / lengthPerCharacteristic);
+      numCharacteristics = Math.min(numCharacteristics, maxCharacteristics);
+
+      response = new Buffer(2 + numCharacteristics * lengthPerCharacteristic);
+
+      //response[0] = ATT_OP_READ_BY_TYPE_RESP;
+      //response[1] = lengthPerCharacteristic;
+      response.writeUInt8(ATT_OP_READ_BY_TYPE_RESP, 0);
+      response.writeUInt8(lengthPerCharacteristic, 1);
+
+      for (i = 0; i < numCharacteristics; i++) {
+        var characteristic = characteristics[i];
+
+        response.writeUInt16LE(characteristic.startHandle, 2 + i * lengthPerCharacteristic);
+        response.writeUInt8(characteristic.properties, 2 + i * lengthPerCharacteristic + 2);
+        response.writeUInt16LE(characteristic.valueHandle, 2 + i * lengthPerCharacteristic + 3);
+
+        var characteristicUuid = new Buffer(characteristic.uuid.match(/.{1,2}/g).reverse().join(''), 'hex');
+        for (var j = 0; j < characteristicUuid.length; j++) {
+          //response[2 + i * lengthPerCharacteristic + 5 + j] = characteristicUuid[j];
+          response.writeUInt8(characteristicUuid.readUInt8(j), 2 + i * lengthPerCharacteristic + 5 + j);
+        }
+      }
+    } else {
+      response = this.errorResponse(ATT_OP_READ_BY_TYPE_REQ, startHandle, ATT_ECODE_ATTR_NOT_FOUND);
+    }
+  } else {
+    var handleAttribute = null;
+    var valueHandle = null;
+    var secure = false;
+
+    for (i = startHandle; i <= endHandle; i++) {
+      handle = this._handles[i];
+
+      if (!handle) {
+        break;
+      }
+
+      if (handle.type === 'characteristic' && handle.uuid === uuid) {
+        handleAttribute = handle.attribute;
+        valueHandle = handle.valueHandle;
+        secure = handle.secure & 0x02;
+        break;
+      } else if (handle.type === 'descriptor' && handle.uuid === uuid) {
+        valueHandle = i;
+        secure = handle.secure & 0x02;
+        break;
+      }
+    }
+
+    if (secure && !this._aclStream.encrypted) {
+      response = this.errorResponse(ATT_OP_READ_BY_TYPE_REQ, startHandle, ATT_ECODE_AUTHENTICATION);
+    } else if (valueHandle) {
+      var callback = (function(valueHandle) {
+        return function(result, data) {
+          var callbackResponse = null;
+
+          if (ATT_ECODE_SUCCESS === result) {
+            var dataLength = Math.min(data.length, this._mtu - 4);
+            callbackResponse = new Buffer(4 + dataLength);
+
+            //callbackResponse[0] = ATT_OP_READ_BY_TYPE_RESP;
+            //callbackResponse[1] = dataLength + 2;
+            callbackResponse.writeUInt8(ATT_OP_READ_BY_TYPE_RESP, 0);
+            callbackResponse.writeUInt8(dataLength + 2, 1);
+            callbackResponse.writeUInt16LE(valueHandle, 2);
+            for (i = 0; i < dataLength; i++) {
+              //callbackResponse[4 + i] = data[i];
+              callbackResponse.writeUInt8(data.readUInt8(i), 4 + i);
+            }
+          } else {
+            callbackResponse = this.errorResponse(requestType, valueHandle, result);
+          }
+
+          debug('read by type response: ' + callbackResponse.toString('hex'));
+
+          this.send(callbackResponse);
+        }.bind(this);
+      }.bind(this))(valueHandle);
+
+      var data = this._handles[valueHandle].value;
+
+      if (data) {
+        callback(ATT_ECODE_SUCCESS, data);
+      } else if (handleAttribute) {
+        handleAttribute.emit('readRequest', 0, callback);
+      } else {
+        callback(ATT_ECODE_UNLIKELY);
+      }
+    } else {
+      response = this.errorResponse(ATT_OP_READ_BY_TYPE_REQ, startHandle, ATT_ECODE_ATTR_NOT_FOUND);
+    }
+  }
+
+  return response;
+};
+
+Gatt.prototype.handleReadOrReadBlobRequest = function(request) {
+  var response = null;
+
+  //var requestType = request[0];
+  var requestType = request.readUInt8(0);
+  var valueHandle = request.readUInt16LE(1);
+  var offset = (requestType === ATT_OP_READ_BLOB_REQ) ? request.readUInt16LE(3) : 0;
+
+  var handle = this._handles[valueHandle];
+
+  if (handle) {
+    var result = null;
+    var data = null;
+    var handleType = handle.type;
+
+    var callback = (function(requestType, valueHandle) {
+      return function(result, data) {
+        var callbackResponse = null;
+
+        if (ATT_ECODE_SUCCESS === result) {
+          var dataLength = Math.min(data.length, this._mtu - 1);
+          callbackResponse = new Buffer(1 + dataLength);
+
+          //callbackResponse[0] = (requestType === ATT_OP_READ_BLOB_REQ) ? ATT_OP_READ_BLOB_RESP : ATT_OP_READ_RESP;
+          callbackResponse.writeUInt8((requestType === ATT_OP_READ_BLOB_REQ) ? ATT_OP_READ_BLOB_RESP : ATT_OP_READ_RESP, 0);
+          for (i = 0; i < dataLength; i++) {
+            //callbackResponse[1 + i] = data[i];
+            callbackResponse.writeUInt8(data.readUInt8(i), 1 + i);
+          }
+        } else {
+          callbackResponse = this.errorResponse(requestType, valueHandle, result);
+        }
+
+        debug('read response: ' + callbackResponse.toString('hex'));
+
+        this.send(callbackResponse);
+      }.bind(this);
+    }.bind(this))(requestType, valueHandle);
+
+    if (handleType === 'service' || handleType === 'includedService') {
+      result = ATT_ECODE_SUCCESS;
+      data = new Buffer(handle.uuid.match(/.{1,2}/g).reverse().join(''), 'hex');
+    } else if (handleType === 'characteristic') {
+      var uuid = new Buffer(handle.uuid.match(/.{1,2}/g).reverse().join(''), 'hex');
+
+      result = ATT_ECODE_SUCCESS;
+      data = new Buffer(3 + uuid.length);
+      data.writeUInt8(handle.properties, 0);
+      data.writeUInt16LE(handle.valueHandle, 1);
+
+      for (i = 0; i < uuid.length; i++) {
+        //data[i + 3] = uuid[i];
+        data.writeUInt8(uuid.readUInt8(i), i + 3);
+      }
+    } else if (handleType === 'characteristicValue' || handleType === 'descriptor') {
+      var handleProperties = handle.properties;
+      var handleSecure = handle.secure;
+      var handleAttribute = handle.attribute;
+      if (handleType === 'characteristicValue') {
+        handleProperties = this._handles[valueHandle - 1].properties;
+        handleSecure = this._handles[valueHandle - 1].secure;
+        handleAttribute = this._handles[valueHandle - 1].attribute;
+      }
+
+      if (handleProperties & 0x02) {
+        if (handleSecure & 0x02 && !this._aclStream.encrypted) {
+          result = ATT_ECODE_AUTHENTICATION;
+        } else {
+          data = handle.value;
+
+          if (data) {
+            result = ATT_ECODE_SUCCESS;
+          } else {
+            handleAttribute.emit('readRequest', offset, callback);
+          }
+        }
+      } else {
+        result = ATT_ECODE_READ_NOT_PERM; // non-readable
+      }
+    }
+
+    if (data && typeof data === 'string') {
+      data = new Buffer(data);
+    }
+
+    if (result === ATT_ECODE_SUCCESS && data && offset) {
+      if (data.length < offset) {
+        errorCode = ATT_ECODE_INVALID_OFFSET;
+        data = null;
+      } else {
+        data = data.slice(offset);
+      }
+    }
+
+    if (result !== null) {
+      callback(result, data);
+    }
+  } else {
+    response = this.errorResponse(requestType, valueHandle, ATT_ECODE_INVALID_HANDLE);
+  }
+
+  return response;
+};
+
+Gatt.prototype.handleWriteRequestOrCommand = function(request) {
+  var response = null;
+
+  //var requestType = request[0];
+  var requestType = request.readUInt8(0);
+  var withoutResponse = (requestType === ATT_OP_WRITE_CMD);
+  var valueHandle = request.readUInt16LE(1);
+  var data = request.slice(3);
+  var offset = 0;
+
+  var handle = this._handles[valueHandle];
+
+  if (handle) {
+    if (handle.type === 'characteristicValue') {
+      handle = this._handles[valueHandle - 1];
+    }
+
+    var handleProperties = handle.properties;
+    var handleSecure = handle.secure;
+
+    if (handleProperties && (withoutResponse ? (handleProperties & 0x04) : (handleProperties & 0x08))) {
+
+      var callback = (function(requestType, valueHandle, withoutResponse) {
+        return function(result) {
+          if (!withoutResponse) {
+            var callbackResponse = null;
+
+            if (ATT_ECODE_SUCCESS === result) {
+              callbackResponse = new Buffer([ATT_OP_WRITE_RESP]);
+            } else {
+              callbackResponse = this.errorResponse(requestType, valueHandle, result);
+            }
+
+            debug('write response: ' + callbackResponse.toString('hex'));
+
+            this.send(callbackResponse);
+          }
+        }.bind(this);
+      }.bind(this))(requestType, valueHandle, withoutResponse);
+
+      if (handleSecure & (withoutResponse ? 0x04 : 0x08) && !this._aclStream.encrypted) {
+        response = this.errorResponse(requestType, valueHandle, ATT_ECODE_AUTHENTICATION);
+      } else if (handle.type === 'descriptor' || handle.uuid === '2902') {
+        var result = null;
+
+        if (data.length !== 2) {
+          result = ATT_ECODE_INVAL_ATTR_VALUE_LEN;
+        } else {
+          var value = data.readUInt16LE(0);
+          var handleAttribute = handle.attribute;
+
+          handle.value = data;
+
+          if (value & 0x0003) {
+            var updateValueCallback = (function(valueHandle, attribute) {
+              return function(data) {
+                var dataLength = Math.min(data.length, this._mtu - 3);
+                var useNotify = attribute.properties.indexOf('notify') !== -1;
+                var useIndicate = attribute.properties.indexOf('indicate') !== -1;
+                var i;
+
+                if (useNotify) {
+                  var notifyMessage = new Buffer(3 + dataLength);
+
+                  notifyMessage.writeUInt8(ATT_OP_HANDLE_NOTIFY, 0);
+                  notifyMessage.writeUInt16LE(valueHandle, 1);
+
+                  for (i = 0; i < dataLength; i++) {
+                    //notifyMessage[3 + i] = data[i];
+                    notifyMessage.writeUInt8(data.readUInt8(i), 3 + i);
+                  }
+
+                  debug('notify message: ' + notifyMessage.toString('hex'));
+                  this.send(notifyMessage);
+
+                  attribute.emit('notify');
+                } else if (useIndicate) {
+                  var indicateMessage = new Buffer(3 + dataLength);
+
+                  indicateMessage.writeUInt8(ATT_OP_HANDLE_IND, 0);
+                  indicateMessage.writeUInt16LE(valueHandle, 1);
+
+                  for (i = 0; i < dataLength; i++) {
+                    //indicateMessage[3 + i] = data[i];
+                    indicateMessage.writeUInt8(data.readUInt8(i), 3 + i);
+                  }
+
+                  this._lastIndicatedAttribute = attribute;
+
+                  debug('indicate message: ' + indicateMessage.toString('hex'));
+                  this.send(indicateMessage);
+                }
+              }.bind(this);
+            }.bind(this))(valueHandle - 1, handleAttribute);
+
+            if (handleAttribute.emit) {
+              handleAttribute.emit('subscribe', this._mtu - 3, updateValueCallback);
+            }
+          } else {
+            handleAttribute.emit('unsubscribe');
+          }
+
+          result = ATT_ECODE_SUCCESS;
+        }
+
+        callback(result);
+      } else {
+        handle.attribute.emit('writeRequest', data, offset, withoutResponse, callback);
+      }
+    } else {
+      response = this.errorResponse(requestType, valueHandle, ATT_ECODE_WRITE_NOT_PERM);
+    }
+  } else {
+    response = this.errorResponse(requestType, valueHandle, ATT_ECODE_INVALID_HANDLE);
+  }
+
+  return response;
+};
+
+Gatt.prototype.handlePrepareWriteRequest = function(request) {
+  var response = null;
+
+  //var requestType = request[0];
+  var requestType = request.readUInt8(0);
+  var valueHandle = request.readUInt16LE(1);
+  var offset = request.readUInt16LE(3);
+  var data = request.slice(5);
+
+  var handle = this._handles[valueHandle];
+
+  if (handle) {
+    if (handle.type === 'characteristicValue') {
+      handle = this._handles[valueHandle - 1];
+
+      var handleProperties = handle.properties;
+      var handleSecure = handle.secure;
+
+      if (handleProperties && (handleProperties & 0x08)) {
+        if ((handleSecure & 0x08) && !this._aclStream.encrypted) {
+          response = this.errorResponse(requestType, valueHandle, ATT_ECODE_AUTHENTICATION);
+        } else if (this._preparedWriteRequest) {
+          if (this._preparedWriteRequest.handle !== handle) {
+            response = this.errorResponse(requestType, valueHandle, ATT_ECODE_UNLIKELY);
+          } else if (offset === (this._preparedWriteRequest.offset + this._preparedWriteRequest.data.length)) {
+            this._preparedWriteRequest.data = Buffer.concat([
+              this._preparedWriteRequest.data,
+              data
+            ]);
+
+            response = new Buffer(request.length);
+            request.copy(response);
+            //response[0] = ATT_OP_PREP_WRITE_RESP;
+            response.writeUInt8(ATT_OP_PREP_WRITE_RESP, 0);
+          } else {
+            response = this.errorResponse(requestType, valueHandle, ATT_ECODE_INVALID_OFFSET);
+          }
+        } else {
+          this._preparedWriteRequest = {
+            handle: handle,
+            valueHandle: valueHandle,
+            offset: offset,
+            data: data
+          };
+
+          response = new Buffer(request.length);
+          request.copy(response);
+          // response[0] = ATT_OP_PREP_WRITE_RESP;
+          response.writeUInt8(ATT_OP_PREP_WRITE_RESP, 0);
+        }
+      } else {
+        response = this.errorResponse(requestType, valueHandle, ATT_ECODE_WRITE_NOT_PERM);
+      }
+    } else {
+      response = this.errorResponse(requestType, valueHandle, ATT_ECODE_ATTR_NOT_LONG);
+    }
+  } else {
+    response = this.errorResponse(requestType, valueHandle, ATT_ECODE_INVALID_HANDLE);
+  }
+
+  return response;
+};
+
+Gatt.prototype.handleExecuteWriteRequest = function(request) {
+  var response = null;
+
+  //var requestType = request[0];
+  //var flag = request[1];
+  var requestType = request.readUInt8(0);
+  var flag = request.readUInt8(1);
+
+  if (this._preparedWriteRequest) {
+    var valueHandle = this._preparedWriteRequest.valueHandle;
+
+    if (flag === 0x00) {
+      response = new Buffer([ATT_OP_EXEC_WRITE_RESP]);
+    } else if (flag === 0x01) {
+      var callback = (function(requestType, valueHandle) {
+        return function(result) {
+          var callbackResponse = null;
+
+          if (ATT_ECODE_SUCCESS === result) {
+            callbackResponse = new Buffer([ATT_OP_EXEC_WRITE_RESP]);
+          } else {
+            callbackResponse = this.errorResponse(requestType, valueHandle, result);
+          }
+
+          debug('execute write response: ' + callbackResponse.toString('hex'));
+
+          this.send(callbackResponse);
+        }.bind(this);
+      }.bind(this))(requestType, this._preparedWriteRequest.valueHandle);
+
+      this._preparedWriteRequest.handle.attribute.emit('writeRequest', this._preparedWriteRequest.data, this._preparedWriteRequest.offset, false, callback);
+    } else {
+      response = this.errorResponse(requestType, 0x0000, ATT_ECODE_UNLIKELY);
+    }
+
+    this._preparedWriteRequest = null;
+  } else {
+    response = this.errorResponse(requestType, 0x0000, ATT_ECODE_UNLIKELY);
+  }
+
+  return response;
+};
+
+Gatt.prototype.handleConfirmation = function(request) {
+  if (this._lastIndicatedAttribute) {
+    if (this._lastIndicatedAttribute.emit) {
+      this._lastIndicatedAttribute.emit('indicate');
+    }
+
+    this._lastIndicatedAttribute = null;
+  }
+};
+
+module.exports = Gatt;

--- a/src/js/ble_hci_socket_hci.js
+++ b/src/js/ble_hci_socket_hci.js
@@ -1,0 +1,644 @@
+/* Copyright 2016-present Samsung Electronics Co., Ltd. and other contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/* Copyright (C) 2015 Sandeep Mistry sandeep.mistry@gmail.com
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+var debug = console.log; //requir('debug')('ble_hci');
+
+var events = require('events');
+var util = require('util');
+
+var BluetoothHciSocket = require('ble_hci_socket');
+
+var HCI_COMMAND_PKT = 0x01;
+var HCI_ACLDATA_PKT = 0x02;
+var HCI_EVENT_PKT = 0x04;
+
+var ACL_START_NO_FLUSH = 0x00;
+var ACL_CONT  = 0x01;
+var ACL_START = 0x02;
+
+var EVT_DISCONN_COMPLETE = 0x05;
+var EVT_ENCRYPT_CHANGE = 0x08;
+var EVT_CMD_COMPLETE = 0x0e;
+var EVT_CMD_STATUS = 0x0f;
+var EVT_LE_META_EVENT = 0x3e;
+
+var EVT_LE_CONN_COMPLETE = 0x01;
+var EVT_LE_CONN_UPDATE_COMPLETE = 0x03;
+
+var OGF_LINK_CTL = 0x01;
+var OCF_DISCONNECT = 0x0006;
+
+var OGF_HOST_CTL = 0x03;
+var OCF_SET_EVENT_MASK = 0x0001;
+var OCF_RESET = 0x0003;
+var OCF_READ_LE_HOST_SUPPORTED = 0x006c;
+var OCF_WRITE_LE_HOST_SUPPORTED = 0x006d;
+
+var OGF_INFO_PARAM = 0x04;
+var OCF_READ_LOCAL_VERSION = 0x0001;
+var OCF_READ_BD_ADDR = 0x0009;
+
+var OGF_STATUS_PARAM = 0x05;
+var OCF_READ_RSSI = 0x0005;
+
+var OGF_LE_CTL = 0x08;
+var OCF_LE_SET_EVENT_MASK = 0x0001;
+var OCF_LE_SET_ADVERTISING_PARAMETERS = 0x0006;
+var OCF_LE_SET_ADVERTISING_DATA = 0x0008;
+var OCF_LE_SET_SCAN_RESPONSE_DATA = 0x0009;
+var OCF_LE_SET_ADVERTISE_ENABLE = 0x000a;
+var OCF_LE_LTK_NEG_REPLY = 0x001B;
+
+var DISCONNECT_CMD = OCF_DISCONNECT | OGF_LINK_CTL << 10;
+
+var SET_EVENT_MASK_CMD = OCF_SET_EVENT_MASK | OGF_HOST_CTL << 10;
+var RESET_CMD = OCF_RESET | OGF_HOST_CTL << 10;
+var READ_LE_HOST_SUPPORTED_CMD = OCF_READ_LE_HOST_SUPPORTED | OGF_HOST_CTL << 10;
+var WRITE_LE_HOST_SUPPORTED_CMD = OCF_WRITE_LE_HOST_SUPPORTED | OGF_HOST_CTL << 10;
+
+var READ_LOCAL_VERSION_CMD = OCF_READ_LOCAL_VERSION | (OGF_INFO_PARAM << 10);
+var READ_BD_ADDR_CMD = OCF_READ_BD_ADDR | (OGF_INFO_PARAM << 10);
+
+var READ_RSSI_CMD = OCF_READ_RSSI | OGF_STATUS_PARAM << 10;
+
+var LE_SET_EVENT_MASK_CMD = OCF_LE_SET_EVENT_MASK | OGF_LE_CTL << 10;
+var LE_SET_ADVERTISING_PARAMETERS_CMD = OCF_LE_SET_ADVERTISING_PARAMETERS | OGF_LE_CTL << 10;
+var LE_SET_ADVERTISING_DATA_CMD = OCF_LE_SET_ADVERTISING_DATA | OGF_LE_CTL << 10;
+var LE_SET_SCAN_RESPONSE_DATA_CMD = OCF_LE_SET_SCAN_RESPONSE_DATA | OGF_LE_CTL << 10;
+var LE_SET_ADVERTISE_ENABLE_CMD = OCF_LE_SET_ADVERTISE_ENABLE | OGF_LE_CTL << 10;
+var LE_LTK_NEG_REPLY_CMD = OCF_LE_LTK_NEG_REPLY | OGF_LE_CTL << 10;
+
+var HCI_OE_USER_ENDED_CONNECTION = 0x13;
+
+var STATUS_MAPPER = require('ble_hci_socket_hci_status');
+
+var Hci = function() {
+  this._socket = new BluetoothHciSocket();
+  this._isDevUp = null;
+  this._state = null;
+  this._deviceId = null;
+
+  this._handleBuffers = {};
+
+  this.on('stateChange', this.onStateChange.bind(this));
+};
+
+util.inherits(Hci, events.EventEmitter);
+
+Hci.STATUS_MAPPER = STATUS_MAPPER;
+
+Hci.prototype.init = function() {
+  this._socket.on('data', this.onSocketData.bind(this));
+  this._socket.on('error', this.onSocketError.bind(this));
+
+  var deviceId = process.env.BLENO_HCI_DEVICE_ID ? parseInt(process.env.BLENO_HCI_DEVICE_ID) : undefined;
+
+
+  if (process.env.HCI_CHANNEL_USER) {
+    this._deviceId = this._socket.bindUser(deviceId);
+
+    this._socket.start();
+
+    this.reset();
+  } else {
+    this._deviceId = this._socket.bindRaw(deviceId);
+    this._socket.start();
+
+    this.pollIsDevUp();
+  }
+};
+
+Hci.prototype.pollIsDevUp = function() {
+  var isDevUp = this._socket.isDevUp();
+
+  if (this._isDevUp !== isDevUp) {
+    if (isDevUp) {
+      this.setSocketFilter();
+      this.setEventMask();
+      this.setLeEventMask();
+      this.readLocalVersion();
+      this.writeLeHostSupported();
+      this.readLeHostSupported();
+      this.readBdAddr();
+    } else {
+      this.emit('stateChange', 'poweredOff');
+    }
+
+    this._isDevUp = isDevUp;
+  }
+
+  setTimeout(this.pollIsDevUp.bind(this), 1000);
+};
+
+Hci.prototype.setSocketFilter = function() {
+  var filter = new Buffer(14);
+  var typeMask = (1 << HCI_EVENT_PKT)| (1 << HCI_ACLDATA_PKT);
+  var eventMask1 = (1 << EVT_DISCONN_COMPLETE) | (1 << EVT_ENCRYPT_CHANGE) | (1 << EVT_CMD_COMPLETE) | (1 << EVT_CMD_STATUS);
+  var eventMask2 = (1 << (EVT_LE_META_EVENT - 32));
+  var opcode = 0;
+
+  filter.writeUInt32LE(typeMask, 0);
+  filter.writeUInt32LE(eventMask1, 4);
+  filter.writeUInt32LE(eventMask2, 8);
+  filter.writeUInt16LE(opcode, 12);
+
+  debug('setting filter to: ' + filter.toString('hex'));
+  this._socket.setFilter(filter);
+};
+
+Hci.prototype.setEventMask = function() {
+  var cmd = new Buffer(12);
+  var eventMask = new Buffer('fffffbff07f8bf3d', 'hex');
+
+  // header
+  cmd.writeUInt8(HCI_COMMAND_PKT, 0);
+  cmd.writeUInt16LE(SET_EVENT_MASK_CMD, 1);
+
+  // length
+  cmd.writeUInt8(eventMask.length, 3);
+
+  eventMask.copy(cmd, 4);
+
+  debug('set event mask - writing: ' + cmd.toString('hex'));
+  this._socket.write(cmd);
+};
+
+Hci.prototype.reset = function() {
+  var cmd = new Buffer(4);
+
+  // header
+  cmd.writeUInt8(HCI_COMMAND_PKT, 0);
+  cmd.writeUInt16LE(OCF_RESET | OGF_HOST_CTL << 10, 1);
+
+  // length
+  cmd.writeUInt8(0x00, 3);
+
+  debug('reset - writing: ' + cmd.toString('hex'));
+  this._socket.write(cmd);
+};
+
+Hci.prototype.readLeHostSupported = function() {
+  var cmd = new Buffer(4);
+
+  // header
+  cmd.writeUInt8(HCI_COMMAND_PKT, 0);
+  cmd.writeUInt16LE(READ_LE_HOST_SUPPORTED_CMD, 1);
+
+  // length
+  cmd.writeUInt8(0x00, 3);
+
+  debug('read LE host supported - writing: ' + cmd.toString('hex'));
+  this._socket.write(cmd);
+};
+
+Hci.prototype.writeLeHostSupported = function() {
+  var cmd = new Buffer(6);
+
+  // header
+  cmd.writeUInt8(HCI_COMMAND_PKT, 0);
+  cmd.writeUInt16LE(WRITE_LE_HOST_SUPPORTED_CMD, 1);
+
+  // length
+  cmd.writeUInt8(0x02, 3);
+
+  // data
+  cmd.writeUInt8(0x01, 4); // le
+  cmd.writeUInt8(0x00, 5); // simul
+
+  debug('write LE host supported - writing: ' + cmd.toString('hex'));
+  this._socket.write(cmd);
+};
+
+Hci.prototype.readLocalVersion = function() {
+  var cmd = new Buffer(4);
+
+  // header
+  cmd.writeUInt8(HCI_COMMAND_PKT, 0);
+  cmd.writeUInt16LE(READ_LOCAL_VERSION_CMD, 1);
+
+  // length
+  cmd.writeUInt8(0x0, 3);
+
+  debug('read local version - writing: ' + cmd.toString('hex'));
+  this._socket.write(cmd);
+};
+
+Hci.prototype.readBdAddr = function() {
+  var cmd = new Buffer(4);
+
+  // header
+  cmd.writeUInt8(HCI_COMMAND_PKT, 0);
+  cmd.writeUInt16LE(READ_BD_ADDR_CMD, 1);
+
+  // length
+  cmd.writeUInt8(0x0, 3);
+
+  debug('read bd addr - writing: ' + cmd.toString('hex'));
+  this._socket.write(cmd);
+};
+
+Hci.prototype.setLeEventMask = function() {
+  var cmd = new Buffer(12);
+  var leEventMask = new Buffer('1f00000000000000', 'hex');
+
+  // header
+  cmd.writeUInt8(HCI_COMMAND_PKT, 0);
+  cmd.writeUInt16LE(LE_SET_EVENT_MASK_CMD, 1);
+
+  // length
+  cmd.writeUInt8(leEventMask.length, 3);
+
+  leEventMask.copy(cmd, 4);
+
+  debug('set le event mask - writing: ' + cmd.toString('hex'));
+  this._socket.write(cmd);
+};
+
+Hci.prototype.setAdvertisingParameters = function() {
+  var cmd = new Buffer(19);
+
+  // header
+  cmd.writeUInt8(HCI_COMMAND_PKT, 0);
+  cmd.writeUInt16LE(LE_SET_ADVERTISING_PARAMETERS_CMD, 1);
+
+  // length
+  cmd.writeUInt8(15, 3);
+
+  var advertisementInterval = Math.floor((process.env.BLENO_ADVERTISING_INTERVAL ? parseInt(process.env.BLENO_ADVERTISING_INTERVAL) : 100) * 1.6);
+
+  // data
+  cmd.writeUInt16LE(advertisementInterval, 4); // min interval
+  cmd.writeUInt16LE(advertisementInterval, 6); // max interval
+  cmd.writeUInt8(0x00, 8); // adv type
+  cmd.writeUInt8(0x00, 9); // own addr typ
+  cmd.writeUInt8(0x00, 10); // direct addr type
+  (new Buffer('000000000000', 'hex')).copy(cmd, 11); // direct addr
+  cmd.writeUInt8(0x07, 17);
+  cmd.writeUInt8(0x00, 18);
+
+  debug('set advertisement parameters - writing: ' + cmd.toString('hex'));
+  this._socket.write(cmd);
+};
+
+Hci.prototype.setAdvertisingData = function(data) {
+  var cmd = new Buffer(36);
+
+  cmd.fill(0x00);
+
+  // header
+  cmd.writeUInt8(HCI_COMMAND_PKT, 0);
+  cmd.writeUInt16LE(LE_SET_ADVERTISING_DATA_CMD, 1);
+
+  // length
+  cmd.writeUInt8(32, 3);
+
+  // data
+  cmd.writeUInt8(data.length, 4);
+  data.copy(cmd, 5);
+
+  debug('set advertisement data - writing: ' + cmd.toString('hex'));
+  this._socket.write(cmd);
+};
+
+Hci.prototype.setScanResponseData = function(data) {
+  var cmd = new Buffer(36);
+
+  cmd.fill(0x00);
+
+  // header
+  cmd.writeUInt8(HCI_COMMAND_PKT, 0);
+  cmd.writeUInt16LE(LE_SET_SCAN_RESPONSE_DATA_CMD, 1);
+
+  // length
+  cmd.writeUInt8(32, 3);
+
+  // data
+  cmd.writeUInt8(data.length, 4);
+  data.copy(cmd, 5);
+
+  debug('set scan response data - writing: ' + cmd.toString('hex'));
+  this._socket.write(cmd);
+};
+
+Hci.prototype.setAdvertiseEnable = function(enabled) {
+  var cmd = new Buffer(5);
+
+  // header
+  cmd.writeUInt8(HCI_COMMAND_PKT, 0);
+  cmd.writeUInt16LE(LE_SET_ADVERTISE_ENABLE_CMD, 1);
+
+  // length
+  cmd.writeUInt8(0x01, 3);
+
+  // data
+  cmd.writeUInt8(enabled ? 0x01 : 0x00, 4); // enable: 0 -> disabled, 1 -> enabled
+
+  debug('set advertise enable - writing: ' + cmd.toString('hex'));
+  this._socket.write(cmd);
+};
+
+Hci.prototype.disconnect = function(handle, reason) {
+  var cmd = new Buffer(7);
+
+  reason = reason || HCI_OE_USER_ENDED_CONNECTION;
+
+  // header
+  cmd.writeUInt8(HCI_COMMAND_PKT, 0);
+  cmd.writeUInt16LE(DISCONNECT_CMD, 1);
+
+  // length
+  cmd.writeUInt8(0x03, 3);
+
+  // data
+  cmd.writeUInt16LE(handle, 4); // handle
+  cmd.writeUInt8(reason, 6); // reason
+
+  debug('disconnect - writing: ' + cmd.toString('hex'));
+  this._socket.write(cmd);
+};
+
+Hci.prototype.readRssi = function(handle) {
+  var cmd = new Buffer(6);
+
+  // header
+  cmd.writeUInt8(HCI_COMMAND_PKT, 0);
+  cmd.writeUInt16LE(READ_RSSI_CMD, 1);
+
+  // length
+  cmd.writeUInt8(0x02, 3);
+
+  // data
+  cmd.writeUInt16LE(handle, 4); // handle
+
+  debug('read rssi - writing: ' + cmd.toString('hex'));
+  this._socket.write(cmd);
+};
+
+Hci.prototype.writeAclDataPkt = function(handle, cid, data) {
+  var pkt = new Buffer(9 + data.length);
+
+  // header
+  pkt.writeUInt8(HCI_ACLDATA_PKT, 0);
+  pkt.writeUInt16LE(handle | ACL_START_NO_FLUSH << 12, 1);
+  pkt.writeUInt16LE(data.length + 4, 3); // data length 1
+  pkt.writeUInt16LE(data.length, 5); // data length 2
+  pkt.writeUInt16LE(cid, 7);
+
+  data.copy(pkt, 9);
+
+  debug('write acl data pkt - writing: ' + pkt.toString('hex'));
+  this._socket.write(pkt);
+};
+
+Hci.prototype.onSocketData = function(data) {
+  debug('onSocketData: ' + data.toString('hex'));
+
+  var eventType = data.readUInt8(0);
+  var handle;
+
+  debug('\tevent type = ' + eventType);
+
+  if (HCI_EVENT_PKT === eventType) {
+    var subEventType = data.readUInt8(1);
+
+    debug('\tsub event type = ' + subEventType);
+
+    if (subEventType === EVT_DISCONN_COMPLETE) {
+      handle =  data.readUInt16LE(4);
+      var reason = data.readUInt8(6);
+
+      debug('\t\thandle = ' + handle);
+      debug('\t\treason = ' + reason);
+
+      this.emit('disconnComplete', handle, reason);
+    } else if (subEventType === EVT_ENCRYPT_CHANGE) {
+      handle =  data.readUInt16LE(4);
+      var encrypt = data.readUInt8(6);
+
+      debug('\t\thandle = ' + handle);
+      debug('\t\tencrypt = ' + encrypt);
+
+      this.emit('encryptChange', handle, encrypt);
+    } else if (subEventType === EVT_CMD_COMPLETE) {
+      var cmd = data.readUInt16LE(4);
+      var status = data.readUInt8(6);
+      var result = data.slice(7);
+
+      debug('\t\tcmd = ' + cmd);
+      debug('\t\tstatus = ' + status);
+      debug('\t\tresult = ' + result.toString('hex'));
+
+      this.processCmdCompleteEvent(cmd, status, result);
+    } else if (subEventType === EVT_LE_META_EVENT) {
+      var leMetaEventType = data.readUInt8(3);
+      var leMetaEventStatus = data.readUInt8(4);
+      var leMetaEventData = data.slice(5);
+
+      debug('\t\tLE meta event type = ' + leMetaEventType);
+      debug('\t\tLE meta event status = ' + leMetaEventStatus);
+      debug('\t\tLE meta event data = ' + leMetaEventData.toString('hex'));
+
+      this.processLeMetaEvent(leMetaEventType, leMetaEventStatus, leMetaEventData);
+    }
+  } else if (HCI_ACLDATA_PKT === eventType) {
+    var flags = data.readUInt16LE(1) >> 12;
+    handle = data.readUInt16LE(1) & 0x0fff;
+
+    if (ACL_START === flags) {
+      var cid = data.readUInt16LE(7);
+
+      var length = data.readUInt16LE(5);
+      var pktData = data.slice(9);
+
+      debug('\t\tcid = ' + cid);
+
+      if (length === pktData.length) {
+        debug('\t\thandle = ' + handle);
+        debug('\t\tdata = ' + pktData.toString('hex'));
+
+        this.emit('aclDataPkt', handle, cid, pktData);
+      } else {
+        this._handleBuffers[handle] = {
+          length: length,
+          cid: cid,
+          data: pktData
+        };
+      }
+    } else if (ACL_CONT === flags) {
+      if (!this._handleBuffers[handle] || !this._handleBuffers[handle].data) {
+        return;
+      }
+
+      this._handleBuffers[handle].data = Buffer.concat([
+        this._handleBuffers[handle].data,
+        data.slice(5)
+      ]);
+
+      if (this._handleBuffers[handle].data.length === this._handleBuffers[handle].length) {
+        this.emit('aclDataPkt', handle, this._handleBuffers[handle].cid, this._handleBuffers[handle].data);
+
+        delete this._handleBuffers[handle];
+      }
+    }
+  }
+};
+
+Hci.prototype.onSocketError = function(error) {
+  debug('onSocketError: ' + error.message);
+
+  if (error.message === 'Operation not permitted') {
+    this.emit('stateChange', 'unauthorized');
+  } else if (error.message === 'Network is down') {
+    // no-op
+  }
+};
+
+Hci.prototype.processCmdCompleteEvent = function(cmd, status, result) {
+  var handle;
+
+  if (cmd === RESET_CMD) {
+
+    this.setEventMask();
+    this.setLeEventMask();
+    this.readLocalVersion();
+    this.writeLeHostSupported();
+    this.readLeHostSupported();
+    this.readBdAddr();
+  } else if (cmd === READ_LE_HOST_SUPPORTED_CMD) {
+    if (status === 0) {
+      var le = result.readUInt8(0);
+      var simul = result.readUInt8(1);
+
+      debug('\t\t\tle = ' + le);
+      debug('\t\t\tsimul = ' + simul);
+    }
+  } else if (cmd === READ_LOCAL_VERSION_CMD) {
+    var hciVer = result.readUInt8(0);
+    var hciRev = result.readUInt16LE(1);
+    var lmpVer = result.readInt8(3);
+    var manufacturer = result.readUInt16LE(4);
+    var lmpSubVer = result.readUInt16LE(6);
+
+    if (hciVer < 0x06) {
+      this.emit('stateChange', 'unsupported');
+    } else if (this._state !== 'poweredOn') {
+      this.setAdvertiseEnable(false);
+      this.setAdvertisingParameters();
+    }
+
+    this.emit('readLocalVersion', hciVer, hciRev, lmpVer, manufacturer, lmpSubVer);
+  } else if (cmd === READ_BD_ADDR_CMD) {
+    this.addressType = 'public';
+    this.address = result.toString('hex').match(/.{1,2}/g).reverse().join(':');
+
+    debug('address = ' + this.address);
+
+    this.emit('addressChange', this.address);
+  } else if (cmd === LE_SET_ADVERTISING_PARAMETERS_CMD) {
+    this.emit('stateChange', 'poweredOn');
+
+    this.emit('leAdvertisingParametersSet', status);
+  } else if (cmd === LE_SET_ADVERTISING_DATA_CMD) {
+    this.emit('leAdvertisingDataSet', status);
+  } else if (cmd === LE_SET_SCAN_RESPONSE_DATA_CMD) {
+    this.emit('leScanResponseDataSet', status);
+  } else if (cmd === LE_SET_ADVERTISE_ENABLE_CMD) {
+    this.emit('leAdvertiseEnableSet', status);
+  } else if (cmd === READ_RSSI_CMD) {
+    handle = result.readUInt16LE(0);
+    var rssi = result.readInt8(2);
+
+    debug('\t\t\thandle = ' + handle);
+    debug('\t\t\trssi = ' + rssi);
+
+    this.emit('rssiRead', handle, rssi);
+  } else if (cmd === LE_LTK_NEG_REPLY_CMD) {
+    handle = result.readUInt16LE(0);
+
+    debug('\t\t\thandle = ' + handle);
+    this.emit('leLtkNegReply', handle);
+  }
+};
+
+Hci.prototype.processLeMetaEvent = function(eventType, status, data) {
+  if (eventType === EVT_LE_CONN_COMPLETE) {
+    this.processLeConnComplete(status, data);
+  } else if (eventType === EVT_LE_CONN_UPDATE_COMPLETE) {
+    this.processLeConnUpdateComplete(status, data);
+  }
+};
+
+Hci.prototype.processLeConnComplete = function(status, data) {
+  var handle = data.readUInt16LE(0);
+  var role = data.readUInt8(2);
+  var addressType = data.readUInt8(3) === 0x01 ? 'random': 'public';
+  var address = data.slice(4, 10).toString('hex').match(/.{1,2}/g).reverse().join(':');
+  var interval = data.readUInt16LE(10) * 1.25;
+  var latency = data.readUInt16LE(12); // TODO: multiplier?
+  var supervisionTimeout = data.readUInt16LE(14) * 10;
+  var masterClockAccuracy = data.readUInt8(16); // TODO: multiplier?
+
+  debug('\t\t\thandle = ' + handle);
+  debug('\t\t\trole = ' + role);
+  debug('\t\t\taddress type = ' + addressType);
+  debug('\t\t\taddress = ' + address);
+  debug('\t\t\tinterval = ' + interval);
+  debug('\t\t\tlatency = ' + latency);
+  debug('\t\t\tsupervision timeout = ' + supervisionTimeout);
+  debug('\t\t\tmaster clock accuracy = ' + masterClockAccuracy);
+
+  this.emit('leConnComplete', status, handle, role, addressType, address, interval, latency, supervisionTimeout, masterClockAccuracy);
+};
+
+Hci.prototype.processLeConnUpdateComplete = function(status, data) {
+  var handle = data.readUInt16LE(0);
+  var interval = data.readUInt16LE(2) * 1.25;
+  var latency = data.readUInt16LE(4); // TODO: multiplier?
+  var supervisionTimeout = data.readUInt16LE(6) * 10;
+
+  debug('\t\t\thandle = ' + handle);
+  debug('\t\t\tinterval = ' + interval);
+  debug('\t\t\tlatency = ' + latency);
+  debug('\t\t\tsupervision timeout = ' + supervisionTimeout);
+
+  this.emit('leConnUpdateComplete', status, handle, interval, latency, supervisionTimeout);
+};
+
+Hci.prototype.onStateChange = function(state) {
+  this._state = state;
+};
+
+module.exports = Hci;

--- a/src/js/ble_hci_socket_hci_status.js
+++ b/src/js/ble_hci_socket_hci_status.js
@@ -1,0 +1,103 @@
+/* Copyright 2016-present Samsung Electronics Co., Ltd. and other contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/* Copyright (C) 2015 Sandeep Mistry sandeep.mistry@gmail.com
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+[
+  "Success",
+  "Unknown HCI Command",
+  "Unknown Connection Identifier",
+  "Hardware Failure",
+  "Page Timeout",
+  "Authentication Failure",
+  "PIN or Key Missing",
+  "Memory Capacity Exceeded",
+  "Connection Timeout",
+  "Connection Limit Exceeded",
+  "Synchronous Connection Limit to a Device Exceeded",
+  "ACL Connection Already Exists",
+  "Command Disallowed",
+  "Connection Rejected due to Limited Resources",
+  "Connection Rejected due to Security Reasons",
+  "Connection Rejected due to Unacceptable BD_ADDR",
+  "Connection Accept Timeout Exceeded",
+  "Unsupported Feature or Parameter Value",
+  "Invalid HCI Command Parameters",
+  "Remote User Terminated Connection",
+  "Remote Device Terminated due to Low Resources",
+  "Remote Device Terminated due to Power Off",
+  "Connection Terminated By Local Host",
+  "Repeated Attempts",
+  "Pairing Not Allowed",
+  "Unknown LMP PDU",
+  "Unsupported Remote Feature / Unsupported LMP Feature",
+  "SCO Offset Rejected",
+  "SCO Interval Rejected",
+  "SCO Air Mode Rejected",
+  "Invalid LMP Parameters / Invalid LL Parameters",
+  "Unspecified Error",
+  "Unsupported LMP Parameter Value / Unsupported LL Parameter Value",
+  "Role Change Not Allowed",
+  "LMP Response Timeout / LL Response Timeout",
+  "LMP Error Transaction Collision",
+  "LMP PDU Not Allowed",
+  "Encryption Mode Not Acceptable",
+  "Link Key cannot be Changed",
+  "Requested QoS Not Supported",
+  "Instant Passed",
+  "Pairing With Unit Key Not Supported",
+  "Different Transaction Collision",
+  "Reserved",
+  "QoS Unacceptable Parameter",
+  "QoS Rejected",
+  "Channel Classification Not Supported",
+  "Insufficient Security",
+  "Parameter Out Of Manadatory Range",
+  "Reserved",
+  "Role Switch Pending",
+  "Reserved",
+  "Reserved Slot Violation",
+  "Role Switch Failed",
+  "Extended Inquiry Response Too Large",
+  "Secure Simple Pairing Not Supported By Host",
+  "Host Busy - Pairing",
+  "Connection Rejected due to No Suitable Channel Found",
+  "Controller Busy",
+  "Unacceptable Connection Parameters" ,
+  "Directed Advertising Timeout",
+  "Connection Terminated due to MIC Failure",
+  "Connection Failed to be Established",
+  "MAC Connection Failed",
+  "Coarse Clock Adjustment Rejected but Will Try to Adjust Using Clock Dragging"
+]

--- a/src/js/ble_hci_socket_mgmt.js
+++ b/src/js/ble_hci_socket_mgmt.js
@@ -1,0 +1,126 @@
+/* Copyright 2016-present Samsung Electronics Co., Ltd. and other contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/* Copyright (C) 2015 Sandeep Mistry sandeep.mistry@gmail.com
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+var debug = console.log; // requir('debug')('ble_mgmt');
+
+var events = require('events');
+var util = require('util');
+
+var BluetoothHciSocket = require('ble_hci_socket');
+
+var LTK_INFO_SIZE = 36;
+
+var MGMT_OP_LOAD_LONG_TERM_KEYS = 0x0013;
+
+function Mgmt() {
+  this._socket = new BluetoothHciSocket();
+  this._ltkInfos = [];
+
+  this._socket.on('data', this.onSocketData.bind(this));
+  this._socket.on('error', this.onSocketError.bind(this));
+
+  this._socket.bindControl();
+  this._socket.start();
+}
+
+Mgmt.prototype.onSocketData = function(data) {
+  debug('on data ->' + data.toString('hex'));
+};
+
+Mgmt.prototype.onSocketError = function(error) {
+  debug('on error ->' + error.message);
+};
+
+Mgmt.prototype.addLongTermKey = function(address, addressType, authenticated, master, ediv, rand, key) {
+  var ltkInfo = new Buffer(LTK_INFO_SIZE);
+
+  address.copy(ltkInfo, 0);
+  ltkInfo.writeUInt8(addressType.readUInt8(0) + 1, 6); // BDADDR_LE_PUBLIC = 0x01, BDADDR_LE_RANDOM 0x02, so add one
+
+  ltkInfo.writeUInt8(authenticated, 7);
+  ltkInfo.writeUInt8(master, 8);
+  ltkInfo.writeUInt8(key.length, 9);
+
+  ediv.copy(ltkInfo, 10);
+  rand.copy(ltkInfo, 12);
+  key.copy(ltkInfo, 20);
+
+  this._ltkInfos.push(ltkInfo);
+
+  this.loadLongTermKeys();
+};
+
+Mgmt.prototype.clearLongTermKeys = function() {
+  this._ltkInfos = [];
+
+  this.loadLongTermKeys();
+};
+
+Mgmt.prototype.loadLongTermKeys = function() {
+  var numLongTermKeys = this._ltkInfos.length;
+  var op = new Buffer(2 + numLongTermKeys * LTK_INFO_SIZE);
+
+  op.writeUInt16LE(numLongTermKeys, 0);
+
+  for (var i = 0; i < numLongTermKeys; i++) {
+    this._ltkInfos[i].copy(op, 2 + i * LTK_INFO_SIZE);
+  }
+
+  this.write(MGMT_OP_LOAD_LONG_TERM_KEYS, 0, op);
+};
+
+Mgmt.prototype.write = function(opcode, index, data) {
+  var length = 0;
+
+  if (data) {
+    length = data.length;
+  }
+
+  var pkt = new Buffer(6 + length);
+
+  pkt.writeUInt16LE(opcode, 0);
+  pkt.writeUInt16LE(index, 2);
+  pkt.writeUInt16LE(length, 4);
+
+  if (length) {
+    data.copy(pkt, 6);
+  }
+
+  debug('writing -> ' + pkt.toString('hex'));
+  this._socket.write(pkt);
+};
+
+module.exports = new Mgmt();

--- a/src/js/ble_hci_socket_smp.js
+++ b/src/js/ble_hci_socket_smp.js
@@ -1,0 +1,198 @@
+/* Copyright 2016-present Samsung Electronics Co., Ltd. and other contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/* Copyright (C) 2015 Sandeep Mistry sandeep.mistry@gmail.com
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+var debug = console.log; //requir('debug')('ble_hci_socket_smp');
+
+var events = require('events');
+var util = require('util');
+
+var crypto = require('ble_hci_socket_crypto');
+var mgmt = require('ble_hci_socket_mgmt');
+
+var SMP_CID = 0x0006;
+
+var SMP_PAIRING_REQUEST = 0x01;
+var SMP_PAIRING_RESPONSE = 0x02;
+var SMP_PAIRING_CONFIRM = 0x03;
+var SMP_PAIRING_RANDOM = 0x04;
+var SMP_PAIRING_FAILED = 0x05;
+var SMP_ENCRYPT_INFO = 0x06;
+var SMP_MASTER_IDENT = 0x07;
+
+var SMP_UNSPECIFIED = 0x08;
+
+var Smp = function(aclStream, localAddressType, localAddress, remoteAddressType, remoteAddress) {
+  this._aclStream = aclStream;
+
+  this._iat = new Buffer([(remoteAddressType === 'random') ? 0x01 : 0x00]);
+  this._ia = new Buffer(remoteAddress.split(':').reverse().join(''), 'hex');
+  this._rat = new Buffer([(localAddressType === 'random') ? 0x01 : 0x00]);
+  this._ra = new Buffer(localAddress.split(':').reverse().join(''), 'hex');
+
+  this._stk = null;
+  this._random = null;
+  this._diversifier = null;
+
+  this.onAclStreamDataBinded = this.onAclStreamData.bind(this);
+  this.onAclStreamEncryptChangeBinded = this.onAclStreamEncryptChange.bind(this);
+  this.onAclStreamLtkNegReplyBinded = this.onAclStreamLtkNegReply.bind(this);
+  this.onAclStreamEndBinded = this.onAclStreamEnd.bind(this);
+
+  this._aclStream.on('data', this.onAclStreamDataBinded);
+  this._aclStream.on('encryptChange', this.onAclStreamEncryptChangeBinded);
+  this._aclStream.on('ltkNegReply', this.onAclStreamLtkNegReplyBinded);
+  this._aclStream.on('end', this.onAclStreamEndBinded);
+};
+
+util.inherits(Smp, events.EventEmitter);
+
+Smp.prototype.onAclStreamData = function(cid, data) {
+  if (cid !== SMP_CID) {
+    return;
+  }
+
+  var code = data.readUInt8(0);
+
+  if (SMP_PAIRING_REQUEST === code) {
+    this.handlePairingRequest(data);
+  } else if (SMP_PAIRING_CONFIRM === code) {
+    this.handlePairingConfirm(data);
+  } else if (SMP_PAIRING_RANDOM === code) {
+    this.handlePairingRandom(data);
+  } else if (SMP_PAIRING_FAILED === code) {
+    this.handlePairingFailed(data);
+  }
+};
+
+Smp.prototype.onAclStreamEncryptChange = function(encrypted) {
+  if (encrypted) {
+    if (this._stk && this._diversifier && this._random) {
+      this.write(Buffer.concat([
+        new Buffer([SMP_ENCRYPT_INFO]),
+        this._stk
+      ]));
+
+      this.write(Buffer.concat([
+        new Buffer([SMP_MASTER_IDENT]),
+        this._diversifier,
+        this._random
+      ]));
+    }
+  }
+};
+
+Smp.prototype.onAclStreamLtkNegReply = function() {
+    this.write(new Buffer([
+      SMP_PAIRING_FAILED,
+      SMP_UNSPECIFIED
+    ]));
+
+    this.emit('fail');
+};
+
+Smp.prototype.onAclStreamEnd = function() {
+  this._aclStream.removeListener('data', this.onAclStreamDataBinded);
+  this._aclStream.removeListener('encryptChange', this.onAclStreamEncryptChangeBinded);
+  this._aclStream.removeListener('ltkNegReply', this.onAclStreamLtkNegReplyBinded);
+  this._aclStream.removeListener('end', this.onAclStreamEndBinded);
+};
+
+Smp.prototype.handlePairingRequest = function(data) {
+  this._preq = data;
+
+  this._pres = new Buffer([
+    SMP_PAIRING_RESPONSE,
+    0x03, // IO capability: NoInputNoOutput
+    0x00, // OOB data: Authentication data not present
+    0x01, // Authentication requirement: Bonding - No MITM
+    0x10, // Max encryption key size
+    0x00, // Initiator key distribution: <none>
+    0x01  // Responder key distribution: EncKey
+  ]);
+
+  this.write(this._pres);
+};
+
+Smp.prototype.handlePairingConfirm = function(data) {
+  this._pcnf = data;
+
+  this._tk = new Buffer('00000000000000000000000000000000', 'hex');
+  this._r = crypto.r();
+
+  this.write(Buffer.concat([
+    new Buffer([SMP_PAIRING_CONFIRM]),
+    crypto.c1(this._tk, this._r, this._pres, this._preq, this._iat, this._ia, this._rat, this._ra)
+  ]));
+};
+
+Smp.prototype.handlePairingRandom = function(data) {
+  var r = data.slice(1);
+
+  var pcnf = Buffer.concat([
+    new Buffer([SMP_PAIRING_CONFIRM]),
+    crypto.c1(this._tk, r, this._pres, this._preq, this._iat, this._ia, this._rat, this._ra)
+  ]);
+
+  if (this._pcnf.toString('hex') === pcnf.toString('hex')) {
+    this._diversifier = new Buffer('0000', 'hex');
+    this._random = new Buffer('0000000000000000', 'hex');
+    this._stk = crypto.s1(this._tk, this._r, r);
+
+    mgmt.addLongTermKey(this._ia, this._iat, 0, 0, this._diversifier, this._random, this._stk);
+
+    this.write(Buffer.concat([
+      new Buffer([SMP_PAIRING_RANDOM]),
+      this._r
+    ]));
+  } else {
+    this.write(new Buffer([
+      SMP_PAIRING_FAILED,
+      SMP_PAIRING_CONFIRM
+    ]));
+
+    this.emit('fail');
+  }
+};
+
+Smp.prototype.handlePairingFailed = function(data) {
+  this.emit('fail');
+};
+
+Smp.prototype.write = function(data) {
+  this._aclStream.write(SMP_CID, data);
+};
+
+module.exports = Smp;

--- a/src/js/ble_primary_service.js
+++ b/src/js/ble_primary_service.js
@@ -1,0 +1,58 @@
+/* Copyright 2016-present Samsung Electronics Co., Ltd. and other contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/* Copyright (C) 2015 Sandeep Mistry sandeep.mistry@gmail.com
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+var events = require('events');
+var util = require('util');
+
+var debug = console.log; //requir('debug')('ble_primary_service');
+
+var UuidUtil = require('ble_uuid_util');
+
+function PrimaryService(options) {
+  this.uuid = UuidUtil.removeDashes(options.uuid);
+  this.characteristics = options.characteristics || [];
+}
+
+util.inherits(PrimaryService, events.EventEmitter);
+
+PrimaryService.prototype.toString = function() {
+  return JSON.stringify({
+    uuid: this.uuid,
+    characteristics: this.characteristics
+  });
+};
+
+module.exports = PrimaryService;

--- a/src/js/ble_uuid_util.js
+++ b/src/js/ble_uuid_util.js
@@ -1,0 +1,43 @@
+/* Copyright 2016-present Samsung Electronics Co., Ltd. and other contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/* Copyright (C) 2015 Sandeep Mistry sandeep.mistry@gmail.com
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+module.exports.removeDashes = function(uuid) {
+  if (uuid) {
+    uuid = uuid.replace(/-/g, '');
+  }
+
+  return uuid;
+};

--- a/src/module/iotjs_module_blehcisocket.c
+++ b/src/module/iotjs_module_blehcisocket.c
@@ -73,16 +73,25 @@ JHANDLER_FUNCTION(Start) {
 
 JHANDLER_FUNCTION(BindRaw) {
   JHANDLER_CHECK_THIS(object);
-  // JHANDLER_CHECK_ARGS(1, number);
+  JHANDLER_CHECK(ge(iotjs_jhandler_get_arg_length(jhandler), 1));
 
   const iotjs_jval_t* jblehcisocket = JHANDLER_GET_THIS(object);
 
   iotjs_blehcisocket_t* blehcisocket =
       iotjs_blehcisocket_instance_from_jval(jblehcisocket);
 
-  iotjs_blehcisocket_bindRaw(blehcisocket, 0);
+  int devId = 0;
+  int* pDevId = NULL;
 
-  // iotjs_jhandler_return_null(jhandler);
+  const iotjs_jval_t* raw = iotjs_jhandler_get_arg(jhandler, 0);
+  if (iotjs_jval_is_number(raw)) {
+    devId = iotjs_jval_as_number(raw);
+    pDevId = &devId;
+  }
+
+  int ret = iotjs_blehcisocket_bindRaw(blehcisocket, pDevId);
+
+  iotjs_jhandler_return_number(jhandler, ret);
 }
 
 

--- a/src/platform/iotjs_module_blehcisocket-linux-general.inl.h
+++ b/src/platform/iotjs_module_blehcisocket-linux-general.inl.h
@@ -67,6 +67,27 @@ void iotjs_blehcisocket_setFilter(THIS, char* data, int length) {
 
 void iotjs_blehcisocket_poll(THIS) {
   IOTJS_VALIDATED_STRUCT_METHOD(iotjs_blehcisocket_t, blehcisocket);
+
+  //
+  // emit('data') implementation
+  //
+  // iotjs_jval_t* jhcisocket = iotjs_jobjectwrap_jobject(&_this->jobjectwrap);
+  // iotjs_jval_t jemit = iotjs_jval_get_property(jhcisocket, "emit");
+  // IOTJS_ASSERT(iotjs_jval_is_function(&jemit));
+
+  // iotjs_jargs_t jargs = iotjs_jargs_create(2);
+  // iotjs_jval_t str = iotjs_jval_create_string_raw("data");
+  // iotjs_jval_t jbuf = iotjs_bufferwrap_create_buffer(length);
+  // iotjs_bufferwrap_t* buf_wrap = iotjs_bufferwrap_from_jbuffer(&jbuf);
+  // iotjs_bufferwrap_copy(buf_wrap, data, length);
+  // iotjs_jargs_append_jval(&jargs, &str);
+  // iotjs_jargs_append_jval(&jargs, &jbuf);
+  // iotjs_jhelper_call_ok(&jemit, jhcisocket, &jargs);
+
+  // iotjs_jval_destroy(&str);
+  // iotjs_jval_destroy(&jbuf);
+  // iotjs_jargs_destroy(&jargs);
+  // iotjs_jval_destroy(&jemit);
 }
 
 

--- a/test/run_pass/test_ble_advertisement.js
+++ b/test/run_pass/test_ble_advertisement.js
@@ -19,10 +19,9 @@ ble.on('stateChange', function(state){
   console.log('onStateChange: ' + state);
 
   if (state == 'poweredOn') {
-    ble.startAdvertising('test', ['180F'], function(err) {
+    ble.startAdvertising('iotjs', ['180F'], function(err) {
       if (err) console.log(err);
       else {
-        console.log('advertising start success.');
 
         setTimeout(function() {
           ble.stopAdvertising(function(err) {

--- a/test/run_pass/test_ble_setservices.js
+++ b/test/run_pass/test_ble_setservices.js
@@ -1,0 +1,114 @@
+/* Copyright 2017-present Samsung Electronics Co., Ltd. and other contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/* Copyright (C) 2015 Sandeep Mistry sandeep.mistry@gmail.com
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+var ble = require('ble');
+
+var BlenoPrimaryService = ble.PrimaryService;
+var BlenoCharacteristic = ble.Characteristic;
+
+var util = require('util');
+
+var EchoCharacteristic = function() {
+  BlenoCharacteristic.call(this, {
+    uuid: 'ec0e',
+    properties: ['read', 'write', 'notify'],
+    value: null
+  });
+
+  this._value = new Buffer(0);
+  this._updateValueCallback = null;
+};
+
+util.inherits(EchoCharacteristic, BlenoCharacteristic);
+
+EchoCharacteristic.prototype.onReadRequest = function(offset, callback) {
+  console.log('EchoCharacteristic - onReadRequest: value = ' + this._value.toString('hex'));
+
+  callback(this.RESULT_SUCCESS, this._value);
+};
+
+EchoCharacteristic.prototype.onWriteRequest = function(data, offset, withoutResponse, callback) {
+  this._value = data;
+
+  console.log('EchoCharacteristic - onWriteRequest: value = ' + this._value.toString('hex'));
+
+  if (this._updateValueCallback) {
+    console.log('EchoCharacteristic - onWriteRequest: notifying');
+
+    this._updateValueCallback(this._value);
+  }
+
+  callback(this.RESULT_SUCCESS);
+};
+
+EchoCharacteristic.prototype.onSubscribe = function(maxValueSize, updateValueCallback) {
+  console.log('EchoCharacteristic - onSubscribe');
+
+  this._updateValueCallback = updateValueCallback;
+};
+
+EchoCharacteristic.prototype.onUnsubscribe = function() {
+  console.log('EchoCharacteristic - onUnsubscribe');
+
+  this._updateValueCallback = null;
+};
+
+console.log('ble - echo');
+
+ble.on('stateChange', function(state) {
+  console.log('on -> stateChange: ' + state);
+
+  if (state === 'poweredOn') {
+    ble.startAdvertising('iotjs_echo', ['ec00']);
+  } else {
+    ble.stopAdvertising();
+  }
+});
+
+ble.on('advertisingStart', function(error) {
+  console.log('on -> advertisingStart: ' + (error ? 'error ' + error : 'success'));
+
+  if (!error) {
+    ble.setServices([
+      new BlenoPrimaryService({
+        uuid: 'ec00',
+        characteristics: [
+          new EchoCharacteristic()
+        ]
+      })
+    ]);
+  }
+});

--- a/tools/check_tidy.py
+++ b/tools/check_tidy.py
@@ -154,7 +154,18 @@ def check_tidy(src_dir):
     clang_format_exts = ['.c', '.h']
     skip_dirs = ['deps', 'build', '.git']
     skip_files = ['check_signed_off.sh', '__init__.py',
-                  'iotjs_js.c', 'iotjs_js.h', 'iotjs_string_ext.inl.h']
+                  'iotjs_js.c', 'iotjs_js.h', 'iotjs_string_ext.inl.h',
+                  'ble.js',
+                  'ble_hci_socket_acl_stream.js',
+                  'ble_hci_socket_smp.js',
+                  'ble_hci_socket_hci.js',
+                  'ble_hci_socket_gap.js',
+                  'ble_hci_socket_gatt.js',
+                  'ble_hci_socket_mgmt.js',
+                  'ble_hci_socket_bindings.js',
+                  'ble_characteristic.js',
+                  'test_ble_setservices.js',
+                  ]
 
     style = StyleChecker()
     clang = ClangFormat(clang_format_exts, skip_files)


### PR DESCRIPTION
BLE peripheral is implemented based on bleno open source.

Here are main modifications to bleno in JS:

- Put all bleno js files in our js folder by prefixing ble_ and ble_hci_socket
 : Our module system currently does not use subdirectory.

- Replace minus('-') in js module name to underscore ('_')
 : We produce C file from *.js which requires not including '-'.

- `require` statement in comment are renamed to `requir`
 : module dependency analyzer does not recognize it is in comment.

- require('./blahblah') is changed to require('blahblah')
 : require does not accept the string prefixed with './'

- require('os') is removed, that we don't provide.
 : For os.platform, I replaced it with process.platform. But I just
   removed os.hostname(), os.release()

- Replace buf[idx] with buf.readUInt8 or buf.writeUInt8
 : Currently we don't support buf[idx] operator.
   So we replace the buf[idx] usage in BLE module and examples with
   buf.readUInt8 or buf.writeUInt8. buf[idx] will be implemented later.

- Make testcase by simplifying and modifying bleno's echo sample
 : Remove super_. We don't support super_.

- Add bleno license and our license to every imported file

Native functions (bindRaw and emit('data')) are implemented:

- Main modification are C++ to C, and node binding to iotjs binding.

IoT.js-DCO-1.0-Signed-off-by: Sanggyu Lee sg5.lee@samsung.com