### PR TITLE
Do not create empty object for native js sources

### DIFF
--- a/src/modules/iotjs_module_process.c
+++ b/src/modules/iotjs_module_process.c
@@ -204,11 +204,8 @@ JHANDLER_FUNCTION(InitArgv) {
 
 void SetNativeSources(iotjs_jval_t* native_sources) {
   for (int i = 0; natives[i].name; i++) {
-    iotjs_jval_t native_src = iotjs_jval_create_object();
-    uintptr_t handle = (uintptr_t)(&natives[i]);
-    iotjs_jval_set_object_native_handle(&native_src, handle, NULL);
-    iotjs_jval_set_property_jval(native_sources, natives[i].name, &native_src);
-    iotjs_jval_destroy(&native_src);
+    iotjs_jval_set_property_jval(native_sources, natives[i].name,
+                                 iotjs_jval_get_boolean(true));
   }
 }
 


### PR DESCRIPTION
For each js native source an object was created and the
native handle was set for it. However the native handle
was never queried.

For now removing the object creation and just setting the
value to a boolean true. It would be possible to use a simple
list also but for that the module loading needs a bit of work
as currently it relies on the fact that the native_sources are
an object witk names as keys and something true as values.

Reduces base peak memory usage a bit.

IoT.js-DCO-1.0-Signed-off-by: Peter Gal pgal.u-szeged@partner.samsung.com