### PR TITLE
Fix .gitignore: ensure that build.config is under revision control

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,4 @@ TAGS
 
 # config files
 *.config
+!build.config


### PR DESCRIPTION
Nuttx-related build tasks may create .config files, which as auto-
generated files should be ignored. However, there are other files
with this extension, which are important. Most notably, the master
build.config file is an example. However, even though it is
committed in the repository, it is also on the ignore list. This
patch fixes the .gitignore file to list only what really should be
ignored.

IoT.js-DCO-1.0-Signed-off-by: Akos Kiss akiss@inf.u-szeged.hu