### PR TITLE
Make socket error readable

### DIFF
--- a/src/iotjs_magic_strings.h
+++ b/src/iotjs_magic_strings.h
@@ -65,6 +65,7 @@
 #define IOTJS_MAGIC_STRING_EMIT "emit"
 #define IOTJS_MAGIC_STRING_EMITEXIT "emitExit"
 #define IOTJS_MAGIC_STRING_ENV "env"
+#define IOTJS_MAGIC_STRING_ERRNAME "errname"
 #define IOTJS_MAGIC_STRING_EXECUTE "execute"
 #define IOTJS_MAGIC_STRING_EXPORT "export"
 #define IOTJS_MAGIC_STRING_FAMILY "family"

--- a/src/js/net.js
+++ b/src/js/net.js
@@ -274,7 +274,8 @@ function connect(socket, ip, port) {
       socket.emit('connect');
     } else {
       socket.destroy();
-      emitError(socket, new Error('connect failed - status: ' + status));
+      emitError(socket, new Error('connect failed - status: ' +
+        TCP.errname(status)));
     }
   };
 
@@ -570,7 +571,7 @@ function onconnection(status, clientHandle) {
   var server = this.owner;
 
   if (status) {
-    server.emit('error', new Error('accept error: ' + status));
+    server.emit('error', new Error('accept error: ' + TCP.errname(status)));
     return;
   }
 

--- a/src/module/iotjs_module_tcp.c
+++ b/src/module/iotjs_module_tcp.c
@@ -604,6 +604,13 @@ JHANDLER_FUNCTION(SetKeepAlive) {
   iotjs_jhandler_return_number(jhandler, err);
 }
 
+JHANDLER_FUNCTION(ErrName) {
+  JHANDLER_CHECK_THIS(object);
+  JHANDLER_CHECK_ARGS(1, number);
+
+  int errorcode = JHANDLER_GET_ARG(0, number);
+  iotjs_jhandler_return_string_raw(jhandler, uv_err_name(errorcode));
+}
 
 // used in iotjs_module_udp.cpp
 void AddressToJS(const iotjs_jval_t* obj, const sockaddr* addr) {
@@ -653,7 +660,10 @@ iotjs_jval_t InitTcp() {
   iotjs_jval_t tcp = iotjs_jval_create_function_with_dispatch(TCP);
 
   iotjs_jval_t prototype = iotjs_jval_create_object();
+  iotjs_jval_t errname = iotjs_jval_create_function_with_dispatch(ErrName);
+
   iotjs_jval_set_property_jval(&tcp, IOTJS_MAGIC_STRING_PROTOTYPE, &prototype);
+  iotjs_jval_set_property_jval(&tcp, IOTJS_MAGIC_STRING_ERRNAME, &errname);
 
   iotjs_jval_set_method(&prototype, IOTJS_MAGIC_STRING_OPEN, Open);
   iotjs_jval_set_method(&prototype, IOTJS_MAGIC_STRING_CLOSE, Close);
@@ -669,6 +679,7 @@ iotjs_jval_t InitTcp() {
                         GetSockeName);
 
   iotjs_jval_destroy(&prototype);
+  iotjs_jval_destroy(&errname);
 
   return tcp;
 }


### PR DESCRIPTION
This commit parses an given error code occured from socket and returns
human-readable string.

e.g)
Previous: Error: connect failed - status: -111
 Current: Error: connect failed - status: ECONNREFUSED

IoT.js-DCO-1.0-Signed-off-by: Daeyeon Jeong daeyeon.jeong@samsung.com