### PR TITLE
Fix build type parameter for js2c call

### DIFF
--- a/cmake/iotjs.cmake
+++ b/cmake/iotjs.cmake
@@ -89,7 +89,7 @@ get_variable_value(IOTJS_JS_MODULES
 
 # Run js2c
 set(JS2C_RUN_MODE "release")
-if("${CMAKE_BUILD_TYPE}" STREQUAL "debug")
+if("${CMAKE_BUILD_TYPE}" STREQUAL "Debug")
   set(JS2C_RUN_MODE "debug")
 endif()
 


### PR DESCRIPTION
Previously even in debug mode the js2c was called
with the --buildtype=release option. For snapshot
mode this does nothing however for a no-snapshot build
the js files were always stripped of empty lines and commends
thus making debugging js code a bit harder as the line infos
were off.

By correctly detecting the build type in the CMAKE files
the buildtype problem will be resolved.

IoT.js-DCO-1.0-Signed-off-by: Peter Gal pgal.u-szeged@partner.samsung.com