### PR TITLE
Add missing iotjs_module_uart-i686-linux.c

### DIFF
--- a/src/platform/i686-linux/iotjs_module_uart-i686-linux.c
+++ b/src/platform/i686-linux/iotjs_module_uart-i686-linux.c
@@ -1,0 +1,21 @@
+/* Copyright 2017-present Samsung Electronics Co., Ltd. and other contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+#if defined(__linux__)
+
+#include "../iotjs_module_uart-linux-general.inl.h"
+
+#endif // __linux__


### PR DESCRIPTION
IoT.js-DCO-1.0-Signed-off-by: Zsolt Borbély zsborbely.u-szeged@partner.samsung.com