### PR TITLE
Remove remnants of C++ (documentation & dependency install scripts)

### DIFF
--- a/docs/build/Build-for-Linux.md
+++ b/docs/build/Build-for-Linux.md
@@ -32,7 +32,7 @@ You need to install some packages to build IoT.js, as follows;
 sudo apt-get install gyp cmake build-essential valgrind
 ```
 
-gcc/g++ compiler 4.8 or higher versions are required to compile. If you don't know how to do it, you can get some help from [how-to-install-gcc-4-8](http://askubuntu.com/questions/271388/how-to-install-gcc-4-8) or google.
+gcc compiler 4.8 or higher versions are required to compile. If you don't know how to do it, you can get some help from [how-to-install-gcc-4-8](http://askubuntu.com/questions/271388/how-to-install-gcc-4-8) or google.
 
 ### 1. Get the sources
 

--- a/docs/build/Build-for-RPi2.md
+++ b/docs/build/Build-for-RPi2.md
@@ -78,7 +78,7 @@ Reboot your Raspberry Pi.
 Install arm linux cross compiler.
 
 ``` bash
-sudo apt-get install gcc-arm-linux-gnueabihf g++-arm-linux-gnueabihf
+sudo apt-get install gcc-arm-linux-gnueabihf
 ```
 
 ##### macOS
@@ -87,20 +87,16 @@ Install arm linux cross compiler via [this site](http://www.welzels.de/blog/en/a
 
 The default location for arm linux compiler toolchain is **"/usr/local/linaro/arm-linux-gnueabihf-raspbian"**.
 
-Then you need to locate c_compiler and cxx_compiler.
+Then you need to locate c_compiler.
 In **"./cmake/config/arm-linux.cmake"**,
 ``` cmake
 SET(EXTERNAL_CMAKE_C_COMPILER
     /usr/local/linaro/arm-linux-gnueabihf-raspbian/bin/arm-linux-gnueabihf-gcc)
-SET(EXTERNAL_CMAKE_CXX_COMPILER
-    /usr/local/linaro/arm-linux-gnueabihf-raspbian/bin/arm-linux-gnueabihf-g++)
 ```
 In **"./deps/libtuv/cmake/config/config_arm-linux.cmake"**,
 ``` cmake
 SET(CMAKE_C_COMPILER
     /usr/local/linaro/arm-linux-gnueabihf-raspbian/bin/arm-linux-gnueabihf-gcc)
-SET(CMAKE_CXX_COMPILER
-    /usr/local/linaro/arm-linux-gnueabihf-raspbian/bin/arm-linux-gnueabihf-g++)
 ```
 
 #### Build IoT.js (Cross compile)

--- a/docs/devs/Inside-IoT.js.md
+++ b/docs/devs/Inside-IoT.js.md
@@ -30,7 +30,7 @@ You can see the list of API from [IoT.js API Reference](../api/IoT.js-API-refere
 
 # Javascript Binding
 
-Many modern Javascript Engines come with [embedding API](#embedding-api) to provide functionality for compiling and executing Javascript program, accessing Javascript object and its value, handling errors, managing lifecyles of objects and so on. 
+Many modern Javascript Engines come with [embedding API](#embedding-api) to provide functionality for compiling and executing Javascript program, accessing Javascript object and its value, handling errors, managing lifecyles of objects and so on.
 
 You can think of Javascript binding layer as an interface between upper layer (IoT.js core) and  underlying Javascript engine.
 Although IoT.js only supports JerryScript for now, there will be a chance that we extend supporting Javascript engine (such as [Duktape](http://duktape.org/) or [V8](https://code.google.com/p/v8/)) in the future.
@@ -165,7 +165,7 @@ The process of IoT.js can be summarized as follow:
 1. Initialize JerryScript engine.
 2. Execute empty script
  * Create initial Javascript context.
-3. Initialize builtin modules. 
+3. Initialize builtin modules.
  * Create builin modules including ['process'](../api/IoT.js-API-Process.md).
 4. Evaluate ['iotjs.js'](../../src/js/iotjs.js).
  * Generate entry function.
@@ -182,7 +182,7 @@ The process of IoT.js can be summarized as follow:
 The list of builtin objects can be found at `MAP_MODULE_LIST` macro in ['iotjs_module.h'](../../src/iotjs_module.h).
 
 Because methods of builtin modules are implemented as [native handler](#native-handler),
-are able to access underlying system using libuv, C/C++ library, and system call.
+are able to access underlying system using libuv, C library, and system call.
 Also, builtin modules could be used for optimizing performance of CPU bound routine or reduce binary size.
 
 Builtin modules are initialized during [intializing step of IoT.js](#life-cycle-of-iotjs) and released just before program terminates.

--- a/tools/apt-get-install-arm.sh
+++ b/tools/apt-get-install-arm.sh
@@ -16,4 +16,4 @@
 
 sudo apt-get update -q
 sudo apt-get install -q -y \
-    g++-arm-linux-gnueabihf libc6-dev-armhf-cross
+    gcc-arm-linux-gnueabihf libc6-dev-armhf-cross

--- a/tools/apt-get-install-deps.sh
+++ b/tools/apt-get-install-deps.sh
@@ -16,4 +16,4 @@
 
 sudo apt-get update -q
 sudo apt-get install -q -y \
-    cmake g++ valgrind clang-format-3.8
+    cmake gcc valgrind clang-format-3.8


### PR DESCRIPTION
The project is (almost completely) clean C, so this patch removes
references to C++ compilers from documentation and install scripts.

"Almost completely clean C" refers to the nuttx-stm32f4 target,
which still contains a cxx source file and a Makefile that seems to
mandate a C++ compiler. The cleanup of the target directory is left
for follow-up work.

IoT.js-DCO-1.0-Signed-off-by: Akos Kiss akiss@inf.u-szeged.hu