### PR TITLE
Handle exceptions in process._onUncaughtException

### DIFF
--- a/src/iotjs_binding_helper.c
+++ b/src/iotjs_binding_helper.c
@@ -24,18 +24,23 @@ void iotjs_uncaught_exception(const iotjs_jval_t* jexception) {
   const iotjs_jval_t* process = iotjs_module_get(MODULE_PROCESS);
 
   iotjs_jval_t jonuncaughtexception =
-      iotjs_jval_get_property(process, "_onUncaughtExcecption");
+      iotjs_jval_get_property(process, "_onUncaughtException");
   IOTJS_ASSERT(iotjs_jval_is_function(&jonuncaughtexception));
 
   iotjs_jargs_t args = iotjs_jargs_create(1);
   iotjs_jargs_append_jval(&args, jexception);
 
+  bool throws;
   iotjs_jval_t jres =
-      iotjs_jhelper_call_ok(&jonuncaughtexception, process, &args);
-  iotjs_jval_destroy(&jres);
+      iotjs_jhelper_call(&jonuncaughtexception, process, &args, &throws);
 
   iotjs_jargs_destroy(&args);
+  iotjs_jval_destroy(&jres);
   iotjs_jval_destroy(&jonuncaughtexception);
+
+  if (throws) {
+    exit(2);
+  }
 }
 
 

--- a/src/js/iotjs.js
+++ b/src/js/iotjs.js
@@ -117,7 +117,7 @@
         try {
           callbacks[i]();
         } catch (e) {
-          process._onUncaughtExcecption(e);
+          process._onUncaughtException(e);
         }
       }
 
@@ -131,8 +131,8 @@
 
 
   function initProcessUncaughtException() {
-    process._onUncaughtExcecption = _onUncaughtExcecption;
-    function _onUncaughtExcecption(error) {
+    process._onUncaughtException = _onUncaughtException;
+    function _onUncaughtException(error) {
       var event = 'uncaughtException';
       if (process._events[event] && process._events[event].length > 0) {
         try {
@@ -173,7 +173,7 @@
         process.emitExit(code);
       } catch (e) {
         process.exitCode = 1;
-        process._onUncaughtExcecption(e);
+        process._onUncaughtException(e);
       } finally {
         process.doExit(process.exitCode || 0);
       }


### PR DESCRIPTION
Uncaught exceptions trigger the execution of
process._onUncaughtException (implemented in JS). However, if that
function throws, that causes an assertion failure (in C). This
patch fixes the issue by allowing exceptions in the handler and
exiting (but not aborting) as the last resort.

The patch also fixes a type on the name of _onUncaughtException.

Fixes #648.

IoT.js-DCO-1.0-Signed-off-by: Akos Kiss akiss@inf.u-szeged.hu