### PR TITLE
Provisions to reliably build in cross environment

### DIFF
--- a/tools/build.py
+++ b/tools/build.py
@@ -200,16 +200,6 @@ def init_options():
 
 
 def adjust_options(options):
-    # First fix some option inconsistencies
-    if options.target_os in ['nuttx', 'tizenrt']:
-        options.buildlib = True
-        if not options.sysroot:
-            ex.fail('--sysroot needed for nuttx target')
-
-        options.sysroot = fs.abspath(options.sysroot)
-        if not fs.exists(options.sysroot):
-            ex.fail('Nuttx sysroot %s does not exist' % options.sysroot)
-
     if options.target_arch == 'x86':
         options.target_arch = 'i686'
     if options.target_arch == 'x64':
@@ -229,6 +219,27 @@ def adjust_options(options):
     # Then add calculated options
     options.host_tuple = '%s-%s' % (platform.arch(), platform.os())
     options.target_tuple = '%s-%s' % (options.target_arch, options.target_os)
+
+    # Verify options consistency (sysroot vs. cross build)
+    if options.target_tuple != options.host_tuple:
+        # This is cross build, sysroot should/must be supplied
+        if options.target_os in ['nuttx', 'tizenrt']:
+            require_sysroot = True
+            options.buildlib = True
+        if not options.sysroot:
+            if require_sysroot:
+                ex.fail('--sysroot required for nuttx/tinyara')
+            else:
+                ex.warn('--sysroot recommended for cross builds target')
+        options.sysroot = fs.abspath(options.sysroot)
+        if not fs.exists(options.sysroot):
+            ex.fail('sysroot %s does not exist' % options.sysroot)
+
+    arch_for_iotjs = 'arm' if options.target_arch[0:3] == 'arm' else \
+        options.target_arch
+    os_for_iotjs = 'linux' if options.target_os == 'tizen' else \
+        options.target_os
+    options.target_tuple_for_iotjs = '%s-%s' % (arch_for_iotjs, os_for_iotjs)
 
     options.host_build_root = fs.join(path.PROJECT_ROOT,
                                      options.builddir,
@@ -284,6 +295,20 @@ def build_cmake_args(options, for_jerry=False):
 
     compile_flags += options.compile_flag
     compile_flags += options.jerry_compile_flag if for_jerry else []
+
+    # nosdtinc/nostdlib must be specified when toolchain contains
+    # a non-matching C library.
+    # This is the case with nuttx/tinyara that come with uClibc,
+    # while prebuild GCC mostly comes with glibc/newlib.
+    # TODO: consider factoring this out to an option
+    if options.target_os in ['nuttx', 'tizenrt']:
+        compile_flags.extend(['-nostdinc', '-nostdlib'])
+
+    # With sysroot set, exclude default (host) directories from build.
+    if options.sysroot:
+        compile_flags.extend(['--sysroot', options.sysroot])
+        compile_flags.extend(['-isystem =/include',
+                              '-isystem =/include/tinyara'])
 
     cmake_args.append("-DCMAKE_C_FLAGS='%s'" % (' '.join(compile_flags)))
 

--- a/tools/common_py/system/executor.py
+++ b/tools/common_py/system/executor.py
@@ -42,6 +42,11 @@ class Executor(object):
         exit(1)
 
     @staticmethod
+    def warn(msg):
+        print("%s%s%s" % (Executor._TERM_YELLOW, msg, Executor._TERM_EMPTY))
+        print()
+
+    @staticmethod
     def run_cmd(cmd, args=[], quiet=False):
         if not quiet:
             Executor.print_cmd_line(cmd, args)


### PR DESCRIPTION
So far the build proceeded by chance -- pieces were taken from either:
 - target environment (if sysroot was passed)
 - compiler bundled environment (hosted cross builds)
 - host system (yes, even for cross builds it happens)

Not sure this is the last patch addressing the problem. There are issues still:
 - any cross build should be constrained to target or compiler environment
 - perhaps this should be extracted as a build flag (bar compiler from accessing bundled sysroot), something like --freestanding? This would be useful to build with compiler that has incompatible libc (i.e.: newlib bundled with popular linaro arm-none-eabi-gcc 4.9.3 against nuttx bundled uClibc)

Fix build dependencies:
 - pass sysroot to cmake (as CFLAGS) if set
 - exclude non-target dependencies on nuttx/tinyara (-nostd{inc,lib})

IoT.js-DCO-1.0-Signed-off-by: Tomasz Wozniak t.wozniak@samsung.com