### PR TITLE
Test case for the Event Emitter

### DIFF
--- a/test/run_pass/test_events.js
+++ b/test/run_pass/test_events.js
@@ -213,3 +213,19 @@ eventSequence += "|";
 
 
 assert.equal(eventSequence, "112123123456677|7||88||123||");
+
+
+/* Test if an event listener for a once
+   call can be removed.
+ */
+var removableListenerCnt = 0;
+function removableListener() {
+  removableListenerCnt++;
+}
+
+emitter.once('onceRemove', removableListener);
+assert.equal(removableListenerCnt, 0);
+emitter.removeListener('onceRemove', removableListener);
+emitter.emit('onceRemove');
+assert.equal(removableListenerCnt, 0,
+    'a listener for a "once" typed evet should be removable');


### PR DESCRIPTION
Test if an event listener for a 'once' call can be removed.

IoT.js-DCO-1.0-Signed-off-by: Peter Gal pgal.u-szeged@partner.samsung.com