### PR TITLE
Eliminate the macro generated jump methods

### DIFF
--- a/src/module/iotjs_module_blehcisocket.c
+++ b/src/module/iotjs_module_blehcisocket.c
@@ -227,7 +227,8 @@ JHANDLER_FUNCTION(BleHciSocketCons) {
 
 
 iotjs_jval_t InitBlehcisocket() {
-  iotjs_jval_t jblehcisocketCons = iotjs_jval_create_function(BleHciSocketCons);
+  iotjs_jval_t jblehcisocketCons =
+      iotjs_jval_create_function_with_dispatch(BleHciSocketCons);
 
   iotjs_jval_t prototype = iotjs_jval_create_object();
 

--- a/src/module/iotjs_module_buffer.c
+++ b/src/module/iotjs_module_buffer.c
@@ -483,10 +483,11 @@ JHANDLER_FUNCTION(ByteLength) {
 
 
 iotjs_jval_t InitBuffer() {
-  iotjs_jval_t buffer = iotjs_jval_create_function(Buffer);
+  iotjs_jval_t buffer = iotjs_jval_create_function_with_dispatch(Buffer);
 
   iotjs_jval_t prototype = iotjs_jval_create_object();
-  iotjs_jval_t byte_length = iotjs_jval_create_function(ByteLength);
+  iotjs_jval_t byte_length =
+      iotjs_jval_create_function_with_dispatch(ByteLength);
 
   iotjs_jval_set_property_jval(&buffer, "prototype", &prototype);
   iotjs_jval_set_property_jval(&buffer, "byteLength", &byte_length);

--- a/src/module/iotjs_module_fs.c
+++ b/src/module/iotjs_module_fs.c
@@ -22,6 +22,8 @@
 #include "iotjs_exception.h"
 #include "iotjs_reqwrap.h"
 
+#undef JHANDLER_FUNCTION
+#define JHANDLER_FUNCTION(name) static void name(iotjs_jhandler_t* jhandler)
 
 iotjs_fs_reqwrap_t* iotjs_fs_reqwrap_create(const iotjs_jval_t* jcallback) {
   iotjs_fs_reqwrap_t* fs_reqwrap = IOTJS_ALLOC(iotjs_fs_reqwrap_t);

--- a/src/module/iotjs_module_httpparser.c
+++ b/src/module/iotjs_module_httpparser.c
@@ -461,7 +461,8 @@ JHANDLER_FUNCTION(HTTPParserCons) {
 iotjs_jval_t InitHttpparser() {
   iotjs_jval_t httpparser = iotjs_jval_create_object();
 
-  iotjs_jval_t jParserCons = iotjs_jval_create_function(HTTPParserCons);
+  iotjs_jval_t jParserCons =
+      iotjs_jval_create_function_with_dispatch(HTTPParserCons);
   iotjs_jval_set_property_jval(&httpparser, "HTTPParser", &jParserCons);
 
   iotjs_jval_set_property_number(&jParserCons, "REQUEST", HTTP_REQUEST);

--- a/src/module/iotjs_module_i2c.c
+++ b/src/module/iotjs_module_i2c.c
@@ -440,7 +440,7 @@ JHANDLER_FUNCTION(ReadBlock) {
 
 
 iotjs_jval_t InitI2c() {
-  iotjs_jval_t jI2cCons = iotjs_jval_create_function(I2cCons);
+  iotjs_jval_t jI2cCons = iotjs_jval_create_function_with_dispatch(I2cCons);
 
   iotjs_jval_t prototype = iotjs_jval_create_object();
 

--- a/src/module/iotjs_module_spi.c
+++ b/src/module/iotjs_module_spi.c
@@ -409,7 +409,7 @@ JHANDLER_FUNCTION(Unexport) {
 
 
 iotjs_jval_t InitSpi() {
-  iotjs_jval_t jSpiCons = iotjs_jval_create_function(SpiCons);
+  iotjs_jval_t jSpiCons = iotjs_jval_create_function_with_dispatch(SpiCons);
 
   iotjs_jval_t prototype = iotjs_jval_create_object();
 

--- a/src/module/iotjs_module_tcp.c
+++ b/src/module/iotjs_module_tcp.c
@@ -639,7 +639,7 @@ JHANDLER_FUNCTION(GetSockeName) {
 }
 
 iotjs_jval_t InitTcp() {
-  iotjs_jval_t tcp = iotjs_jval_create_function(TCP);
+  iotjs_jval_t tcp = iotjs_jval_create_function_with_dispatch(TCP);
 
   iotjs_jval_t prototype = iotjs_jval_create_object();
   iotjs_jval_set_property_jval(&tcp, "prototype", &prototype);

--- a/src/module/iotjs_module_timer.c
+++ b/src/module/iotjs_module_timer.c
@@ -162,7 +162,7 @@ JHANDLER_FUNCTION(Timer) {
 
 
 iotjs_jval_t InitTimer() {
-  iotjs_jval_t timer = iotjs_jval_create_function(Timer);
+  iotjs_jval_t timer = iotjs_jval_create_function_with_dispatch(Timer);
 
   iotjs_jval_t prototype = iotjs_jval_create_object();
   iotjs_jval_set_property_jval(&timer, "prototype", &prototype);

--- a/src/module/iotjs_module_uart.c
+++ b/src/module/iotjs_module_uart.c
@@ -295,7 +295,7 @@ JHANDLER_FUNCTION(Write) {
 
 
 iotjs_jval_t InitUart() {
-  iotjs_jval_t jUartCons = iotjs_jval_create_function(UartCons);
+  iotjs_jval_t jUartCons = iotjs_jval_create_function_with_dispatch(UartCons);
 
   iotjs_jval_t prototype = iotjs_jval_create_object();
 

--- a/src/module/iotjs_module_udp.c
+++ b/src/module/iotjs_module_udp.c
@@ -474,7 +474,7 @@ JHANDLER_FUNCTION(Unref) {
 
 
 iotjs_jval_t InitUdp() {
-  iotjs_jval_t udp = iotjs_jval_create_function(UDP);
+  iotjs_jval_t udp = iotjs_jval_create_function_with_dispatch(UDP);
 
   iotjs_jval_t prototype = iotjs_jval_create_object();
   iotjs_jval_set_property_jval(&udp, "prototype", &prototype);


### PR DESCRIPTION
The JHANDLER_FUNCTION macro always created a
simple jump method for the given c method.
These extra jump methods were responsible to
convert the JerryScript arguments into IoT.js
handlers.

These extra methods can be eliminated by creating
a generic dispatch method which can call the target
native method. This is achieved by attaching the target
method as a native handler for the JS method.

IoT.js-DCO-1.0-Signed-off-by: Peter Gal pgal.u-szeged@partner.samsung.com