### PR TITLE
Fix scope in modules (#617)

### DIFF
--- a/src/js/module.js
+++ b/src/js/module.js
@@ -185,7 +185,7 @@ iotjs_module_t.prototype.compile = function() {
 
   var source = process.readSource(self.filename);
   var fn = process.compile(source);
-  fn.call(self, self.exports, requireForThis, self);
+  fn.call(self.exports, self.exports, requireForThis, self);
 };
 
 


### PR DESCRIPTION
`this` refers to the `exports` in Node.js

Signed-off-by: Lauri Rooden <lauri@rooden.ee>