### PR TITLE
Fix #673 via checking bound_range properly

### DIFF
--- a/src/module/iotjs_module_buffer.c
+++ b/src/module/iotjs_module_buffer.c
@@ -376,7 +376,7 @@ JHANDLER_FUNCTION(ReadUInt8) {
   iotjs_bufferwrap_t* buffer_wrap = iotjs_bufferwrap_from_jbuiltin(jbuiltin);
 
   size_t buffer_length = iotjs_bufferwrap_length(buffer_wrap);
-  offset = bound_range(offset, 0, buffer_length);
+  offset = bound_range(offset, 0, buffer_length - 1);
 
   char* buffer = iotjs_bufferwrap_buffer(buffer_wrap);
 

--- a/test/run_pass/test_buffer.js
+++ b/test/run_pass/test_buffer.js
@@ -140,4 +140,6 @@ assert.equal(buff16.readInt8(1), 13);
 assert.equal(buff16.readInt8(2), 13);
 assert.equal(buff16.readInt8(3), 13);
 
-assert.equal(Buffer(new Array()).toString(),'');
+assert.equal(Buffer(new Array()).toString(), '');
+assert.equal(new Buffer(1).readUInt8(1, true), 0);
+assert.equal(new Buffer(1).readUInt16LE({}, true), 0);


### PR DESCRIPTION
This commit fixes the buffer over-read error in ReadUInt8.

IoT.js-DCO-1.0-Signed-off-by: Daeyeon Jeong daeyeon.jeong@samsung.com