### PR TITLE
Add address- and undefined behavior sanitizer to Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,7 @@ before_install:
   - if [[ "$INSTALL_ARM_DEPS" == "yes" ]]; then tools/apt-get-install-arm.sh; fi
   - if [[ "$INSTALL_NUTTX_DEPS" == "yes" ]]; then tools/apt-get-install-nuttx.sh; fi
   - if [[ "$INSTALL_TIZEN_DEPS" == "yes" ]]; then . tools/apt-get-install-tizen.sh; fi
+  - if [[ "$INSTALL_TRAVIS_I686_DEPS" == "yes" ]]; then tools/apt-get-install-travis-i686.sh; fi
   - tools/apt-get-install-deps.sh
 
 install:
@@ -15,9 +16,32 @@ install:
 script: "tools/precommit.py $OPTS"
 
 env:
-  - OPTS="--test=host --buildtype=release"
-  - OPTS="--test=host --buildtype=debug"
+  - OPTS="--test=host"
   - OPTS="--test=rpi2" INSTALL_ARM_DEPS=yes
   - OPTS="--test=nuttx" INSTALL_NUTTX_DEPS=yes
   - OPTS="--test=artik10" INSTALL_TIZEN_DEPS=yes
   - OPTS="--test=misc"
+
+matrix:
+  include:
+    - compiler: gcc-4.9
+      addons:
+        apt:
+          sources:
+            - ubuntu-toolchain-r-test
+          packages:
+            - gcc-4.9
+            - gcc-4.9-multilib
+      env: OPTS="--test=host --buildtype=debug --buildoptions=--target-arch=i686,--compile-flag=-fsanitize=address,--compile-flag=-fno-omit-frame-pointer,--compile-flag=-fno-common,--jerry-cmake-param=-DJERRY_LIBC=OFF,--jerry-cmake-param=-DFEATURE_SYSTEM_ALLOCATOR=ON,--no-snapshot,--no-check-valgrind" INSTALL_TRAVIS_I686_DEPS=yes ASAN_OPTIONS=detect_stack_use_after_return=1:check_initialization_order=true:strict_init_order=true
+    - compiler: gcc-4.9
+      addons:
+        apt:
+          sources:
+            - ubuntu-toolchain-r-test
+          packages:
+            - gcc-4.9
+            - gcc-4.9-multilib
+      env: OPTS="--test=host --buildtype=debug --buildoptions=--target-arch=i686,--compile-flag=-fsanitize=undefined,--compile-flag=-fno-omit-frame-pointer,--compile-flag=-fno-common,--jerry-cmake-param=-DJERRY_LIBC=OFF,--jerry-cmake-param=-DFEATURE_SYSTEM_ALLOCATOR=ON,--no-snapshot,--no-check-valgrind" INSTALL_TRAVIS_I686_DEPS=yes UBSAN_OPTIONS=print_stacktrace=1
+  allow_failures:
+    - compiler: gcc-4.9
+  fast_finish: true

--- a/tools/apt-get-install-travis-i686.sh
+++ b/tools/apt-get-install-travis-i686.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+# Copyright 2017-present Samsung Electronics Co., Ltd. and other contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+sudo dpkg --add-architecture i386
+sudo apt-get update -q
+sudo apt-get install -q -y \
+    linux-libc-dev:i386

--- a/tools/build.py
+++ b/tools/build.py
@@ -731,12 +731,13 @@ if __name__ == '__main__':
     # Run tests
     if not options.no_check_test:
         print_progress('Run tests')
-        # Run check test when target is host.
-        if options.host_tuple != options.target_tuple:
-            print("Skip unit tests - target is not host\n")
-        elif options.buildlib:
+        if options.buildlib:
             print("Skip unit tests - build target is library\n")
+        elif (options.host_tuple == options.target_tuple or
+              (options.host_tuple == 'x86_64-linux' and
+               options.target_tuple == 'i686-linux')):
+             run_checktest(options)
         else:
-            run_checktest(options)
+            print("Skip unit tests - target-host pair is not allowed\n")
 
     print("\n%sIoT.js Build Succeeded!!%s\n" % (ex._TERM_GREEN, ex._TERM_EMPTY))


### PR DESCRIPTION
Additional modifications:
  - Introduce a new option (--buildoptions) to precommit.py,
    which allows to customize testing with extra buildoptions.
  - Merge two similar Travis job into one.
  - Allow to run tests on Linux, when the host is x86_64 and the target is i686.

IoT.js-DCO-1.0-Signed-off-by: Zsolt Borbély zsborbely.u-szeged@partner.samsung.com