### PR TITLE
Refactor testsuite to not use parent directory hard-link

### DIFF
--- a/test/run_pass/test_fs.js
+++ b/test/run_pass/test_fs.js
@@ -19,7 +19,7 @@ var fs = require('fs');
 var assert = require('assert');
 
 
-var fileName = "../resources/greeting.txt";
+var fileName = "resources/greeting.txt";
 var expectedContents = "Hello IoT.js!!";
 var flags = "r";
 var mode = 438;

--- a/test/run_pass/test_fs1.js
+++ b/test/run_pass/test_fs1.js
@@ -19,8 +19,8 @@ var fs = require('fs');
 var assert = require('assert');
 
 
-var srcFilePath = "../resources/test1.txt";
-var dstFilePath = "../tmp/test_fs1.txt";
+var srcFilePath = "resources/test1.txt";
+var dstFilePath = "tmp/test_fs1.txt";
 
 try {
   var fd1 = fs.openSync(srcFilePath, 'r');

--- a/test/run_pass/test_fs2.js
+++ b/test/run_pass/test_fs2.js
@@ -19,8 +19,8 @@ var fs = require('fs');
 var assert = require('assert');
 
 
-var srcFilePath = "../resources/test1.txt";
-var dstFilePath = "../tmp/test_fs2.txt";
+var srcFilePath = "resources/test1.txt";
+var dstFilePath = "tmp/test_fs2.txt";
 
 var data;
 

--- a/test/run_pass/test_fs_exists.js
+++ b/test/run_pass/test_fs_exists.js
@@ -17,7 +17,7 @@ var fs = require('fs');
 var assert = require('assert');
 
 {
-  var filePath = "../resources/tobeornottobe.txt";
+  var filePath = "resources/tobeornottobe.txt";
 
   fs.exists(filePath, function(exists) {
     assert.equal(exists, true);
@@ -25,7 +25,7 @@ var assert = require('assert');
 }
 
 {
-  var filePath = "../resources/empty.txt";
+  var filePath = "resources/empty.txt";
 
   fs.exists(filePath, function(exists) {
     assert.equal(exists, false);

--- a/test/run_pass/test_fs_existssync.js
+++ b/test/run_pass/test_fs_existssync.js
@@ -17,14 +17,14 @@ var fs = require('fs');
 var assert = require('assert');
 
 {
-  var filePath = "../resources/tobeornottobe.txt";
+  var filePath = "resources/tobeornottobe.txt";
 
   var result = fs.existsSync(filePath);
   assert.equal(result, true);
 }
 
 {
-  var filePath = "../resources/empty.txt";
+  var filePath = "resources/empty.txt";
 
   var result = fs.existsSync(filePath);
   assert.equal(result, false);

--- a/test/run_pass/test_fs_mkdir_rmdir.js
+++ b/test/run_pass/test_fs_mkdir_rmdir.js
@@ -25,9 +25,9 @@ function unlink(path) {
 }
 
 {
-  var root = "../resources/test_dir";
-  var sub1 = "../resources/test_dir/file1";
-  var sub2 = "../resources/test_dir/file2";
+  var root = "resources/test_dir";
+  var sub1 = "resources/test_dir/file1";
+  var sub2 = "resources/test_dir/file2";
 
   unlink(sub1);
   unlink(sub2);

--- a/test/run_pass/test_fs_open_close.js
+++ b/test/run_pass/test_fs_open_close.js
@@ -19,7 +19,7 @@ var fs = require('fs');
 var assert = require('assert');
 
 
-var fileName = "../resources/greeting.txt";
+var fileName = "resources/greeting.txt";
 
 
 // test sync open & close.

--- a/test/run_pass/test_fs_readdir.js
+++ b/test/run_pass/test_fs_readdir.js
@@ -16,7 +16,7 @@
 var fs = require('fs');
 var assert = require('assert');
 
-var path = '../resources/readdir'
+var path = 'resources/readdir'
 var ans = 'DO_NOT_MODIFY_THIS_FOLDER\n'+
           'This_is_a_directory\n'+
           'This_is_another_directory\n'+

--- a/test/run_pass/test_fs_readfile.js
+++ b/test/run_pass/test_fs_readfile.js
@@ -17,7 +17,7 @@
 var fs = require('fs');
 var assert = require('assert');
 
-var filePath = "../resources/tobeornottobe.txt";
+var filePath = "resources/tobeornottobe.txt";
 
 fs.readFile(filePath, function(err, data) {
   assert.equal(err, null);

--- a/test/run_pass/test_fs_readfilesync.js
+++ b/test/run_pass/test_fs_readfilesync.js
@@ -17,7 +17,7 @@
 var fs = require('fs');
 var assert = require('assert');
 
-var filePath = "../resources/tobeornottobe.txt";
+var filePath = "resources/tobeornottobe.txt";
 
 var data = fs.readFileSync(filePath);
 

--- a/test/run_pass/test_fs_rename.js
+++ b/test/run_pass/test_fs_rename.js
@@ -20,8 +20,8 @@
 var fs = require('fs');
 var assert = require('assert');
 
-var file1 = "../resources/rename.txt";
-var file2 = "../resources/rename.txt.async";
+var file1 = "resources/rename.txt";
+var file2 = "resources/rename.txt.async";
 
 fs.rename(file1, file2, function(err) {
   assert.equal(err, null);

--- a/test/run_pass/test_fs_rename_sync.js
+++ b/test/run_pass/test_fs_rename_sync.js
@@ -16,8 +16,8 @@
 var fs = require('fs');
 var assert = require('assert');
 
-var file1 = "../resources/rename.txt";
-var file2 = "../resources/rename.txt.sync";
+var file1 = "resources/rename.txt";
+var file2 = "resources/rename.txt.sync";
 
 fs.renameSync(file1, file2);
 assert.equal(fs.existsSync(file1), false);

--- a/test/run_pass/test_fs_stat.js
+++ b/test/run_pass/test_fs_stat.js
@@ -18,11 +18,11 @@ var fs = require('fs');
 var assert = require('assert');
 
 
-var stats1 = fs.statSync('test_fs_stat.js');
+var stats1 = fs.statSync('run_pass/test_fs_stat.js');
 assert.equal(stats1.isFile(), true);
 assert.equal(stats1.isDirectory(), false);
 
-fs.stat('test_fs_stat.js', function(err, stats) {
+fs.stat('run_pass/test_fs_stat.js', function(err, stats) {
   if (!err) {
     assert.equal(stats.isFile(), true);
     assert.equal(stats.isDirectory(), false);
@@ -33,11 +33,11 @@ fs.stat('test_fs_stat.js', function(err, stats) {
 });
 
 
-var stats2 = fs.statSync('../resources');
+var stats2 = fs.statSync('resources');
 assert.equal(stats2.isDirectory(), true);
 assert.equal(stats2.isFile(), false);
 
-fs.stat('../resources', function(err, stats) {
+fs.stat('resources', function(err, stats) {
   if (!err) {
     assert.equal(stats.isDirectory(), true);
     assert.equal(stats.isFile(), false);

--- a/test/run_pass/test_fs_writefile_unlink.js
+++ b/test/run_pass/test_fs_writefile_unlink.js
@@ -20,8 +20,8 @@
 var fs = require('fs');
 var assert = require('assert');
 
-var file1 = "../resources/tobeornottobe.txt";
-var file2 = "../resources/tobeornottobe_async.txt";
+var file1 = "resources/tobeornottobe.txt";
+var file2 = "resources/tobeornottobe_async.txt";
 
 fs.readFile(file1, function(err, buf1) {
   assert.equal(err, null);

--- a/test/run_pass/test_fs_writefile_unlink_sync.js
+++ b/test/run_pass/test_fs_writefile_unlink_sync.js
@@ -16,8 +16,8 @@
 var fs = require('fs');
 var assert = require('assert');
 
-var file1 = "../resources/tobeornottobe.txt";
-var file2 = "../resources/tobeornottobe_sync.txt";
+var file1 = "resources/tobeornottobe.txt";
+var file2 = "resources/tobeornottobe_sync.txt";
 
 /* make a new file2 from file1 */
 var buf1 = fs.readFileSync(file1);

--- a/test/run_pass/test_module_cache.js
+++ b/test/run_pass/test_module_cache.js
@@ -15,8 +15,8 @@
 
 var assert = require('assert');
 
-var module_cache = require('require1/module_cache.js');
+var module_cache = require('run_pass/require1/module_cache.js');
 module_cache.i = 100;
-module_cache = require('require1/module_cache.js');
+module_cache = require('run_pass/require1/module_cache.js');
 
 assert.equal(module_cache.i, 100);

--- a/tools/check_test.js
+++ b/tools/check_test.js
@@ -133,7 +133,6 @@ Driver.prototype.runNextTest = function() {
     this.finish();
   } else {
     if (this.fIdx == this.fLength) {
-      process.chdir(this.root);
       this.dIdx++;
       if (this.dIdx == this.dLength) {
         this.finish();
@@ -176,7 +175,6 @@ Driver.prototype.nextTestSet = function(skipped) {
 
   var dirname = this.dirname();
   this.fLength = this.tests[dirname].length;
-  process.chdir(util.absolutePath(dirname));
   this.logger.message("\n");
   this.logger.message(">>>> " + dirname, "summary");
 };
@@ -192,8 +190,10 @@ Driver.prototype.currentTest = function() {
 
 Driver.prototype.test = function() {
   var test = this.currentTest();
-  var content = fs.readFileSync(util.absolutePath(test['name'])).toString();
-  return content;
+  var dirname = this.dirname();
+  var testfile = util.absolutePath(util.join(dirname, test['name']));
+
+  return fs.readFileSync(testfile).toString();
 };
 
 Driver.prototype.finish = function() {


### PR DESCRIPTION
Since [NuttX does not use file system that supports parent directory hard-link](https://bitbucket.org/nuttx/nuttx/issues/39/relative-path-with-parent-directory-symbol), I've removed that hard-link from relative paths in tests.

Testrunner is just a bit modified. Now, there is no need to change directory (to the current testset folder), tests are executed always from the root test directory.