### PR TITLE
Remove unused require calls from http common module

### DIFF
--- a/src/js/http_common.js
+++ b/src/js/http_common.js
@@ -13,12 +13,10 @@
  * limitations under the License.
  */
 
-var EventEmitter = require('events');
 var util = require('util');
 var HTTPParser = process.binding(process.binding.httpparser).HTTPParser;
 var IncomingMessage = require('http_incoming').IncomingMessage;
 var OutgoingMessage = require('http_outgoing').OutgoingMessage;
-var Buffer = require('buffer');
 
 
 


### PR DESCRIPTION
EventEmmitter and Buffer modules were not used in the
http_common.js module so we'll just remove them.

IoT.js-DCO-1.0-Signed-off-by: Peter Gal pgal.u-szeged@partner.samsung.com