### PR TITLE
Specify nuttx tag to improve maintenance

### DIFF
--- a/docs/build/Build-for-NuttX.md
+++ b/docs/build/Build-for-NuttX.md
@@ -48,7 +48,16 @@ $ brew install gcc-arm-none-eabi libusb minicom
 
 ### 2. Build NuttX (For the first time)
 
-Currently we checked that NuttX with commit id ** 419fd6e ** works well. To generate headers which are required to build IoT.js, for the first time, you need to build NuttX at least once. This time nuttx build will be failed. But don't worry at this time. After one execution, you don't need this sequence any more.
+To generate headers which are required to build IoT.js, for the first time, you need to build NuttX at least once. This time nuttx build will be failed. But don't worry at this time. After one execution, you don't need this sequence any more.
+
+#### Supported Nuttx version
+|Repository|Tag Name|
+|----------|:------:|
+| nuttx | nuttx-7.19 |
+| app | nuttx-7.19 |
+
+We only guarantee that the specified version will work well. It is recommended to check out with the specified tag from a git repository.
+
 
 #### Follow the instruction
 * [STM32F4-discovery](../../targets/nuttx-stm32f4/README.md)

--- a/targets/nuttx-stm32f4/README.md
+++ b/targets/nuttx-stm32f4/README.md
@@ -13,10 +13,12 @@ Clone IoT.js and NuttX into iotjs-nuttx directory
 $ mkdir iotjs-nuttx
 $ cd iotjs-nuttx
 $ git clone https://github.com/Samsung/iotjs.git
-$ git clone https://bitbucket.org/nuttx/nuttx.git
-$ git clone https://bitbucket.org/nuttx/apps.git
+$ git clone https://bitbucket.org/nuttx/nuttx.git --branch nuttx-7.19
+$ git clone https://bitbucket.org/nuttx/apps.git --branch nuttx-7.19
 $ git clone https://github.com/texane/stlink.git
 ```
+
+Note that we only support the specified git tag from nuttx repository
 
 The following directory structure is created after these commands
 
@@ -64,67 +66,66 @@ $ make menuconfig
 Followings are the options to set:
 
 * Common
- * Change `Build Setup -> Build Host Platform` from _Windows_ to [_Linux_|_OSX_]
- * Enable `System Type -> FPU support`
- * Enable `System Type -> STM32 Peripheral Support -> SDIO`
- * Enable `RTOS Features -> Clocks and Timers -> Support CLOCK_MONOTONIC`
- * Enable `RTOS Features -> Pthread Options -> Enable mutex types`
- * Enable `RTOS Features -> Files and I/O -> Enable /dev/console`
- * Enable `RTOS Features -> Work queue support -> High priority (kernel) worker thread`
- * Disable `Device Drivers -> Disable driver poll interfaces`
- * Enable `Device Drivers -> MMC/SD Driver Support`
- * Enable `Device Drivers -> MMC/SD Driver Support -> MMC/SD SDIO transfer support`
- * Enable `Networking Support -> Networking Support`
- * Enable `Networking Support -> Socket Support -> Socket options`
- * Enable `Networking Support -> Unix Domain Socket Support`
- * Enable `Networking Support -> TCP/IP Networking`
- * Enable `Networking Support -> TCP/IP Networking -> Enable TCP/IP write buffering`
- * Enable `File Systems -> FAT file system`
- * Enable `File Systems -> FAT file system -> FAT upper/lower names`
- * Enable `File Systems -> FAT file system -> FAT long file names`
- * Enable `Device Drivers -> Network Device/PHY Support -> Late driver initialization`
- * Enable `Library Routines -> Standard Math library`
- * Enable `Application Configuration -> System Libraries and NSH Add-ons -> IoT.js`
- * Enable all children of `Application Configuration -> System Libraries and NSH Add-ons -> readline() Support` (for those who wants to use readline)
+  * Change `Build Setup -> Build Host Platform` from _Windows_ to [_Linux_|_OSX_]
+  * Enable `System Type -> FPU support`
+  * Enable `System Type -> STM32 Peripheral Support -> SDIO`
+  * Enable `RTOS Features -> Clocks and Timers -> Support CLOCK_MONOTONIC`
+  * Enable `RTOS Features -> Pthread Options -> Enable mutex types`
+  * Enable `RTOS Features -> Files and I/O -> Enable /dev/console`
+  * Enable `RTOS Features -> Work queue support -> High priority (kernel) worker thread`
+  * Disable `Device Drivers -> Disable driver poll interfaces`
+  * Enable `Device Drivers -> MMC/SD Driver Support`
+  * Enable `Device Drivers -> MMC/SD Driver Support -> MMC/SD SDIO transfer support`
+  * Enable `Networking Support -> Networking Support`
+  * Enable `Networking Support -> Socket Support -> Socket options`
+  * Enable `Networking Support -> Unix Domain Socket Support`
+  * Enable `Networking Support -> TCP/IP Networking`
+  * Enable `Networking Support -> TCP/IP Networking -> Enable TCP/IP write buffering`
+  * Enable `File Systems -> FAT file system`
+  * Enable `File Systems -> FAT file system -> FAT upper/lower names`
+  * Enable `File Systems -> FAT file system -> FAT long file names`
+  * Enable `Device Drivers -> Network Device/PHY Support -> Late driver initialization`
+  * Enable `Library Routines -> Standard Math library`
+  * Enable `Application Configuration -> System Libraries and NSH Add-ons -> IoT.js`
+  * Enable all children of `Application Configuration -> System Libraries and NSH Add-ons -> readline() Support` (for those who wants to use readline)
 
 * For `net` module
- * Enable `System Type -> STM32 Peripheral Support -> Ethernet MAC`
- * Disable `System Type -> STM32 Peripheral Support -> USART2`
- * Enable `System Type -> STM32 Peripheral Support -> USART6`
- * Set `System Type -> Ethernet MAC configuration -> PHY address` to `0`
- * Set `System Type -> Ethernet MAC configuration -> PHY Status Register Address (decimal)` to `31`
- * Enable `System Type -> Ethernet MAC configuration -> PHY Status Alternate Bit Layout`
- * Set `System Type -> Ethernet MAC configuration -> PHY Mode Mask` to `0x001c`
- * Set `System Type -> Ethernet MAC configuration -> 10MBase-T Half Duplex Value` to `0x0004`
- * Set `System Type -> Ethernet MAC configuration -> 100Base-T Half Duplex Value` to `0x0008`
- * Set `System Type -> Ethernet MAC configuration -> 10Base-T Full Duplex Value` to `0x0014`
- * Set `System Type -> Ethernet MAC configuration -> 10MBase-T Full Duplex Value` to `0x0018`
- * Set `System Type -> Ethernet MAC configuration -> RMII clock configuration` to `External RMII clock`
- * Enable `Board Selection -> STM32F4DIS-BB base board`
- * Set `Device Drivers -> Network Device/PHY Support -> Board PHY Selection` to `SMSC LAN8720 PHY`
- * Enable `Networking Support -> Driver buffer configuration -> Use multiple device-side I/O buffers`
- * Enable `Networking Support -> Data link support -> Local loopback`
- * Enable `Networking Support -> TCP/IP Networking -> TCP/IP backlog support`
- * Enable `Networking Support -> ARP Configuration -> ARP send`
+  * Enable `System Type -> STM32 Peripheral Support -> Ethernet MAC`
+  * Disable `System Type -> STM32 Peripheral Support -> USART2`
+  * Enable `System Type -> STM32 Peripheral Support -> USART6`
+  * Set `System Type -> Ethernet MAC configuration -> PHY address` to `0`
+  * Set `System Type -> Ethernet MAC configuration -> PHY Status Register Address (decimal)` to `31`
+  * Enable `System Type -> Ethernet MAC configuration -> PHY Status Alternate Bit Layout`
+  * Set `System Type -> Ethernet MAC configuration -> PHY Mode Mask` to `0x001c`
+  * Set `System Type -> Ethernet MAC configuration -> 10MBase-T Half Duplex Value` to `0x0004`
+  * Set `System Type -> Ethernet MAC configuration -> 100Base-T Half Duplex Value` to `0x0008`
+  * Set `System Type -> Ethernet MAC configuration -> 10Base-T Full Duplex Value` to `0x0014`
+  * Set `System Type -> Ethernet MAC configuration -> 10MBase-T Full Duplex Value` to `0x0018`
+  * Set `System Type -> Ethernet MAC configuration -> RMII clock configuration` to `External RMII clock`
+  * Enable `Board Selection -> STM32F4DIS-BB base board`
+  * Set `Device Drivers -> Network Device/PHY Support -> Board PHY Selection` to `SMSC LAN8720 PHY`
+  * Enable `Networking Support -> Data link support -> Local loopback`
+  * Enable `Networking Support -> TCP/IP Networking -> TCP/IP backlog support`
+  * Enable `Networking Support -> ARP Configuration -> ARP send`
 
 * For `dgram`
- * Enable `Networking Support > UDP Networking`
+  * Enable `Networking Support > UDP Networking`
 
 * For `pwm` module
- * Enable `System Type -> STM32 Peripheral Support -> TIM(N)`
- * Enable `System Type -> Timer Configuration -> TIM(N) PWM`
- * Set `System Type -> Timer Configuration -> TIM(N) PWM -> TIM(n) PWM Output Channel` to channel number you want
- * Enable `Device Drivers -> PWM Driver Support`
+  * Enable `System Type -> STM32 Peripheral Support -> TIM(N)`
+  * Enable `System Type -> Timer Configuration -> TIM(N) PWM`
+  * Set `System Type -> Timer Configuration -> TIM(N) PWM -> TIM(n) PWM Output Channel` to channel number you want
+  * Enable `Device Drivers -> PWM Driver Support`
 
 * For `adc` module
- * Enable `System Type -> STM32 Peripheral Support -> ADC(N)`
- * Enable `System Type -> STM32 Peripheral Support -> TIM(M)`
- * Enable `System Type -> Timer Configuration -> TIM(M) ADC`
- * Enable `Device Drivers -> Analog Device(ADC/DAC) Support`
- * Enable `Device Drivers -> Analog Device(ADC/DAC) Support -> Analog-to-Digital Conversion`
+  * Enable `System Type -> STM32 Peripheral Support -> ADC(N)`
+  * Enable `System Type -> STM32 Peripheral Support -> TIM(M)`
+  * Enable `System Type -> Timer Configuration -> TIM(M) ADC`
+  * Enable `Device Drivers -> Analog Device(ADC/DAC) Support`
+  * Enable `Device Drivers -> Analog Device(ADC/DAC) Support -> Analog-to-Digital Conversion`
 
 * For `uart` module
- * Enable `System Type -> STM32 Peripheral Support -> U[S]ART(N)`
+  * Enable `System Type -> STM32 Peripheral Support -> U[S]ART(N)`
 
 #### 4. Build IoT.js for NuttX
 

--- a/tools/precommit.py
+++ b/tools/precommit.py
@@ -28,6 +28,7 @@ from check_tidy import check_tidy
 
 TESTS=['host', 'rpi2', 'nuttx', 'misc', 'artik10']
 BUILDTYPES=['debug', 'release']
+NUTTXTAG = 'nuttx-7.19'
 
 def get_config():
     config_path = path.BUILD_CONFIG_PATH
@@ -57,20 +58,19 @@ def setup_nuttx_root(nuttx_root):
     # Step 1
     fs.maybe_make_directory(nuttx_root)
     fs.chdir(nuttx_root)
-    if fs.exists('nuttx'):
-        fs.chdir('nuttx')
-        ex.check_run_cmd('git', ['pull'])
-        fs.chdir('..')
-    else:
+    if not fs.exists('nuttx'):
         ex.check_run_cmd('git', ['clone',
                                  'https://bitbucket.org/nuttx/nuttx.git'])
-    if fs.exists('apps'):
-        fs.chdir('apps')
-        ex.check_run_cmd('git', ['pull'])
-        fs.chdir('..')
-    else:
+    fs.chdir('nuttx')
+    ex.check_run_cmd('git', ['checkout', NUTTXTAG])
+    fs.chdir('..')
+
+    if not fs.exists('apps'):
         ex.check_run_cmd('git', ['clone',
                                  'https://bitbucket.org/nuttx/apps.git'])
+    fs.chdir('apps')
+    ex.check_run_cmd('git', ['checkout', NUTTXTAG])
+    fs.chdir('..')
 
     # Step 2
     fs.maybe_make_directory(fs.join(nuttx_root, 'apps', 'system', 'iotjs'))


### PR DESCRIPTION
The latest version of nuttx does not guarantee the build and execution of iotjs. Therefore, we need to specify a verified version of nuttx. 
I confirmed that all tests have been passed in the tag I specified.

IoT.js-DCO-1.0-Signed-off-by: Hosung Kim hs852.kim@samsung.com