### PR TITLE
Add python tool to compare JS heap usage of different builds

### DIFF
--- a/tools/measure_js_heap.py
+++ b/tools/measure_js_heap.py
@@ -1,0 +1,78 @@
+#!/usr/bin/env python
+
+# Copyright 2017-present Samsung Electronics Co., Ltd. and other contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import print_function
+
+import argparse
+import os
+import re
+import subprocess
+import sys
+
+from common_py import path
+from common_py.system.filesystem import FileSystem as fs
+
+def get_arguments():
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--base', required=True,
+        help='Path to the base IoT.js binary')
+    parser.add_argument('--new',  required=True,
+        help='Path to the new IoT.js binary')
+
+    script_args = parser.parse_args()
+
+    return script_args
+
+def run_iotjs(cmd):
+    pattern = re.compile(r'Peak allocated = (\d+) bytes')
+
+    try:
+        output = subprocess.check_output(cmd, stderr=subprocess.STDOUT)
+    except subprocess.CalledProcessError as err:
+        return ""
+
+    match = pattern.search(str(output))
+
+    if match:
+        return match.group(1)
+    else:
+        return ""
+
+
+if __name__ == "__main__":
+    script_args = get_arguments()
+    print("**JS heap peak (bytes)**\n")
+    print("| {0:^40} | {1:^10} | {2:^10} |".format("Test file", "base", "new"))
+    print("| {0} | {1} | {2} |".format("-"*40, "-"*10, "-"*10))
+
+    for test_file in os.listdir(path.RUN_PASS_DIR):
+        if test_file.endswith(".js"):
+            line = "| " + test_file + " | "
+            cmd = [script_args.base,
+                os.path.join(path.RUN_PASS_DIR, test_file),
+                '--memstat'
+            ]
+            base_out = run_iotjs(cmd)
+
+            cmd = [script_args.new,
+                os.path.join(path.RUN_PASS_DIR, test_file),
+                '--memstat'
+            ]
+            new_out = run_iotjs(cmd)
+
+            if base_out or new_out:
+                print("| {0:40} | {1:^10} | {2:^10} |"
+                    .format(test_file, base_out, new_out))


### PR DESCRIPTION
Example output (b33f982 vs b1cc183):

**JS heap peak (bytes)**

| Test file | base | new |
| --------- | ---- | --- |
| test_assert.js | 24568 | 24568 |
| test_uncaught_error2.js | 24480 | 23768 |
| test_httpclient_timeout2.js | 49144 | 49144 |
| test_net10.js | 37280 | 36568 |
| test_stream.js | 31400 | 30416 |
| test_console.js | 24560 | 23880 |
| test_experimental_off.js | 23416 | 22736 |
| test_http_get.js | 57336 | 57336 |
| test_dns.js | 40952 | 40952 |
| test_net3.js | 106488 | 106488 |
| test_buffer_builtin.js | 27576 | 26904 |
| test_uncaught_error1.js | 23760 | 23064 |
| test_uncaught2.js | 24560 | 24568 |
| test_httpserver.js | 65528 | 65528 |
| test_module_cache.js | 24576 | 24264 |
| test_net2.js | 40944 | 40952 |
| test_util.js | 32760 | 32760 |
| test_net5.js | 40944 | 40944 |
| test_net4.js | 40952 | 40944 |
| test_httpclient_timeout.js | 49144 | 49144 |
| test_buffer.js | 30872 | 30200 |
| test_cwd.js | 22120 | 21440 |
| test_net8.js | 40952 | 40952 |
| test_uncaught1.js | 24568 | 24304 |
| test_timers2.js | 26720 | 25944 |
| test_net6.js | 40952 | 40944 |
| test_net9.js | 40952 | 40952 |
| test_next_tick.js | 24568 | 23896 |
| test_process.js | 23720 | 23008 |
| test_net7.js | 114680 | 114680 |
| test_events.js | 32112 | 31416 |
| test_timers.js | 24560 | 24568 |
| test_httpserver_timeout.js | 49144 | 49136 |
| test_net1.js | 40944 | 40944 |
| test_http_header.js | 49144 | 50360 |