### PR TITLE
Remove capacity attribute of iotjs_string_t.

### DIFF
--- a/src/iotjs_binding.c
+++ b/src/iotjs_binding.c
@@ -223,7 +223,7 @@ iotjs_string_t iotjs_jval_as_string(const iotjs_jval_t* jval) {
   jerry_size_t size = jerry_get_string_size(_this->value);
 
   if (size == 0)
-    return iotjs_string_create("");
+    return iotjs_string_create();
 
   char* buffer = iotjs_buffer_allocate(size + 1);
   jerry_char_t* jerry_buffer = (jerry_char_t*)(buffer);

--- a/src/iotjs_string.c
+++ b/src/iotjs_string.c
@@ -21,42 +21,43 @@
 #include <string.h>
 
 
-static char iotjs_empty_string[] = { '\0' };
+iotjs_string_t iotjs_string_create() {
+  iotjs_string_t str;
+  IOTJS_VALIDATED_STRUCT_CONSTRUCTOR(iotjs_string_t, &str);
 
+  _this->size = 0;
+  _this->data = NULL;
 
-iotjs_string_t iotjs_string_create(const char* data) {
-  return iotjs_string_create_with_size(data, strlen(data));
+  return str;
 }
 
 
-iotjs_string_t iotjs_string_create_with_size(const char* data, unsigned size) {
+iotjs_string_t iotjs_string_create_with_size(const char* data, uint32_t size) {
   iotjs_string_t str;
   IOTJS_VALIDATED_STRUCT_CONSTRUCTOR(iotjs_string_t, &str);
 
   IOTJS_ASSERT(data != NULL);
-  IOTJS_ASSERT(strnlen(data, size) == size); // forbidden due to ambiguity
 
-  _this->size = _this->cap = size;
+  _this->size = size;
 
   if (size > 0) {
-    _this->data = iotjs_buffer_allocate(size + 1);
+    _this->data = iotjs_buffer_allocate(size);
     memcpy(_this->data, data, size);
-    _this->data[size] = '\0';
   } else {
-    _this->data = iotjs_empty_string;
+    _this->data = NULL;
   }
 
   return str;
 }
 
 
-iotjs_string_t iotjs_string_create_with_buffer(char* buffer, unsigned size) {
+iotjs_string_t iotjs_string_create_with_buffer(char* buffer, uint32_t size) {
   iotjs_string_t str;
   IOTJS_VALIDATED_STRUCT_CONSTRUCTOR(iotjs_string_t, &str);
 
   IOTJS_ASSERT(buffer != NULL);
 
-  _this->size = _this->cap = size;
+  _this->size = size;
   _this->data = buffer;
 
   return str;
@@ -66,25 +67,10 @@ iotjs_string_t iotjs_string_create_with_buffer(char* buffer, unsigned size) {
 void iotjs_string_destroy(iotjs_string_t* str) {
   IOTJS_VALIDATED_STRUCT_DESTRUCTOR(iotjs_string_t, str);
 
-  if (_this->data != iotjs_empty_string) {
+  if (_this->data != NULL) {
     iotjs_buffer_release(_this->data);
+    _this->size = 0;
   }
-}
-
-
-void iotjs_string_reserve(iotjs_string_t* str, unsigned capacity) {
-  IOTJS_VALIDATED_STRUCT_METHOD(iotjs_string_t, str);
-
-  if (_this->cap >= capacity)
-    return;
-
-  if (_this->cap == 0) {
-    IOTJS_ASSERT(_this->data == iotjs_empty_string);
-    _this->data = iotjs_buffer_allocate(capacity + 1);
-  } else {
-    _this->data = iotjs_buffer_reallocate(_this->data, capacity + 1);
-  }
-  _this->cap = capacity;
 }
 
 
@@ -98,57 +84,41 @@ bool iotjs_string_is_empty(const iotjs_string_t* str) {
 void iotjs_string_make_empty(iotjs_string_t* str) {
   IOTJS_VALIDATED_STRUCT_METHOD(iotjs_string_t, str);
 
-  if (_this->data != iotjs_empty_string) {
+  if (_this->data != NULL) {
     iotjs_buffer_release(_this->data);
-    _this->cap = _this->size = 0;
-    _this->data = iotjs_empty_string;
+    _this->size = 0;
+    _this->data = NULL;
   }
 }
 
 
-void iotjs_string_append(iotjs_string_t* str, const char* data, int size) {
+void iotjs_string_append(iotjs_string_t* str, const char* data, uint32_t size) {
   IOTJS_VALIDATED_STRUCT_METHOD(iotjs_string_t, str);
 
-  const int kCapacityIncreaseFactor = 2;
+  IOTJS_ASSERT(data != NULL);
 
-  IOTJS_ASSERT(_this->data != NULL);
-  IOTJS_ASSERT(_this->cap >= _this->size);
-
-  if (size < 0) {
-    size = strlen(data);
-  }
   if (size == 0) {
     return;
   }
 
-  if (_this->cap == 0) {
-    // No buffer was allocated.
-    IOTJS_ASSERT(_this->size == 0);
-    IOTJS_ASSERT(_this->data == iotjs_empty_string);
-    _this->cap = _this->size = size;
-    _this->data = iotjs_buffer_allocate(_this->cap + 1);
-    strncpy(_this->data, data, _this->size);
-  } else if (_this->cap >= _this->size + size) {
-    // Have enough capacity to append data.
-    strncpy(_this->data + _this->size, data, size);
-    _this->size += size;
+  if (_this->data != NULL) {
+    _this->data = iotjs_buffer_reallocate(_this->data, _this->size + size);
   } else {
-    // Lack of capacity, calculate next capacity.
-    while (_this->cap < _this->size + size) {
-      _this->cap *= kCapacityIncreaseFactor;
-    }
-    // Reallocate buffer and copy data.
-    _this->data = iotjs_buffer_reallocate(_this->data, _this->cap + 1);
-    strncpy(_this->data + _this->size, data, size);
-    _this->size += size;
+    IOTJS_ASSERT(_this->size == 0);
+    _this->data = iotjs_buffer_allocate(size);
   }
-  _this->data[_this->size] = 0;
+
+  memcpy(_this->data + _this->size, data, size);
+  _this->size += size;
 }
 
 
 const char* iotjs_string_data(const iotjs_string_t* str) {
   const IOTJS_VALIDATED_STRUCT_METHOD(iotjs_string_t, str);
-  IOTJS_ASSERT(_this->data != NULL);
+  if (_this->data == NULL) {
+    return "";
+  }
+
   return _this->data;
 }
 

--- a/src/iotjs_string.h
+++ b/src/iotjs_string.h
@@ -18,21 +18,17 @@
 
 
 typedef struct {
-  unsigned size;
-  unsigned cap;
+  uint32_t size;
   char* data;
 } IOTJS_VALIDATED_STRUCT(iotjs_string_t);
 
 // Create new string
-iotjs_string_t iotjs_string_create(const char* data);
-iotjs_string_t iotjs_string_create_with_size(const char* data, unsigned size);
-iotjs_string_t iotjs_string_create_with_buffer(char* buffer, unsigned size);
+iotjs_string_t iotjs_string_create();
+iotjs_string_t iotjs_string_create_with_size(const char* data, uint32_t size);
+iotjs_string_t iotjs_string_create_with_buffer(char* buffer, uint32_t size);
 
 // Destroy string
 void iotjs_string_destroy(iotjs_string_t* str);
-
-// Reserve string capacity
-void iotjs_string_reserve(iotjs_string_t* str, unsigned capacity);
 
 // Check if string is empty
 bool iotjs_string_is_empty(const iotjs_string_t* str);
@@ -41,11 +37,7 @@ bool iotjs_string_is_empty(const iotjs_string_t* str);
 void iotjs_string_make_empty(iotjs_string_t* str);
 
 // Append `data` to tail of the string.
-void iotjs_string_append(iotjs_string_t* str, const char* data, int size);
-static inline void iotjs_string_append_without_size(iotjs_string_t* str,
-                                                    const char* data) {
-  iotjs_string_append(str, data, -1);
-}
+void iotjs_string_append(iotjs_string_t* str, const char* data, uint32_t size);
 
 // Returns pointer to the bytes (never returns NULL)
 const char* iotjs_string_data(const iotjs_string_t* str);

--- a/src/module/iotjs_module_buffer.c
+++ b/src/module/iotjs_module_buffer.c
@@ -458,12 +458,16 @@ JHANDLER_FUNCTION(ToHexString) {
   int length = iotjs_bufferwrap_length(buffer_wrap);
   const char* data = iotjs_bufferwrap_buffer(buffer_wrap);
 
-  iotjs_string_t str = iotjs_string_create("");
-  iotjs_string_reserve(&str, length * 2);
+  char* buffer = iotjs_buffer_allocate(length * 2);
+  iotjs_string_t str = iotjs_string_create_with_buffer(buffer, length * 2);
+
   for (int i = 0; i < length; i++) {
-    iotjs_string_append(&str, &"0123456789abcdef"[data[i] >> 4 & 0xF], 1);
-    iotjs_string_append(&str, &"0123456789abcdef"[data[i] >> 0 & 0xF], 1);
+    memcpy(buffer, &"0123456789abcdef"[data[i] >> 4 & 0xF], 1);
+    buffer++;
+    memcpy(buffer, &"0123456789abcdef"[data[i] >> 0 & 0xF], 1);
+    buffer++;
   }
+
   iotjs_jhandler_return_string(jhandler, &str);
   iotjs_string_destroy(&str);
 }

--- a/src/module/iotjs_module_httpparser.c
+++ b/src/module/iotjs_module_httpparser.c
@@ -36,11 +36,11 @@ iotjs_httpparserwrap_t* iotjs_httpparserwrap_create(const iotjs_jval_t* jparser,
   iotjs_jobjectwrap_initialize(&_this->jobjectwrap, jparser,
                                (JFreeHandlerType)iotjs_httpparserwrap_destroy);
 
-  _this->url = iotjs_string_create("");
-  _this->status_msg = iotjs_string_create("");
+  _this->url = iotjs_string_create();
+  _this->status_msg = iotjs_string_create();
   for (size_t i = 0; i < HEADER_MAX; i++) {
-    _this->fields[i] = iotjs_string_create("");
-    _this->values[i] = iotjs_string_create("");
+    _this->fields[i] = iotjs_string_create();
+    _this->values[i] = iotjs_string_create();
   }
 
   iotjs_httpparserwrap_initialize(httpparserwrap, type);

--- a/src/module/iotjs_module_process.c
+++ b/src/module/iotjs_module_process.c
@@ -38,17 +38,15 @@ static iotjs_jval_t WrapEval(const char* source, size_t length, bool* throws) {
   int len0 = strlen(wrapper[0]);
   int len1 = strlen(wrapper[1]);
 
-  iotjs_string_t code = iotjs_string_create("");
-  iotjs_string_reserve(&code, len0 + length + len1);
-  iotjs_string_append(&code, wrapper[0], len0);
-  iotjs_string_append(&code, source, length);
-  iotjs_string_append(&code, wrapper[1], len1);
+  uint32_t buffer_length = len0 + len1 + length;
+  char* buffer = iotjs_buffer_allocate(buffer_length);
+  memcpy(buffer, wrapper[0], len0);
+  memcpy(buffer + len0, source, length);
+  memcpy(buffer + len0 + length, wrapper[1], len1);
 
-  iotjs_jval_t res =
-      iotjs_jhelper_eval(iotjs_string_data(&code), iotjs_string_size(&code),
-                         false, throws);
+  iotjs_jval_t res = iotjs_jhelper_eval(buffer, buffer_length, false, throws);
 
-  iotjs_string_destroy(&code);
+  iotjs_buffer_release(buffer);
 
   return res;
 }


### PR DESCRIPTION
This patch simplifies the strings in iotjs a bit and save 4 byte for each string.