### PR TITLE
Fix include order for newer clang-format

### DIFF
--- a/src/platform/linux/iotjs_module_uart-linux.c
+++ b/src/platform/linux/iotjs_module_uart-linux.c
@@ -17,12 +17,12 @@
 #ifndef IOTJS_MODULE_UART_LINUX_GENERAL_INL_H
 #define IOTJS_MODULE_UART_LINUX_GENERAL_INL_H
 
-#include "modules/iotjs_module_uart.h"
 #include <errno.h>
 #include <fcntl.h>
 #include <termios.h>
 #include <unistd.h>
 
+#include "modules/iotjs_module_uart.h"
 
 static int baud_to_constant(int baudRate) {
   switch (baudRate) {

--- a/src/platform/nuttx/iotjs_module_i2c-nuttx.c
+++ b/src/platform/nuttx/iotjs_module_i2c-nuttx.c
@@ -15,9 +15,9 @@
 
 #if defined(__NUTTX__)
 
+#include "iotjs_systemio-nuttx.h"
 
 #include "modules/iotjs_module_i2c.h"
-#include "iotjs_systemio-nuttx.h"
 
 
 #define I2C_DEFAULT_FREQUENCY 400000

--- a/src/platform/nuttx/iotjs_module_stm32f4dis-nuttx.c
+++ b/src/platform/nuttx/iotjs_module_stm32f4dis-nuttx.c
@@ -17,9 +17,10 @@
 
 
 #include "iotjs_def.h"
-#include "modules/iotjs_module_stm32f4dis.h"
 #include "iotjs_systemio-nuttx.h"
 #include "stm32_gpio.h"
+
+#include "modules/iotjs_module_stm32f4dis.h"
 
 
 #if ENABLE_MODULE_ADC


### PR DESCRIPTION
The clang-fromat (3.8+) also checks #include order to
make sure it is in alphabetical order.

IoT.js-DCO-1.0-Signed-off-by: Peter Gal pgal.u-szeged@partner.samsung.com