### PR TITLE
[Code Coverage] Covering buffer + removing unneccessary functions

### DIFF
--- a/src/js/buffer.js
+++ b/src/js/buffer.js
@@ -19,8 +19,6 @@ var util = require('util');
 
 
 function checkInt(buffer, value, offset, ext, max, min) {
-  if (!(buffer instanceof Buffer))
-    throw new TypeError('buffer must be a Buffer instance');
   if (value > max || value < min)
     throw new TypeError('value is out of bounds');
   if (offset + ext > buffer.length)

--- a/src/modules/iotjs_module_buffer.c
+++ b/src/modules/iotjs_module_buffer.c
@@ -131,7 +131,6 @@ static unsigned hex2bin(char c) {
   if (c >= 'a' && c <= 'f')
     return 10 + (c - 'a');
 
-  IOTJS_ASSERT(!"Bad argument");
   return (unsigned)(-1);
 }
 

--- a/test/run_pass/test_buffer.js
+++ b/test/run_pass/test_buffer.js
@@ -53,6 +53,37 @@ assert.equal(buff4.toString(), 'a1b2c3');
 buff5.copy(buff4, 4, 2);
 assert.equal(buff4.toString(), 'a1b2b2c3');
 assert.throws(function() { buff5.copy(buff4, -1); }, RangeError);
+assert.throws(function() { buff2.write(null, 0, 0);}, TypeError);
+assert.throws(function() { buff5.copy(null); }, TypeError);
+assert.throws(function() { buff5.compare(null); }, TypeError);
+assert.throws(function() { buff5.equals(null); }, TypeError);
+assert.throws(function() { Buffer.concat([buff1, null]);}, TypeError);
+assert.throws(function() {Buffer.concat(null, null); }, TypeError);
+assert.throws(function() {var buff_err = new Buffer(null); }, TypeError);
+
+var buffer_err = new Buffer(-1);
+
+var buff_1 = new Buffer("asd");
+var buff_2 = new Buffer(2);
+buff_1.copy(buff_2, 0, 0, 2);
+buff_2.write("asd", 0, 3);
+
+assert.throws(function() {var buff_3 = new Buffer('asd', 'hex'); }, TypeError);
+
+var buff_3 = new Buffer(4);
+assert.throws(function() {buff_3.writeUInt8(10000, 0); }, TypeError);
+var buff_4 = new Buffer(4);
+assert.throws(function() {buff_4.writeUInt8(0x11, 3000); }, RangeError);
+var buff_5 = new Buffer(4);
+assert.throws(function() {buff_5.readUInt8(3000); }, RangeError);
+var buff_6 = buff_5.slice(undefined, 2);
+
+buff_5.fill("asd");
+
+buff_5.readInt8(3, true);
+buff_5.writeUInt32LE(0, 0, true);
+buff_5.writeUInt8(0, 0, true);
+buff_5.writeUInt16LE(0, 0, true);
 
 
 var buff6 = buff3.slice(1);


### PR DESCRIPTION
Buffer.js got a 100% coverage.
In addition there was an unnecessary if statement which checked whether the object calling it is a Buffer or not. This is not needed, since the function itself can only be called from a Buffer object, therefore this test would never run.
In iotjs_module_buffer.c IOTJS_ASSERT made the script crash, thus got commented.

IoT.js-DCO-1.0-Signed-off-by: Daniel Balla dballa@inf.u-szeged.hu