### PR TITLE
Avoid manual argument copy, use Array slice instead in events.js

### DIFF
--- a/src/js/events.js
+++ b/src/js/events.js
@@ -42,11 +42,7 @@ EventEmitter.prototype.emit = function(type) {
   var listeners = this._events[type];
   if (util.isArray(listeners)) {
     listeners = listeners.slice();
-    var len = arguments.length;
-    var args = new Array(len - 1);
-    for (var i = 1; i < len; ++i) {
-      args[i - 1] = arguments[i];
-    }
+    var args = Array.prototype.slice.call(arguments, 1);
     for (var i = 0; i < listeners.length; ++i) {
       listeners[i].apply(this, args);
     }


### PR DESCRIPTION
To remove the first argument form the arguments object previously
a manual copy was used. This can be replaced by an Array.slice call.

IoT.js-DCO-1.0-Signed-off-by: Peter Gal pgal.u-szeged@partner.samsung.com