### PR TITLE
Change the iotjs execution methods on TizenRT

### DIFF
--- a/config/tizenrt/artik05x/app/Kconfig
+++ b/config/tizenrt/artik05x/app/Kconfig
@@ -9,7 +9,7 @@ config SYSTEM_IOTJS
   ---help---
     Enable IoT.js platform
 
-if IOTJS
+if SYSTEM_IOTJS
 
 config IOTJS_PRIORITY
   int "IoT.js task priority"
@@ -17,7 +17,7 @@ config IOTJS_PRIORITY
 
 config IOTJS_STACKSIZE
   int "IoT.js stack size"
-  default 16384
+  default 32768
 
 endif
 

--- a/config/tizenrt/artik05x/app/Makefile
+++ b/config/tizenrt/artik05x/app/Makefile
@@ -168,3 +168,5 @@ distclean: clean
 	$(call DELFILE, .depend)
 
 -include Make.dep
+.PHONY: preconfig
+preconfig:


### PR DESCRIPTION
It will fix the crash error when we execute iotjs test casaes

IoT.js-DCO-1.0-Signed-off-by: Haesik, Jun haesik.jun@samsung.com