### PR TITLE
Refactor issue-266.js testfile

### DIFF
--- a/test/run_pass/issue/issue-266.js
+++ b/test/run_pass/issue/issue-266.js
@@ -21,11 +21,11 @@ var assert = require('assert');
 var server = net.createServer();
 var port = 30266;
 
-var server = net.createServer();
 server.listen(port);
 
 server.on('connection', function(socket) {
   socket.on('data', function(data) {
+    server.close()
   });
   socket.on('finish', function() {
     socket.destroy();
@@ -33,12 +33,6 @@ server.on('connection', function(socket) {
     socket.destroy();
   });
 });
-
-
-setTimeout(function() {
-    server.close();
-}, 1000);
-
 
 var socket = new net.Socket();
 socket.connect(port, "127.0.0.1");


### PR DESCRIPTION
More information about the change can be read in this [page](https://github.com/Samsung/iotjs/issues/696). This modification and the [setjmp implementation](https://github.com/Samsung/iotjs/pull/767) fix the failing tests on the [stm32f4-discovery board](https://samsung.github.io/iotjs-test-results/).