### PR TITLE
Module analyzer tool fix

### DIFF
--- a/tools/module_analyzer.py
+++ b/tools/module_analyzer.py
@@ -171,6 +171,7 @@ def _load_options(argv):
     with open(config_path, 'rb') as f:
         config = json.loads(f.read().decode('ascii'))
 
+    loaded_argv = []
     for opt_key, opt_value in config['build_option'].items():
         if opt_key not in allowed_options:
             continue # ignore any option that is not for us


### PR DESCRIPTION
A variable was accidentally left out thus rendering the
tool unusable via cli.

IoT.js-DCO-1.0-Signed-off-by: Peter Gal pgal.u-szeged@partner.samsung.com