### PR TITLE
Use array for headers in http_common.js

### DIFF
--- a/src/js/http_common.js
+++ b/src/js/http_common.js
@@ -67,8 +67,7 @@ function parserOnHeadersComplete(info) {
 
   if (!headers) {
     headers = parser._headers;
-    // FIXME: This should be impl. with Array
-    parser._headers = {};
+    parser._headers = [];
   }
 
 
@@ -111,23 +110,11 @@ function parserOnBody(buf, start, len) {
 }
 
 
-function AddHeader(dest, src) {
-  if (!dest.length) {
-    dest.length = 0;
-  }
-
-  for (var i=0;i<src.length;i++) {
-    dest[dest.length+i] = src[i];
-  }
-  dest.length = dest.length + src.length;
-}
-
-
 // This is called when http header is fragmented and
 // HTTPParser sends it to JS in separate pieces.
 function parserOnHeaders(headers, url) {
-  // FIXME: This should be impl. with Array.concat
-  AddHeader(this._headers, headers);
+  // push new header parts into existing array
+  this._headers.push.apply(this._headers, headers);
   if (url) {
     this._url += url;
   }


### PR DESCRIPTION
Previously for storing headers an object was used as an array and
had a helper method do add elements into the headers object.

As the JS engine has full array support the logic can be
replaced with an array.

IoT.js-DCO-1.0-Signed-off-by: Peter Gal pgal.u-szeged@partner.samsung.com