### PR TITLE
Fix dns module test.

### DIFF
--- a/test/run_pass/test_dns_lookup.js
+++ b/test/run_pass/test_dns_lookup.js
@@ -44,16 +44,23 @@ dns.lookup('localhost', 4, function(err, ip, family) {
   assert.strictEqual(family, 4);
 });
 
+// Test without explicit options parameter.
+dns.lookup('localhost', function(err, ip, family) {
+  assert.equal(err, null);
+  assert.equal(isIPv4(ip), true);
+  assert.equal(ip, '127.0.0.1');
+});
+
 // Test with invalid hostname.
 dns.lookup('invalid', 4, function(err, ip, family) {
   assert.notEqual(err, null);
-  assert.equal(err.code, -3008);
+  assert.equal(err.code == -3008 || err.code == -3007, true);
 });
 
 // Test with empty hostname.
 dns.lookup('', 4, function(err, ip, family) {
   assert.notEqual(err, null);
-  assert.equal(err.code, -3008);
+  assert.equal(err.code == -3008 || err.code == -3007, true);
 });
 
 // Test with non string hostname.


### PR DESCRIPTION
 - Add a missing branch test.
 - Modify the error code check in the invalid hostname test cases.
      The returned code depends on the used system,
      in this case the -3007 and the -3008 error codes are valid.

IoT.js-DCO-1.0-Signed-off-by: Imre Kiss kissi.szeged@partner.samsung.com