### PR TITLE
Fix travis configuration for Coverity Scan

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -39,6 +39,7 @@ matrix:
           project:
             name: "Samsung/iotjs"
             description: "Platform for Internet of Things with JavaScript"
+          notification_email: duddlf.choi@samsung.com
           build_command: "tools/precommit.py --test=coverity"
           branch_pattern: master
       env: OPTS="--test=coverity"


### PR DESCRIPTION
This commit adds notification email, mandatory field for Coverity Scan.

IoT.js-DCO-1.0-Signed-off-by: Daeyeon Jeong daeyeon.jeong@samsung.com