### PR TITLE
Console.log crash problem fix

### DIFF
--- a/src/js/util.js
+++ b/src/js/util.js
@@ -101,7 +101,7 @@ function format(s) {
   });
 
   while (i < args.length) {
-      str += ' ' + args[i++].toString();
+      str += ' ' + formatValue(args[i++]);
   }
 
   return str;


### PR DESCRIPTION
console.log("test", null, undefined);

When there are some null parameters console.log is crushing. 