### PR TITLE
Followup patch for the Jerry-debugger

### DIFF
--- a/cmake/jerry.cmake
+++ b/cmake/jerry.cmake
@@ -29,8 +29,6 @@ ExternalProject_Add(hostjerry
     -DJERRY_CMDLINE_MINIMAL=OFF
     -DFEATURE_SNAPSHOT_SAVE=${ENABLE_SNAPSHOT}
     -DFEATURE_PROFILE=es5.1
-    -DFEATURE_DEBUGGER=${FEATURE_DEBUGGER}
-    -DFEATURE_DEBUGGER_PORT=${FEATURE_DEBUGGER_PORT}
 )
 add_executable(jerry IMPORTED)
 add_dependencies(jerry hostjerry)

--- a/docs/devs/Use-JerryScript-Debugger.md
+++ b/docs/devs/Use-JerryScript-Debugger.md
@@ -6,8 +6,7 @@ Detailed description about the debugger is available
 ### Enable debugger support in IoT.js
 
 To enable the debugger support under IoT.js, the `--jerry-debugger` option
-should be passed to the `tools/build.py`. This option will implicitly turn on
-the system libc in JerryScript-submodule. The server part of the debugger is
+should be passed to the `tools/build.py`. The server part of the debugger is
 intergrated into the binary of IoT.js.
 
 If you want to specify the port number of the debugger-server (default: 5001),


### PR DESCRIPTION
After jerryscript#1734 we don't need to add
the debugger-related defines at hostjerry build.

This patch also get rid of some remnants of a previous version of #722.

IoT.js-DCO-1.0-Signed-off-by: Zsolt Borbély zsborbely.u-szeged@partner.samsung.com