### PR TITLE
Fixed the close function in gpio

### DIFF
--- a/src/js/gpio.js
+++ b/src/js/gpio.js
@@ -160,7 +160,7 @@ GpioPin.prototype.close = function(callback) {
     throw new Error('GPIO pin is not opened');
   }
 
-  this._binding.close(function(err) {
+  this._binding.close(function(err, value) {
     util.isFunction(callback) && callback.call(self, err, value);
   });
 

--- a/src/module/iotjs_module_gpio.c
+++ b/src/module/iotjs_module_gpio.c
@@ -143,6 +143,7 @@ void iotjs_gpio_after_worker(uv_work_t* work_req, int status) {
           iotjs_jargs_append_error(&jargs, "GPIO Close Error");
         } else {
           iotjs_jargs_append_null(&jargs);
+          iotjs_jargs_append_bool(&jargs, req_data->value);
         }
         break;
       default:


### PR DESCRIPTION
When the close function is called, that returned an error :
uncaughtException: ReferenceError: value is not defined

The value parameter does not exist in the close function and the close callback is called with only one parameter.