### PR TITLE
Update JerryScript and Remove deprecated APIs

### DIFF
--- a/src/iotjs_binding.c
+++ b/src/iotjs_binding.c
@@ -365,11 +365,11 @@ iotjs_jval_t iotjs_jval_get_property(const iotjs_jval_t* jobj,
 
 void iotjs_jval_set_object_native_handle(const iotjs_jval_t* jobj,
                                          uintptr_t ptr,
-                                         JFreeHandlerType free_handler) {
+                                         JNativeInfoType native_info) {
   const IOTJS_VALIDATED_STRUCT_METHOD(iotjs_jval_t, jobj);
   IOTJS_ASSERT(iotjs_jval_is_object(jobj));
 
-  jerry_set_object_native_handle(_this->value, ptr, free_handler);
+  jerry_set_object_native_pointer(_this->value, (void*)ptr, native_info);
 }
 
 
@@ -377,8 +377,9 @@ uintptr_t iotjs_jval_get_object_native_handle(const iotjs_jval_t* jobj) {
   const IOTJS_VALIDATED_STRUCT_METHOD(iotjs_jval_t, jobj);
   IOTJS_ASSERT(iotjs_jval_is_object(jobj));
 
-  uintptr_t ptr;
-  jerry_get_object_native_handle(_this->value, &ptr);
+  uintptr_t ptr = 0x0;
+  JNativeInfoType out_info;
+  jerry_get_object_native_pointer(_this->value, (void**)&ptr, &out_info);
   return ptr;
 }
 
@@ -781,7 +782,10 @@ static jerry_value_t iotjs_native_dispatch_function(
     const jerry_value_t jfunc, const jerry_value_t jthis,
     const jerry_value_t jargv[], const JRawLengthType jargc) {
   uintptr_t target_function_ptr = 0x0;
-  if (!jerry_get_object_native_handle(jfunc, &target_function_ptr)) {
+  JNativeInfoType out_info;
+
+  if (!jerry_get_object_native_pointer(jfunc, (void**)&target_function_ptr,
+                                       &out_info)) {
     const jerry_char_t* jmsg = (const jerry_char_t*)("Internal dispatch error");
     return jerry_create_error((jerry_error_t)IOTJS_ERROR_COMMON, jmsg);
   }

--- a/src/iotjs_binding.h
+++ b/src/iotjs_binding.h
@@ -23,7 +23,7 @@
 
 
 typedef jerry_external_handler_t JHandlerType;
-typedef jerry_object_free_callback_t JFreeHandlerType;
+typedef const jerry_object_native_info_t* JNativeInfoType;
 typedef jerry_length_t JRawLengthType;
 
 
@@ -126,7 +126,7 @@ void iotjs_jval_set_property_string_raw(THIS_JVAL, const char* name,
 iotjs_jval_t iotjs_jval_get_property(THIS_JVAL, const char* name);
 
 void iotjs_jval_set_object_native_handle(THIS_JVAL, uintptr_t ptr,
-                                         JFreeHandlerType free_handler);
+                                         JNativeInfoType native_info);
 uintptr_t iotjs_jval_get_object_native_handle(THIS_JVAL);
 
 void iotjs_jval_set_property_by_index(THIS_JVAL, uint32_t idx,

--- a/src/iotjs_handlewrap.c
+++ b/src/iotjs_handlewrap.c
@@ -20,13 +20,13 @@
 void iotjs_handlewrap_initialize(iotjs_handlewrap_t* handlewrap,
                                  const iotjs_jval_t* jobject,
                                  uv_handle_t* handle,
-                                 JFreeHandlerType jfreehandler) {
+                                 JNativeInfoType native_info) {
   IOTJS_VALIDATED_STRUCT_CONSTRUCTOR(iotjs_handlewrap_t, handlewrap);
 
   // Increase ref count of Javascript object to guarantee it is alive until the
   // handle has closed.
   iotjs_jval_t jobjectref = iotjs_jval_create_copied(jobject);
-  iotjs_jobjectwrap_initialize(&_this->jobjectwrap, &jobjectref, jfreehandler);
+  iotjs_jobjectwrap_initialize(&_this->jobjectwrap, &jobjectref, native_info);
 
   _this->handle = handle;
   _this->on_close_cb = NULL;

--- a/src/iotjs_handlewrap.h
+++ b/src/iotjs_handlewrap.h
@@ -53,7 +53,7 @@ typedef struct {
 void iotjs_handlewrap_initialize(iotjs_handlewrap_t* handlewrap,
                                  const iotjs_jval_t* jobject,
                                  uv_handle_t* handle,
-                                 JFreeHandlerType jfreehandler);
+                                 JNativeInfoType native_info);
 
 void iotjs_handlewrap_destroy(iotjs_handlewrap_t* handlewrap);
 

--- a/src/iotjs_objectwrap.c
+++ b/src/iotjs_objectwrap.c
@@ -19,7 +19,7 @@
 
 void iotjs_jobjectwrap_initialize(iotjs_jobjectwrap_t* jobjectwrap,
                                   const iotjs_jval_t* jobject,
-                                  JFreeHandlerType jfreehandler) {
+                                  JNativeInfoType native_info) {
   IOTJS_VALIDATED_STRUCT_CONSTRUCTOR(iotjs_jobjectwrap_t, jobjectwrap);
 
   IOTJS_ASSERT(iotjs_jval_is_object(jobject));
@@ -31,7 +31,7 @@ void iotjs_jobjectwrap_initialize(iotjs_jobjectwrap_t* jobjectwrap,
   // Set native pointer of the object to be this wrapper.
   // If the object is freed by GC, the wrapper instance should also be freed.
   iotjs_jval_set_object_native_handle(&_this->jobject, (uintptr_t)jobjectwrap,
-                                      jfreehandler);
+                                      native_info);
 }
 
 

--- a/src/iotjs_objectwrap.h
+++ b/src/iotjs_objectwrap.h
@@ -28,7 +28,7 @@ typedef struct {
 
 void iotjs_jobjectwrap_initialize(iotjs_jobjectwrap_t* jobjectwrap,
                                   const iotjs_jval_t* jobject,
-                                  JFreeHandlerType jfreehandler);
+                                  JNativeInfoType native_info);
 
 void iotjs_jobjectwrap_destroy(iotjs_jobjectwrap_t* jobjectwrap);
 
@@ -36,5 +36,9 @@ iotjs_jval_t* iotjs_jobjectwrap_jobject(iotjs_jobjectwrap_t* jobjectwrap);
 iotjs_jobjectwrap_t* iotjs_jobjectwrap_from_jobject(
     const iotjs_jval_t* jobject);
 
+#define IOTJS_DEFINE_NATIVE_HANDLE_INFO(module)                              \
+  static const jerry_object_native_info_t module##_native_info = {           \
+    .free_cb = (jerry_object_native_free_callback_t)iotjs_##module##_destroy \
+  }
 
 #endif /* IOTJS_OBJECTWRAP_H */

--- a/src/modules/iotjs_module_adc.c
+++ b/src/modules/iotjs_module_adc.c
@@ -19,14 +19,14 @@
 
 
 static void iotjs_adc_destroy(iotjs_adc_t* adc);
+IOTJS_DEFINE_NATIVE_HANDLE_INFO(adc);
 static iotjs_adc_t* iotjs_adc_instance_from_jval(const iotjs_jval_t* jadc);
 
 
 static iotjs_adc_t* iotjs_adc_create(const iotjs_jval_t* jadc) {
   iotjs_adc_t* adc = IOTJS_ALLOC(iotjs_adc_t);
   IOTJS_VALIDATED_STRUCT_CONSTRUCTOR(iotjs_adc_t, adc);
-  iotjs_jobjectwrap_initialize(&_this->jobjectwrap, jadc,
-                               (JFreeHandlerType)iotjs_adc_destroy);
+  iotjs_jobjectwrap_initialize(&_this->jobjectwrap, jadc, &adc_native_info);
 
   return adc;
 }

--- a/src/modules/iotjs_module_blehcisocket.c
+++ b/src/modules/iotjs_module_blehcisocket.c
@@ -46,6 +46,7 @@
 
 
 static void iotjs_blehcisocket_destroy(THIS);
+IOTJS_DEFINE_NATIVE_HANDLE_INFO(blehcisocket);
 
 
 iotjs_blehcisocket_t* iotjs_blehcisocket_create(const iotjs_jval_t* jble) {
@@ -53,7 +54,7 @@ iotjs_blehcisocket_t* iotjs_blehcisocket_create(const iotjs_jval_t* jble) {
   IOTJS_VALIDATED_STRUCT_CONSTRUCTOR(iotjs_blehcisocket_t, blehcisocket);
 
   iotjs_jobjectwrap_initialize(&_this->jobjectwrap, jble,
-                               (JFreeHandlerType)iotjs_blehcisocket_destroy);
+                               &blehcisocket_native_info);
 
   iotjs_blehcisocket_initialize(blehcisocket);
 

--- a/src/modules/iotjs_module_buffer.c
+++ b/src/modules/iotjs_module_buffer.c
@@ -21,6 +21,8 @@
 
 
 static void iotjs_bufferwrap_destroy(iotjs_bufferwrap_t* bufferwrap);
+IOTJS_DEFINE_NATIVE_HANDLE_INFO(bufferwrap);
+
 
 iotjs_bufferwrap_t* iotjs_bufferwrap_create(const iotjs_jval_t* jbuiltin,
                                             size_t length) {
@@ -28,7 +30,7 @@ iotjs_bufferwrap_t* iotjs_bufferwrap_create(const iotjs_jval_t* jbuiltin,
   IOTJS_VALIDATED_STRUCT_CONSTRUCTOR(iotjs_bufferwrap_t, bufferwrap);
 
   iotjs_jobjectwrap_initialize(&_this->jobjectwrap, jbuiltin,
-                               (JFreeHandlerType)iotjs_bufferwrap_destroy);
+                               &bufferwrap_native_info);
   if (length > 0) {
     _this->length = length;
     _this->buffer = iotjs_buffer_allocate(length);

--- a/src/modules/iotjs_module_gpio.c
+++ b/src/modules/iotjs_module_gpio.c
@@ -23,13 +23,13 @@
 
 static void iotjs_gpio_destroy(iotjs_gpio_t* gpio);
 static iotjs_gpio_t* iotjs_gpio_instance_from_jval(const iotjs_jval_t* jgpio);
+IOTJS_DEFINE_NATIVE_HANDLE_INFO(gpio);
 
 
 static iotjs_gpio_t* iotjs_gpio_create(const iotjs_jval_t* jgpio) {
   iotjs_gpio_t* gpio = IOTJS_ALLOC(iotjs_gpio_t);
   IOTJS_VALIDATED_STRUCT_CONSTRUCTOR(iotjs_gpio_t, gpio);
-  iotjs_jobjectwrap_initialize(&_this->jobjectwrap, jgpio,
-                               (JFreeHandlerType)iotjs_gpio_destroy);
+  iotjs_jobjectwrap_initialize(&_this->jobjectwrap, jgpio, &gpio_native_info);
   return gpio;
 }
 

--- a/src/modules/iotjs_module_httpparser.c
+++ b/src/modules/iotjs_module_httpparser.c
@@ -26,6 +26,7 @@
 
 
 static void iotjs_httpparserwrap_destroy(THIS);
+IOTJS_DEFINE_NATIVE_HANDLE_INFO(httpparserwrap);
 
 
 iotjs_httpparserwrap_t* iotjs_httpparserwrap_create(const iotjs_jval_t* jparser,
@@ -34,7 +35,7 @@ iotjs_httpparserwrap_t* iotjs_httpparserwrap_create(const iotjs_jval_t* jparser,
   IOTJS_VALIDATED_STRUCT_CONSTRUCTOR(iotjs_httpparserwrap_t, httpparserwrap);
 
   iotjs_jobjectwrap_initialize(&_this->jobjectwrap, jparser,
-                               (JFreeHandlerType)iotjs_httpparserwrap_destroy);
+                               &httpparserwrap_native_info);
 
   _this->url = iotjs_string_create();
   _this->status_msg = iotjs_string_create();

--- a/src/modules/iotjs_module_i2c.c
+++ b/src/modules/iotjs_module_i2c.c
@@ -22,6 +22,10 @@
 #define THIS iotjs_i2c_reqwrap_t* i2c_reqwrap
 
 
+static void iotjs_i2c_destroy(iotjs_i2c_t* i2c);
+IOTJS_DEFINE_NATIVE_HANDLE_INFO(i2c);
+
+
 iotjs_i2c_reqwrap_t* iotjs_i2c_reqwrap_create(const iotjs_jval_t* jcallback,
                                               const iotjs_jval_t* ji2c,
                                               I2cOp op) {
@@ -86,9 +90,6 @@ iotjs_i2c_t* iotjs_i2c_instance_from_reqwrap(THIS) {
 #undef THIS
 
 
-static void iotjs_i2c_destroy(iotjs_i2c_t* i2c);
-
-
 iotjs_i2c_t* iotjs_i2c_create(const iotjs_jval_t* ji2c) {
   iotjs_i2c_t* i2c = IOTJS_ALLOC(iotjs_i2c_t);
   IOTJS_VALIDATED_STRUCT_CONSTRUCTOR(iotjs_i2c_t, i2c);
@@ -97,8 +98,7 @@ iotjs_i2c_t* iotjs_i2c_create(const iotjs_jval_t* ji2c) {
   _this->i2c_master = NULL;
 #endif
 
-  iotjs_jobjectwrap_initialize(&_this->jobjectwrap, ji2c,
-                               (JFreeHandlerType)iotjs_i2c_destroy);
+  iotjs_jobjectwrap_initialize(&_this->jobjectwrap, ji2c, &i2c_native_info);
   return i2c;
 }
 

--- a/src/modules/iotjs_module_pwm.c
+++ b/src/modules/iotjs_module_pwm.c
@@ -20,13 +20,13 @@
 
 static void iotjs_pwm_destroy(iotjs_pwm_t* pwm);
 static iotjs_pwm_t* iotjs_pwm_instance_from_jval(const iotjs_jval_t* jpwm);
+IOTJS_DEFINE_NATIVE_HANDLE_INFO(pwm);
 
 
 static iotjs_pwm_t* iotjs_pwm_create(const iotjs_jval_t* jpwm) {
   iotjs_pwm_t* pwm = IOTJS_ALLOC(iotjs_pwm_t);
   IOTJS_VALIDATED_STRUCT_CONSTRUCTOR(iotjs_pwm_t, pwm);
-  iotjs_jobjectwrap_initialize(&_this->jobjectwrap, jpwm,
-                               (JFreeHandlerType)iotjs_pwm_destroy);
+  iotjs_jobjectwrap_initialize(&_this->jobjectwrap, jpwm, &pwm_native_info);
 
   _this->period = -1;
   _this->duty_cycle = 0;

--- a/src/modules/iotjs_module_spi.c
+++ b/src/modules/iotjs_module_spi.c
@@ -25,13 +25,13 @@
  */
 static void iotjs_spi_destroy(iotjs_spi_t* spi);
 static iotjs_spi_t* iotjs_spi_instance_from_jval(const iotjs_jval_t* jspi);
+IOTJS_DEFINE_NATIVE_HANDLE_INFO(spi);
 
 
 static iotjs_spi_t* iotjs_spi_create(const iotjs_jval_t* jspi) {
   iotjs_spi_t* spi = IOTJS_ALLOC(iotjs_spi_t);
   IOTJS_VALIDATED_STRUCT_CONSTRUCTOR(iotjs_spi_t, spi);
-  iotjs_jobjectwrap_initialize(&_this->jobjectwrap, jspi,
-                               (JFreeHandlerType)iotjs_spi_destroy);
+  iotjs_jobjectwrap_initialize(&_this->jobjectwrap, jspi, &spi_native_info);
 
   _this->device = iotjs_string_create("");
 

--- a/src/modules/iotjs_module_tcp.c
+++ b/src/modules/iotjs_module_tcp.c
@@ -23,6 +23,7 @@
 
 
 static void iotjs_tcpwrap_destroy(iotjs_tcpwrap_t* tcpwrap);
+IOTJS_DEFINE_NATIVE_HANDLE_INFO(tcpwrap);
 
 
 iotjs_tcpwrap_t* iotjs_tcpwrap_create(const iotjs_jval_t* jtcp) {
@@ -31,7 +32,7 @@ iotjs_tcpwrap_t* iotjs_tcpwrap_create(const iotjs_jval_t* jtcp) {
 
   iotjs_handlewrap_initialize(&_this->handlewrap, jtcp,
                               (uv_handle_t*)(&_this->handle),
-                              (JFreeHandlerType)iotjs_tcpwrap_destroy);
+                              &tcpwrap_native_info);
 
   const iotjs_environment_t* env = iotjs_environment_get();
   uv_tcp_init(iotjs_environment_loop(env), &_this->handle);

--- a/src/modules/iotjs_module_timer.c
+++ b/src/modules/iotjs_module_timer.c
@@ -19,6 +19,7 @@
 
 static void iotjs_timerwrap_destroy(iotjs_timerwrap_t* timerwrap);
 static void iotjs_timerwrap_on_timeout(iotjs_timerwrap_t* timerwrap);
+IOTJS_DEFINE_NATIVE_HANDLE_INFO(timerwrap);
 
 
 iotjs_timerwrap_t* iotjs_timerwrap_create(const iotjs_jval_t* jtimer) {
@@ -27,7 +28,7 @@ iotjs_timerwrap_t* iotjs_timerwrap_create(const iotjs_jval_t* jtimer) {
 
   iotjs_handlewrap_initialize(&_this->handlewrap, jtimer,
                               (uv_handle_t*)(&_this->handle),
-                              (JFreeHandlerType)iotjs_timerwrap_destroy);
+                              &timerwrap_native_info);
 
   // Initialize timer handler.
   const iotjs_environment_t* env = iotjs_environment_get();

--- a/src/modules/iotjs_module_uart.c
+++ b/src/modules/iotjs_module_uart.c
@@ -22,13 +22,13 @@
 
 static void iotjs_uart_destroy(iotjs_uart_t* uart);
 static iotjs_uart_t* iotjs_uart_instance_from_jval(const iotjs_jval_t* juart);
+IOTJS_DEFINE_NATIVE_HANDLE_INFO(uart);
 
 
 static iotjs_uart_t* iotjs_uart_create(const iotjs_jval_t* juart) {
   iotjs_uart_t* uart = IOTJS_ALLOC(iotjs_uart_t);
   IOTJS_VALIDATED_STRUCT_CONSTRUCTOR(iotjs_uart_t, uart);
-  iotjs_jobjectwrap_initialize(&_this->jobjectwrap, juart,
-                               (JFreeHandlerType)iotjs_uart_destroy);
+  iotjs_jobjectwrap_initialize(&_this->jobjectwrap, juart, &uart_native_info);
 
   _this->device_fd = -1;
 

--- a/src/modules/iotjs_module_udp.c
+++ b/src/modules/iotjs_module_udp.c
@@ -24,6 +24,7 @@
 
 
 static void iotjs_udpwrap_destroy(iotjs_udpwrap_t* udpwrap);
+IOTJS_DEFINE_NATIVE_HANDLE_INFO(udpwrap);
 
 
 iotjs_udpwrap_t* iotjs_udpwrap_create(const iotjs_jval_t* judp) {
@@ -32,7 +33,7 @@ iotjs_udpwrap_t* iotjs_udpwrap_create(const iotjs_jval_t* judp) {
 
   iotjs_handlewrap_initialize(&_this->handlewrap, judp,
                               (uv_handle_t*)(&_this->handle),
-                              (JFreeHandlerType)iotjs_udpwrap_destroy);
+                              &udpwrap_native_info);
 
   const iotjs_environment_t* env = iotjs_environment_get();
   uv_udp_init(iotjs_environment_loop(env), &_this->handle);


### PR DESCRIPTION
Update for build failure of JerryScript``01fe5ab``

* Remove deprecated JerryScript APIs

IoT.js-DCO-1.0-Signed-off-by: Youngil Choi duddlf.choi@samsung.com