### PR TITLE
Remove unimplemented functions in fs.js

### DIFF
--- a/src/js/fs.js
+++ b/src/js/fs.js
@@ -101,17 +101,6 @@ fs.statSync = function(path) {
 };
 
 
-fs.fstat = function(fd, callback) {
-  fsBuiltin.fstat(checkArgNumber(fd, 'fd'),
-                  checkArgFunction(callback, 'callback'));
-};
-
-
-fs.fstatSync = function(fd) {
-  return fsBuiltin.fstat(checkArgNumber(fd, 'fd'));
-};
-
-
 fs.close = function(fd, callback) {
   fsBuiltin.close(checkArgNumber(fd, 'fd'),
                   checkArgFunction(callback, 'callback'));


### PR DESCRIPTION
fstat is not implemented in the C source file, causing crashes. fstatSync is also causing crashes, since it returns the missing builtin function fstat.
I suggest removing them from the code.

IoT.js-DCO-1.0-Signed-off-by: Daniel Balla dballa@inf.u-szeged.hu