### PR TITLE
Remove duplicate tizen entires from build.config

### DIFF
--- a/build.config
+++ b/build.config
@@ -28,8 +28,6 @@
   },
   "compile_flags": {
     "os": {
-      "tizen": ["-D__LINUX__",
-                "-fno-builtin"],
       "linux": ["-D__LINUX__",
                 "-fno-builtin"],
       "darwin": ["-D__DARWIN__",
@@ -79,7 +77,6 @@
   },
   "link_flags": {
     "os": {
-      "tizen": ["-pthread"],
       "linux": ["-pthread"],
       "darwin": [],
       "nuttx": [],
@@ -88,7 +85,6 @@
   },
   "shared_libs": {
     "os": {
-      "tizen": ["m", "rt"],
       "linux": ["m", "rt"],
       "darwin": [],
       "nuttx": [],


### PR DESCRIPTION
After a previous commit the tizen entires in the
build config file were duplicated. As the config
file is a json there is no reason for this duplication.

IoT.js-DCO-1.0-Signed-off-by: Peter Gal pgal.u-szeged@partner.samsung.com