### PR TITLE
make dns.lookup asynchonous (fix for nuttx)

### DIFF
--- a/src/js/dns.js
+++ b/src/js/dns.js
@@ -59,18 +59,19 @@ exports.lookup = function lookup(hostname, options, callback) {
   if (family !== 0 && family !== 4 && family !== 6)
     throw new TypeError('invalid argument: family must be 4 or 6');
 
-  var err = dnsBuiltin.getaddrinfo(
-      hostname,
-      family,
-      hints,
-      function(err, address, family) {
-        var errObj = null;
-        if (err) {
-          errObj = dnsException(err, 'getaddrinfo', hostname);
-        }
-        return callback(errObj, address, family);
-      });
-  return err;
+   process.nextTick(function() {
+     var err = dnsBuiltin.getaddrinfo(
+       hostname,
+       family,
+       hints,
+       function(err, address, family) {
+         var errObj = null;
+         if (err) {
+           errObj = dnsException(err, 'getaddrinfo', hostname);
+         }
+       callback(errObj, address, family);
+       });
+   });
 };
 
 


### PR DESCRIPTION
On nuttx, I noticed that some net and dns events get fired too early, before the call stack has completed execution and all handlers are registered.

On nuttx, ``dnsBuiltin.getaddrinfo`` synchronously calls ``iotjs_make_callback``, with the effect of running the lookup callback synchronously and then processing the nextTick queue.
As a result, the ``lookup`` event is fired immediately after the callback is run. This has also indirect consequences on the ``net.connect``events which are also fired too early.

I think that this is an improper use of ``iotjs_make_callback`` which should only be called from asynchronous C callbacks ( such as libuv callbacks) and never from synchronous C code.

The proposed fix wraps the call to ``dnsBuiltin.getaddrinfo`` into a ``process.nextTick`` to ensure that the code will run its own tick.

IoT.js-DCO-1.0-Signed-off-by: Vincent Prunet vincent.prunet@gmail.com