### PR TITLE
[Code Coverage] Covering events.js

### DIFF
--- a/src/js/events.js
+++ b/src/js/events.js
@@ -37,7 +37,6 @@ EventEmitter.prototype.emit = function(type) {
     } else {
       throw Error("Uncaught 'error' event");
     }
-    return false;
   }
 
   var listeners = this._events[type];

--- a/test/run_pass/test_events.js
+++ b/test/run_pass/test_events.js
@@ -37,6 +37,42 @@ emitter.emit('once');
 assert.equal(onceCnt, 1);
 
 
+{
+  var emit_test = new EventEmitter();
+  emit_test._events=false;
+  emit_test.emit();
+}
+{
+  var emit_test = new EventEmitter();
+  emit_test._events.error=false;
+  emit_test.emit(null);
+}
+{
+  var emit_test = new EventEmitter();
+  emit_test._events=false;
+  assert.throws(function() { emit_test.addListener(null, null); }, TypeError);
+}
+{
+  var emit_test = new EventEmitter();
+  emit_test._events=false;
+  emit_test.addListener('event', function() { });
+}
+{
+  var emit_test = new EventEmitter();
+  assert.throws(function() { emit_test.once(null, null); }, TypeError);
+}
+{
+  var emit_test = new EventEmitter();
+  assert.throws(function() {
+    emit_test.removeListener(null, null);
+  }, TypeError);
+}
+{
+  var emit_test = new EventEmitter();
+  emit_test._events = false;
+  emit_test.removeListener('rmtest', function() { });
+}
+
 emitter.once('once2', function() {
   onceCnt += 1;
   assert.equal(arguments.length, 14);


### PR DESCRIPTION
Remove line40 from events.js since it would be impossible to call it, as the previous if checks both exit with throw events.

IoT.js-DCO-1.0-Signed-off-by: Daniel Balla dballa@inf.u-szeged.hu