### PR TITLE
Fixed http_server.writeHead function

### DIFF
--- a/src/js/http_server.js
+++ b/src/js/http_server.js
@@ -115,8 +115,10 @@ ServerResponse.prototype.writeHead = function(statusCode, reason, obj) {
     if (util.isNullOrUndefined(this._headers)) {
       this._headers = {};
     }
-    for (key in Object.keys(obj)) {
-      this._headers[key] = obj[key];
+    for (var key in obj) {
+      if (obj.hasOwnProperty(key)) {
+        this._headers[key] = obj[key];
+      }
     }
   }
 


### PR DESCRIPTION
Hello,

I have fixed writeHead function in the http_server module. The problem was that `Object.keys` returns an array so the `for..in` loop was iterating over array properties, not array values (which were numerical). And this wass set as response header which have results like `{0: undefined, 1: undefined}`

IoT.js-DCO-1.0-Signed-off-by: Krzysztof Antoszek k.antoszek@samsung.com