### PR TITLE
Add iotjs command on TizenRT

### DIFF
--- a/targets/tizenrt-artik05x/app/iotjs/iotjs_main.c
+++ b/targets/tizenrt-artik05x/app/iotjs/iotjs_main.c
@@ -104,6 +104,10 @@ int main(int argc, FAR char *argv[])
 int iotjs_main(int argc, char *argv[])
 #endif
 {
+  return iotjs(argc, argv);
+}
+
+int iotjs_register_cmd() {
   tash_cmdlist_install(iotjs_cmds);
   return 0;
 }


### PR DESCRIPTION
Add iotjs_register_cmd() to use iotjs command in TizenRT Shell (TASH)

IoT.js-DCO-1.0-Signed-off-by: Haesik, Jun haesik.jun@samsung.com