### PR TITLE
build.py modified to ignore commented JS during dependency analysis

### DIFF
--- a/tools/build.py
+++ b/tools/build.py
@@ -574,6 +574,10 @@ def analyze_module_dependency(options):
         with open(js_module_path) as module:
             content = module.read()
 
+        # Pretend to ignore comments in JavaScript
+        re_js_comments = "\/\/.*|\/\*.*\*\/";
+        content = re.sub(re_js_comments, "", content)
+
         re_js_module = 'require\([\'\"](.*?)[\'\"]\)'
         for js_module in re.findall(re_js_module, content):
             if js_module in options.iotjs_exclude_module:


### PR DESCRIPTION
1. Build uses regexp to look for require in JS files. It is used for
   automated dependency analysis.
2. Additional regexp was added to remove basic JS comments from
   analysed file.

Verification:
1. Modify existing module to use require for non existing module.
2. Build fails due to missing module.
3. Comment require statement using // and /* in one line.
4. Build is successful.

IoT.js-DCO-1.0-Signed-off-by: Piotr Marcinkiewicz p.marcinkiew@samsung.com