### PR TITLE
Fix the close function in gpio, adc and uart

### DIFF
--- a/docs/api/IoT.js-API-GPIO.md
+++ b/docs/api/IoT.js-API-GPIO.md
@@ -166,7 +166,7 @@ console.log('value:', gpio10.readSync());
 
 
 ### `gpiopin.close([callback])` <a name="gpiopin-close"></a>
-* `callback <Function(err: Error | null, value: Boolean)>`
+* `callback <Function(err: Error | null)>`
 
 Closes a GPIO pin asynchronously.
 

--- a/src/js/adc.js
+++ b/src/js/adc.js
@@ -88,7 +88,7 @@ AdcPin.prototype.close = function(callback) {
   }
 
   this._binding.close(function(err) {
-    util.isFunction(callback) && callback.call(self, err, value);
+    util.isFunction(callback) && callback.call(self, err);
   });
 
   this._binding = null;

--- a/src/js/gpio.js
+++ b/src/js/gpio.js
@@ -161,7 +161,7 @@ GpioPin.prototype.close = function(callback) {
   }
 
   this._binding.close(function(err) {
-    util.isFunction(callback) && callback.call(self, err, value);
+    util.isFunction(callback) && callback.call(self, err);
   });
 
   this._binding = null;

--- a/src/js/uart.js
+++ b/src/js/uart.js
@@ -116,7 +116,7 @@ UartPort.prototype.close = function(callback) {
   }
 
   this._binding.close(function(err) {
-    util.isFunction(callback) && callback.call(self, err, value);
+    util.isFunction(callback) && callback.call(self, err);
   });
   this._binding = null;
 };


### PR DESCRIPTION
When the close function is called, that returned an error :
uncaughtException: ReferenceError: value is not defined

The value parameter does not exist in the close function and the close callback is called with only one parameter.

IoT.js-DCO-1.0-Signed-off-by: cedricDum duminy.cedric@gmail.com