### PR TITLE
Support for TizenRT and Artik 05x

### DIFF
--- a/build.config
+++ b/build.config
@@ -39,8 +39,13 @@
                 "-fno-strength-reduce",
                 "-fomit-frame-pointer"],
       "tizen": ["-D__LINUX__",
-                "-fno-builtin"]
-    },
+                "-fno-builtin"],
+      "tizenrt": ["-D__TIZENRT__",
+                "-Os",
+                "-fno-strict-aliasing",
+                "-fno-strength-reduce",
+                "-fomit-frame-pointer"]
+  },
     "arch": {
       "i686": ["-D__i686__",
                "-D__x86__",
@@ -65,6 +70,9 @@
       "rpi2": ["-mcpu=cortex-a7",
                "-mfpu=neon-vfpv4",
                "-DTARGET_BOARD=RP2"],
+      "artik05x": ["-mcpu=cortex-r4",
+                   "-mfpu=vfp3",
+                   "-DTARGET_BOARD=artik05x"],
       "artik10": ["-mcpu=cortex-a7",
                   "-mfpu=neon-vfpv4",
                   "-mfloat-abi=softfp",
@@ -81,7 +89,8 @@
       "linux": ["-pthread"],
       "darwin": [],
       "nuttx": [],
-      "tizen": ["-pthread"]
+      "tizen": ["-pthread"],
+      "tizenrt": []
     }
   },
   "shared_libs": {
@@ -89,7 +98,8 @@
       "linux": ["m", "rt"],
       "darwin": [],
       "nuttx": [],
-      "tizen": ["m", "rt"]
+      "tizen": ["m", "rt"],
+      "tizenrt": []
     }
   },
   "module": {

--- a/cmake/config/arm-tizenrt.cmake
+++ b/cmake/config/arm-tizenrt.cmake
@@ -1,0 +1,22 @@
+# Copyright 2017-present Samsung Electronics Co., Ltd. and other contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+include(CMakeForceCompiler)
+
+set(CMAKE_SYSTEM_NAME EXTERNAL)
+set(CMAKE_SYSTEM_PROCESSOR armv7l)
+
+set(EXTERNAL_CMAKE_C_COMPILER arm-none-eabi-gcc)
+
+CMAKE_FORCE_C_COMPILER(${EXTERNAL_CMAKE_C_COMPILER} GNU)

--- a/src/iotjs_def.h
+++ b/src/iotjs_def.h
@@ -19,7 +19,7 @@
 
 
 #ifndef IOTJS_MAX_READ_BUFFER_SIZE
-#ifdef __NUTTX__
+#if defined(__NUTTX__) || defined(__TIZENRT__)
 #define IOTJS_MAX_READ_BUFFER_SIZE 1023
 #define IOTJS_MAX_PATH_SIZE 120
 #else
@@ -55,6 +55,8 @@
 #define TARGET_OS "nuttx"
 #elif defined(__APPLE__)
 #define TARGET_OS "darwin"
+#elif defined(__TIZENRT__)
+#define TARGET_OS "tizenrt"
 #else
 #define TARGET_OS "unknown"
 #endif

--- a/src/iotjs_util.c
+++ b/src/iotjs_util.c
@@ -33,7 +33,7 @@ iotjs_string_t iotjs_file_read(const char* path) {
 
   char* buffer = iotjs_buffer_allocate(len + 1);
 
-#if defined(__NUTTX__)
+#if defined(__NUTTX__) || defined(__TIZENRT__)
   char* ptr = buffer;
   unsigned nread = 0;
   unsigned read = 0;

--- a/src/module/iotjs_module_dns.c
+++ b/src/module/iotjs_module_dns.c
@@ -65,7 +65,7 @@ const iotjs_jval_t* iotjs_getaddrinfo_reqwrap_jcallback(THIS) {
 #undef THIS
 
 
-#if !defined(__NUTTX__)
+#if !defined(__NUTTX__) && !defined(__TIZENRT__)
 static void AfterGetAddrInfo(uv_getaddrinfo_t* req, int status,
                              struct addrinfo* res) {
   iotjs_getaddrinfo_reqwrap_t* req_wrap =
@@ -129,7 +129,7 @@ JHANDLER_FUNCTION(GetAddrInfo) {
     return;
   }
 
-#if defined(__NUTTX__)
+#if defined(__NUTTX__) || defined(__TIZENRT__)
   iotjs_jargs_t args = iotjs_jargs_create(3);
   int err = 0;
   char ip[INET6_ADDRSTRLEN];

--- a/src/module/iotjs_module_process.c
+++ b/src/module/iotjs_module_process.c
@@ -208,7 +208,7 @@ static void SetProcessEnv(iotjs_jval_t* process) {
 
   nodepath = getenv("NODE_PATH");
   if (nodepath == NULL) {
-#if defined(__NUTTX__)
+#if defined(__NUTTX__) || defined(__TIZENRT__)
     nodepath = "/mnt/sdcard";
 #else
     nodepath = "";

--- a/src/module/iotjs_module_udp.c
+++ b/src/module/iotjs_module_udp.c
@@ -368,7 +368,7 @@ JHANDLER_FUNCTION(GetSockeName) {
 
 
 JHANDLER_FUNCTION(SetBroadcast) {
-#if !defined(__NUTTX__)
+#if !defined(__NUTTX__) && !defined(__TIZENRT__)
   IOTJS_UV_SET_SOCKOPT(uv_udp_set_broadcast);
 #else
   IOTJS_ASSERT(!"Not implemented");
@@ -379,7 +379,7 @@ JHANDLER_FUNCTION(SetBroadcast) {
 
 
 JHANDLER_FUNCTION(SetTTL) {
-#if !defined(__NUTTX__)
+#if !defined(__NUTTX__) && !defined(__TIZENRT__)
   IOTJS_UV_SET_SOCKOPT(uv_udp_set_ttl);
 #else
   IOTJS_ASSERT(!"Not implemented");
@@ -390,7 +390,7 @@ JHANDLER_FUNCTION(SetTTL) {
 
 
 JHANDLER_FUNCTION(SetMulticastTTL) {
-#if !defined(__NUTTX__)
+#if !defined(__NUTTX__) && !defined(__TIZENRT__)
   IOTJS_UV_SET_SOCKOPT(uv_udp_set_multicast_ttl);
 #else
   IOTJS_ASSERT(!"Not implemented");
@@ -401,7 +401,7 @@ JHANDLER_FUNCTION(SetMulticastTTL) {
 
 
 JHANDLER_FUNCTION(SetMulticastLoopback) {
-#if !defined(__NUTTX__)
+#if !defined(__NUTTX__) && !defined(__TIZENRT__)
   IOTJS_UV_SET_SOCKOPT(uv_udp_set_multicast_loop);
 #else
   IOTJS_ASSERT(!"Not implemented");
@@ -414,7 +414,7 @@ JHANDLER_FUNCTION(SetMulticastLoopback) {
 
 
 void SetMembership(iotjs_jhandler_t* jhandler, uv_membership membership) {
-#if !defined(__NUTTX__)
+#if !defined(__NUTTX__) && !defined(__TIZENRT__)
   JHANDLER_CHECK_THIS(object);
   JHANDLER_CHECK_ARGS_1(string);
 

--- a/targets/tizenrt-artik05x/app/README.md
+++ b/targets/tizenrt-artik05x/app/README.md
@@ -1,0 +1,82 @@
+### About
+
+This directory contains files to run IoT.js on [TizenRT](https://github.com/Samsung/TizenRT).
+
+WARNING: **This document is not 100% accurate since Artik05x board with tooling is not available yet**
+
+### How to build
+
+#### 1. Set up the build environment for Artik05x board
+
+Clone IoT.js and TizenRT into iotjs-tizenrt directory
+
+```bash
+$ mkdir iotjs-tizenrt
+$ cd iotjs-tizenrt
+$ git clone https://github.com/Samsung/iotjs.git
+$ git clone https://github.com/Samsung/TizenRT.git tizenrt
+```
+The following directory structure is created after these commands
+
+```bash
+iotjs-tizenrt
+  + iotjs
+  |  + targets
+  |      + tizenrt-artik05x
+  + tizenrt
+```
+
+#### 2. Add IoT.js as a builtin application for TizenRT
+
+```bash
+$ cd tizenrt/apps/system
+$ mkdir iotjs
+$ cp ../../../iotjs/targets/tizenrt-artik05x/app/* ./iotjs/
+```
+
+**WARNING: Manual modification is required**
+
+**WARNING: Below two bullet points are subject to change**
+
+* change tizenrt/apps/system/Kconfig to include iotjs folder
+    ```
+    menu "IoT.js node.js like Javascript runtime"
+    source "$APPSDIR/system/iotjs/Kconfig"
+    endmenu
+    ```
+* Libraries required to link iotjs have to be supplied in some way
+    ```
+    EXTRA_LIBS = -lhttpparser -liotjs -ljerrycore -ltuv -ljerry-libm
+    ```
+
+
+#### 3. Configure TizenRT
+
+```bash
+$ cd tizenrt/os/tools
+$ ./configure.sh sidk_s5jt200/hello_with_tash
+
+$ cd ..
+# might require to run "make menuconfig" twice
+$ make menuconfig
+```
+
+#### 4. Build IoT.js for TizenRT
+
+```bash
+$ cd iotjs
+$ ./tools/build.py --target-arch=arm --target-os=tizenrt --target-board=artik05x --sysroot=../tizenrt/os
+
+```
+
+#### 5. Build TizenRT
+
+```bash
+$ cd tizenrt/os
+IOTJS_LIB_DIR=../iotjs/build/arm-tizenrt/debug/lib make
+```
+Binaries are available in `tizenrt/build/output/bin`
+
+#### 6. Flashing
+
+Yet to be announced on [TizenRT page](https://github.com/Samsung/TizenRT#board)

--- a/targets/tizenrt-artik05x/app/iotjs/.gitignore
+++ b/targets/tizenrt-artik05x/app/iotjs/.gitignore
@@ -1,0 +1,11 @@
+/Make.dep
+/.depend
+/.built
+/*.asm
+/*.obj
+/*.rel
+/*.lst
+/*.sym
+/*.adb
+/*.lib
+/*.src

--- a/targets/tizenrt-artik05x/app/iotjs/Kconfig
+++ b/targets/tizenrt-artik05x/app/iotjs/Kconfig
@@ -1,0 +1,27 @@
+#
+# For a description of the syntax of this configuration file,
+# see the file kconfig-language.txt in the NuttX tools repository.
+#
+
+config SYSTEM_IOTJS
+  bool "IoT.js"
+  default y
+  ---help---
+    Enable IoT.js platform
+
+if IOTJS
+
+config IOTJS_PRIORITY
+  int "IoT.js task priority"
+  default 100
+
+config IOTJS_STACKSIZE
+  int "IoT.js stack size"
+  default 16384
+
+endif
+
+config USER_ENTRYPOINT
+        string
+        default "iotjs_main" if ENTRY_IOTJS
+

--- a/targets/tizenrt-artik05x/app/iotjs/Kconfig_ENTRY
+++ b/targets/tizenrt-artik05x/app/iotjs/Kconfig_ENTRY
@@ -1,0 +1,3 @@
+config ENTRY_IOTJS
+	bool "iotjs application"
+	depends on SYSTEM_IOTJS

--- a/targets/tizenrt-artik05x/app/iotjs/Make.defs
+++ b/targets/tizenrt-artik05x/app/iotjs/Make.defs
@@ -1,0 +1,18 @@
+# Copyright 2016-present Samsung Electronics Co., Ltd. and other contributors
+# Copyright 2016 University of Szeged
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+ifeq ($(CONFIG_SYSTEM_IOTJS),y)
+CONFIGURED_APPS += system/iotjs
+endif

--- a/targets/tizenrt-artik05x/app/iotjs/Makefile
+++ b/targets/tizenrt-artik05x/app/iotjs/Makefile
@@ -1,0 +1,170 @@
+###########################################################################
+#
+# Copyright 2016 Samsung Electronics All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+# either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+#
+###########################################################################
+############################################################################
+# apps/examples/iotjs/Makefile
+#
+#   Copyright (C) 2008, 2010-2013 Gregory Nutt. All rights reserved.
+#   Author: Gregory Nutt <gnutt@nuttx.org>
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+# 1. Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+# 2. Redistributions in binary form must reproduce the above copyright
+#    notice, this list of conditions and the following disclaimer in
+#    the documentation and/or other materials provided with the
+#    distribution.
+# 3. Neither the name NuttX nor the names of its contributors may be
+#    used to endorse or promote products derived from this software
+#    without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+# FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+# COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+# INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+# BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+# OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+# AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+# LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+# ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+#
+############################################################################
+
+EXTRA_LIBPATHS += -L$(IOTJS_LIB_DIR)
+EXTRA_LIBS += libhttpparser.a libiotjs.a libjerrycore.a libtuv.a libjerry-libm.a
+
+LINKLIBS=$(EXTRA_LIBS)
+
+-include $(TOPDIR)/.config
+-include $(TOPDIR)/Make.defs
+include $(APPDIR)/Make.defs
+
+
+# IoT.js application
+CONFIG_IOTJS_PRIORITY ?= SCHED_PRIORITY_DEFAULT
+CONFIG_IOTJS_STACKSIZE ?= 16384
+IOTJS_LIB_DIR ?= n
+
+APPNAME = iotjs
+PRIORITY = $(CONFIG_IOTJS_PRIORITY)
+STACKSIZE = $(CONFIG_IOTJS_STACKSIZE)
+HEAPSIZE = $(CONFIG_IOTJS_HEAPSIZE)
+
+ASRCS =
+CSRCS =
+MAINSRC = iotjs_main.c
+
+AOBJS = $(ASRCS:.S=$(OBJEXT))
+COBJS = $(CSRCS:.c=$(OBJEXT))
+MAINOBJ = $(MAINSRC:.c=$(OBJEXT))
+
+SRCS = $(ASRCS) $(CSRCS) $(MAINSRC)
+OBJS = $(AOBJS) $(COBJS)
+
+ifeq ($(R),1)
+  BUILD_TYPE = release
+else
+  BUILD_TYPE = debug
+endif
+
+ifneq ($(CONFIG_BUILD_KERNEL),y)
+  OBJS += $(MAINOBJ)
+endif
+
+ifeq ($(CONFIG_WINDOWS_NATIVE),y)
+  BIN = ..\..\libapps$(LIBEXT)
+else
+ifeq ($(WINTOOL),y)
+  BIN = ..\\..\\libapps$(LIBEXT)
+else
+  BIN = ../../libapps$(LIBEXT)
+endif
+endif
+
+ifeq ($(WINTOOL),y)
+  INSTALL_DIR = "${shell cygpath -w $(BIN_DIR)}"
+else
+  INSTALL_DIR = $(BIN_DIR)
+endif
+
+CONFIG_IOTJS_PROGNAME ?= iotjs$(EXEEXT)
+PROGNAME = $(CONFIG_IOTJS_PROGNAME)
+
+ROOTDEPPATH = --dep-path .
+
+# Common build
+
+VPATH =
+
+all: .built
+.PHONY: clean depend distclean check_iotjs
+
+$(AOBJS): %$(OBJEXT): %.S
+	$(call ASSEMBLE, $<, $@)
+
+$(COBJS) $(MAINOBJ): %$(OBJEXT): %.c
+	$(call COMPILE, $<, $@)
+
+.built: $(OBJS) check_iotjs
+	$(call ARCHIVE, $(BIN), $(OBJS))
+	@touch .built
+
+ifeq ($(CONFIG_BUILD_KERNEL),y)
+$(BIN_DIR)$(DELIM)$(PROGNAME): $(OBJS) $(MAINOBJ) check_iotjs
+	$(Q) $(LD) $(LDELFFLAGS) $(LDLIBPATH) -o $(INSTALL_DIR)$(DELIM)$(PROGNAME) $(ARCHCRT0OBJ) $(MAINOBJ) $(LDLIBS)
+	$(Q) $(NM) -u  $(INSTALL_DIR)$(DELIM)$(PROGNAME)
+
+install: $(BIN_DIR)$(DELIM)$(PROGNAME)
+
+else
+install:
+
+endif
+
+check_iotjs:
+ifeq ($(IOTJS_LIB_DIR),n)
+	@echo "ERROR: IOTJS_LIB_DIR not set! Aborting..."
+	@exit 1
+endif
+	@echo IOTJS_LIB_DIR set!
+	@echo "$(LDLIBPATH), $(IOTJS_LIB_DIR) $(TOPDIR)"
+	@cp $(IOTJS_LIB_DIR)/lib* $(TOPDIR)/../build/output/libraries/
+	@cp $(IOTJS_LIB_DIR)/../deps/jerry/lib/libjerry-libm.a $(TOPDIR)/../build/output/libraries/
+
+context:
+
+.depend: Makefile $(SRCS)
+	@$(MKDEP) $(ROOTDEPPATH) "$(CC)" -- $(CFLAGS) -- $(SRCS) >Make.dep
+	@touch $@
+
+depend: .depend
+
+clean:
+	$(call DELFILE, .built)
+	$(call CLEAN)
+
+distclean: clean
+	$(call DELFILE, Make.dep)
+	$(call DELFILE, .depend)
+
+-include Make.dep

--- a/targets/tizenrt-artik05x/app/iotjs/iotjs_main.c
+++ b/targets/tizenrt-artik05x/app/iotjs/iotjs_main.c
@@ -1,0 +1,109 @@
+/* Copyright 2015-present Samsung Electronics Co., Ltd. and other contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/****************************************************************************
+ *   Copyright (C) 2013 Gregory Nutt. All rights reserved.
+ *   Author: Gregory Nutt <gnutt@nuttx.org>
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name NuttX nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <apps/shell/tash.h>
+#include <tinyara/arch.h>
+#include <tinyara/config.h>
+
+#include <setjmp.h>
+#include <stdio.h>
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+/**
+ * Compiler built-in setjmp function.
+ *
+ * @return 0 when called the first time
+ *         1 when returns from a longjmp call
+ */
+
+int setjmp(jmp_buf buf) {
+  return __builtin_setjmp(buf);
+} /* setjmp */
+
+/**
+ * Compiler built-in longjmp function.
+ *
+ * Note:
+ *   ignores value argument
+ */
+
+void longjmp(jmp_buf buf, int value) {
+  /* Must be called with 1. */
+  __builtin_longjmp(buf, 1);
+} /* longjmp */
+
+int iotjs_entry(int argc, char *argv[]);
+int tuv_cleanup(void);
+
+static int iotjs(int argc, char *argv[]) {
+  int ret = 0;
+  ret = iotjs_entry(argc, argv);
+  tuv_cleanup();
+  return ret;
+}
+
+const static tash_cmdlist_t iotjs_cmds[] = { { "iotjs", iotjs,
+                                               TASH_EXECMD_SYNC },
+                                             { 0, 0, 0 } };
+
+#ifdef CONFIG_BUILD_KERNEL
+int main(int argc, FAR char *argv[])
+#else
+int iotjs_main(int argc, char *argv[])
+#endif
+{
+  tash_cmdlist_install(iotjs_cmds);
+  return 0;
+}

--- a/tools/build.py
+++ b/tools/build.py
@@ -92,13 +92,13 @@ def init_options():
         help='Specify the target architecture: '
              '%(choices)s (default: %(default)s)')
     parser.add_argument('--target-os',
-        choices=['linux', 'darwin', 'osx', 'nuttx', 'tizen'],
+        choices=['linux', 'darwin', 'osx', 'nuttx', 'tizen', 'tizenrt'],
         default=platform.os(),
         help='Specify the target os: %(choices)s (default: %(default)s)')
 
     parser.add_argument('--target-board',
-        choices=['none', 'artik10', 'stm32f4dis', 'rpi2'], default='none',
-        help='Specify the targeted board (if needed): '
+        choices=['none', 'artik10', 'stm32f4dis', 'rpi2', 'artik05x'],
+        default='none', help='Specify the targeted board (if needed): '
              '%(choices)s (default: %(default)s)')
     parser.add_argument('--nuttx-home', default=None, dest='sysroot',
         help='Specify the NuttX base directory (required for NuttX build)')
@@ -201,7 +201,7 @@ def init_options():
 
 def adjust_options(options):
     # First fix some option inconsistencies
-    if options.target_os == 'nuttx':
+    if options.target_os in ['nuttx', 'tizenrt']:
         options.buildlib = True
         if not options.sysroot:
             ex.fail('--sysroot needed for nuttx target')
@@ -218,7 +218,7 @@ def adjust_options(options):
     if options.target_os == 'darwin':
         options.no_check_valgrind = True
 
-    if options.target_board in ['rpi2', 'artik10']:
+    if options.target_board in ['rpi2', 'artik10', 'artik05x']:
         options.no_check_valgrind = True
     elif options.target_board == 'none':
         options.target_board = None
@@ -314,7 +314,7 @@ def build_cmake_args(options, for_jerry=False):
 
     # external include dir
     include_dirs = []
-    if options.target_os == 'nuttx' and options.sysroot:
+    if options.target_os in ['nuttx', 'tizenrt'] and options.sysroot:
         include_dirs.append('%s/include' % options.sysroot)
         if options.target_board == 'stm32f4dis':
             include_dirs.append('%s/arch/arm/src/stm32' % options.sysroot)
@@ -454,7 +454,7 @@ def build_libjerry(options):
         cmake_opt.append('-DCMAKE_BUILD_TYPE=Debug')
         cmake_opt.append('-DFEATURE_ERROR_MESSAGES=On')
 
-    if options.target_os == 'nuttx':
+    if options.target_os in ['nuttx', 'tizenrt']:
         cmake_opt.append("-DEXTERNAL_LIBC_INTERFACE='%s'" %
                          fs.join(options.sysroot, 'include'))
         if options.target_arch == 'arm':
@@ -463,6 +463,10 @@ def build_libjerry(options):
     if options.target_os in ['linux', 'tizen', 'darwin']:
         cmake_opt.append('-DJERRY_LIBC=OFF')
         cmake_opt.append('-DJERRY_LIBM=OFF')
+
+    if options.target_os in ['tizenrt']:
+        cmake_opt.append('-DJERRY_LIBC=OFF')
+        cmake_opt.append('-DJERRY_LIBM=ON')
 
     # --jerry-heaplimit
     if options.jerry_heaplimit:
@@ -529,8 +533,10 @@ def build_libhttpparser(options):
         '-DBUILDTYPE=%s' % options.buildtype.capitalize(),
     ]
 
-    if options.target_os == 'nuttx':
+    if options.target_os in ['nuttx', 'tizenrt']:
         cmake_opt.append("-DNUTTX_HOME='%s'" % options.sysroot)
+
+    if options.target_os in ['nuttx', 'tizenrt']:
         cmake_opt.append('-DOS=NUTTX')
 
     if options.target_os in ['linux', 'tizen']:


### PR DESCRIPTION
Requirements:
- TizenRT properly configured (network support)
- JerryScript with support for sysroot (PR WIP)
- libtuv with https://github.com/Samsung/libtuv/pull/72 merged

Building:
Follow instruction from targets/tizenrt-artik05x/README.md.
Make sure in os/.config have lines:
CONFIG_SYSTEM_IOTJS=y
CONFIG_USER_ENTRYPOINT="iotjs_main"
then run:
./tools/build.py --target-arch=arm --target-os=tizenrt --target-board=artik05x --sysroot=path/to/tinyara/os


IoT.js-DCO-1.0-Signed-off-by: Konrad Lipner k.lipner@samsung.com