### PR TITLE
[Bugfix] PWM/linux: Fix command buffer for enable/disable

### DIFF
--- a/src/platform/iotjs_module_pwm-linux-general.inl.h
+++ b/src/platform/iotjs_module_pwm-linux-general.inl.h
@@ -192,8 +192,8 @@ void SetEnableWorker(uv_work_t* work_req) {
 
   strcat(path, PWM_PIN_ENABlE);
 
-  char value[2] = { 0 };
-  snprintf(value, 1, "%d", req_data->enable);
+  char value[4];
+  snprintf(value, sizeof(value), "%d", req_data->enable);
   if (!DeviceOpenWriteClose(path, value)) {
     req_data->result = kPwmErrWrite;
     return;


### PR DESCRIPTION
Sprintf buffer was too short, resulting in only terminating byte fitting