### PR TITLE
Merge tryPath and statPath functions in module.js

### DIFF
--- a/src/js/module.js
+++ b/src/js/module.js
@@ -131,20 +131,13 @@ iotjs_module_t.resolveModPath = function(id, parent) {
 
 
 iotjs_module_t.tryPath = function(path) {
-  var stats = iotjs_module_t.statPath(path);
-  if(stats && !stats.isDirectory()) {
-    return path;
-  }
-  else {
-    return false;
-  }
-};
-
-
-iotjs_module_t.statPath = function(path) {
   try {
-    return fs.statSync(path);
+    var stats = fs.statSync(path);
+    if(stats && !stats.isDirectory()) {
+      return path;
+    }
   } catch (ex) {}
+
   return false;
 };
 


### PR DESCRIPTION
The statPath function was only used by the tryPath function.
By merging the two functions the .rodata size decreases
a bit.

IoT.js-DCO-1.0-Signed-off-by: Peter Gal pgal.u-szeged@partner.samsung.com