### PR TITLE
Remove unused require calls from http server module

### DIFF
--- a/src/js/http_server.js
+++ b/src/js/http_server.js
@@ -13,13 +13,9 @@
  * limitations under the License.
  */
 
-var EventEmitter = require('events');
 var util = require('util');
 var net = require('net');
-var HTTPParser = process.binding(process.binding.httpparser).HTTPParser;
-var IncomingMessage = require('http_incoming').IncomingMessage;
 var OutgoingMessage = require('http_outgoing').OutgoingMessage;
-var Buffer = require('buffer');
 var common = require('http_common');
 
 // RFC 7231 (http://tools.ietf.org/html/rfc7231#page-49)


### PR DESCRIPTION
EventEmmitter, HTTPParser, IncomingMessage, and Buffer
modules were not used in the http_server.js module so
just remove them.

IoT.js-DCO-1.0-Signed-off-by: Peter Gal pgal.u-szeged@partner.samsung.com