### PR TITLE
Add input validation to 'iotjs_jval_create_string'

### DIFF
--- a/src/iotjs_binding.c
+++ b/src/iotjs_binding.c
@@ -47,7 +47,13 @@ iotjs_jval_t iotjs_jval_create_string(const iotjs_string_t* v) {
   const jerry_char_t* data = (const jerry_char_t*)(iotjs_string_data(v));
   jerry_size_t size = iotjs_string_size(v);
 
-  _this->value = jerry_create_string_sz(data, size);
+  if (jerry_is_valid_utf8_string(data, size)) {
+    _this->value = jerry_create_string_sz_from_utf8(data, size);
+  } else {
+    _this->value =
+        jerry_create_error(JERRY_ERROR_TYPE,
+                           (const jerry_char_t*)"Invalid UTF-8 string");
+  }
 
   return jval;
 }

--- a/test/run_pass/test_buffer.js
+++ b/test/run_pass/test_buffer.js
@@ -143,3 +143,6 @@ assert.equal(buff16.readInt8(3), 13);
 assert.equal(Buffer(new Array()).toString(), '');
 assert.equal(new Buffer(1).readUInt8(1, true), 0);
 assert.equal(new Buffer(1).readUInt16LE({}, true), 0);
+
+var buff17 = new Buffer("a");
+assert.throws(function() { buff17.fill(8071).toString(); }, TypeError);


### PR DESCRIPTION
Fixes #726

IoT.js-DCO-1.0-Signed-off-by: László Langó llango.u-szeged@partner.samsung.com