### PR TITLE
Optimize memory usage of iotjs_timerwrap_t.

### DIFF
--- a/src/modules/iotjs_module_timer.h
+++ b/src/modules/iotjs_module_timer.h
@@ -23,7 +23,6 @@
 
 typedef struct {
   iotjs_handlewrap_t handlewrap;
-  uv_timer_t handle;
 } IOTJS_VALIDATED_STRUCT(iotjs_timerwrap_t);
 
 


### PR DESCRIPTION
Results on RPi2, `test_net3.js`:
**before**
```
[1] Peak: 51.3Kb (52576b) Allocs: 5738 Reallocs: 0 Total: 186.7Kb (191188b) 
Group: iotjs
  [2] Peak: 47.5Kb (48640b) Allocs: 828 Reallocs: 0 Total: 64.6Kb (66240b) 
  Group: timer
```
**after**
```
[1] Peak: 48.9Kb (50152b) Allocs: 6566 Reallocs: 0 Total: 183.4Kb (187876b) 
  Group: iotjs
    [2] Peak: 45.0Kb (46132b) Allocs: 1656 Reallocs: 0 Total: 61.4Kb (62928b) 
    Group: timer
```

Related issue: #725 