### PR TITLE
Use array for headers in http_client/server

### DIFF
--- a/src/js/http_client.js
+++ b/src/js/http_client.js
@@ -73,7 +73,7 @@ function setupConnection(req, socket) {
   req.connection = socket;
   parser.socket = socket;
   parser.incoming = null;
-  parser._headers = {};
+  parser._headers = [];
   req.parser = parser;
 
   socket.parser = parser;

--- a/src/js/http_server.js
+++ b/src/js/http_server.js
@@ -189,8 +189,7 @@ function connectionListener(socket) {
   // cf) In Node.js, freelist returns a new parser.
   // parser initialize
   var parser = common.createHTTPParser();
-  // FIXME: This should be impl. with Array
-  parser._headers = {};
+  parser._headers = [];
   parser._url = '';
 
   parser.onIncoming = parserOnIncoming;


### PR DESCRIPTION
The type of `headers` in `http_common` has recently been replaced
to array from object. This commit changes a few parts found in
`http_client/server` which handle it as object.

IoT.js-DCO-1.0-Signed-off-by: Daeyeon Jeong daeyeon.jeong@samsung.com