### PR TITLE
[Code coverage] Improve the http module coverage.

### DIFF
--- a/test/run_pass/test_net_headers.js
+++ b/test/run_pass/test_net_headers.js
@@ -29,6 +29,8 @@ var server = http.createServer(function (req, res) {
   });
 
   var endHandler = function () {
+    // this should return.
+    res.removeHeader('h1');
 
     res.setHeader('h1','h1');
     res.setHeader('h2','h2');
@@ -39,8 +41,13 @@ var server = http.createServer(function (req, res) {
     }
     // final res.headers = { 'h1' : 'h1', 'h3': 'h3prime' }
 
+    // Large header on response.
+    for (var i = 0; i < 500; i++) {
+      res.setHeader('h' + (5 + i), 'h' + (5 + i));
+    }
+
     res.end(function(){
-        server.close();
+      server.close();
     });
   };
 

--- a/test/run_pass/test_net_http_request_response.js
+++ b/test/run_pass/test_net_http_request_response.js
@@ -1,0 +1,195 @@
+/* Copyright 2017-present Samsung Electronics Co., Ltd. and other contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+var assert = require('assert');
+var http = require('http');
+var net = require('net');
+
+// Messages for further requests.
+var message = 'Hello IoT.js';
+
+// Options for further requests.
+var options = {
+  method: 'POST',
+  port: 3005,
+  path: '/',
+  headers : {'Content-Length': message.length}
+};
+
+var server1 = http.createServer(function(request, response) {
+  var str = '';
+
+  request.on('data', function (chunk) {
+    str += chunk.toString();
+  });
+
+  request.on('end', function() {
+    assert.equal(str, message);
+    response.end();
+  });
+});
+server1.listen(3005, 5);
+
+// Simple request with valid utf-8 message.
+var isRequest1Finished = false;
+var request1 = http.request(options, function(response) {
+  var str = '';
+
+  response.on('data', function(chunk) {
+    str += chunk.toString();
+  });
+
+  response.on('end', function() {
+    isRequest1Finished = true;
+    server1.close();
+  });
+});
+request1.end(message, 'utf-8');
+
+
+var server2 = http.createServer(function(request, response) {
+  response.end();
+});
+server2.listen(3006, 5);
+
+// Simple request with end callback.
+var isRequest2Finished = false;
+options.port = 3006;
+var request2 = http.request(options);
+request2.end(message, function() {
+  server2.close();
+  isRequest2Finished = true;
+});
+
+// Call the request2 end again to test the finish state.
+request2.end(message, function() {
+  // This clabback should never be called.
+  assert.equal(isRequest2Finished, false);
+});
+
+
+var server3 = http.createServer(function(request, response) {
+  var str = '';
+
+  request.on('data', function(chunk) {
+    str += chunk;
+  });
+
+  request.on('end', function() {
+    // Check if we got the proper message.
+    assert.equal(str, message);
+    response.end();
+  });
+});
+server3.listen(3007, 5);
+
+// Simple request with buffer chunk as message parameter.
+options.port = 3007;
+var isRequest3Finished = false;
+var request3 = http.request(options, function(response) {
+  var str = '';
+
+  response.on('data', function(chunk) {
+    str += chunk;
+  });
+
+  response.on('end', function() {
+    isRequest3Finished = true;
+    server3.close();
+  });
+});
+request3.end(new Buffer(message));
+
+
+// This test is to make sure that when the HTTP server
+// responds to a HEAD request, it does not send any body.
+var server4 = http.createServer(function(request, response) {
+  response.writeHead(200);
+  response.end();
+});
+server4.listen(3008, 5);
+
+var isRequest4Finished = false;
+var request4 = http.request({
+  method: 'HEAD',
+  port: 3008,
+  path: '/'
+}, function(response) {
+  response.on('end', function() {
+    isRequest4Finished = true;
+    assert.equal(response.statusCode, 200);
+    server4.close();
+  });
+});
+request4.end();
+
+
+// Write a header twice in the server response.
+var server5 = http.createServer(function(request, response) {
+  var str = '';
+
+  request.on('data', function(chunk) {
+    str += chunk;
+  });
+
+  request.on('end', function() {
+    response.writeHead(200, 'OK', {'Connection' : 'close1'});
+    // Wrote the same head twice.
+    response.writeHead(200, 'OK', {'Connection' : 'close2'});
+    // Wrote a new head.
+    response.writeHead(200, {'Head' : 'Value'});
+    response.end();
+  });
+});
+server5.listen(3009, 5);
+
+options.port = 3009;
+options.headers = null;
+var isRequest5Finished = false;
+var request5 = http.request(options, function(response) {
+  response.on('end', function() {
+    isRequest5Finished = true;
+    assert.equal(response.headers['Connection'], 'close2');
+    assert.equal(response.headers['Head'], 'Value');
+    server5.close();
+  });
+});
+request5.end();
+
+
+// Test the IncomingMessage read function.
+var readRequest = http.request({
+  host: 'localhost',
+  port: 80,
+  path: '/',
+  method: 'GET'
+});
+readRequest.end();
+readRequest.on('response', function(incomingMessage) {
+  incomingMessage.on('readable', function() {
+    var inc = incomingMessage.read();
+    assert.equal(inc instanceof Buffer, true);
+    assert(inc.toString('utf8').length > 0);
+  });
+});
+
+
+process.on('exit', function() {
+  assert.equal(isRequest1Finished, true);
+  assert.equal(isRequest2Finished, true);
+  assert.equal(isRequest3Finished, true);
+  assert.equal(isRequest4Finished, true);
+  assert.equal(isRequest5Finished, true);
+});

--- a/test/run_pass/test_net_httpserver.js
+++ b/test/run_pass/test_net_httpserver.js
@@ -14,6 +14,7 @@
  */
 
 var assert = require('assert');
+var Server = require('http_server').Server;
 var http = require('http');
 
 
@@ -176,6 +177,12 @@ finalReq.on('socket', function() {
 finalReq.write(finalMsg);
 finalReq.end();
 
+// Create server without requestListener.
+var server2 = http.createServer();
+
+// Create server instance without new keyword.
+var server3 = Server(function(request, response) {});
+
 process.on('exit', function() {
   assert.equal(responseCheck.length, 3);
   assert.equal(connectionEvent, 3);
@@ -183,4 +190,6 @@ process.on('exit', function() {
   assert.equal(requestEvent, 3);
   assert.equal(responseEvent, 3);
   assert.equal(socketEvent, 3);
+  assert.equal(server2 instanceof Server, true);
+  assert.equal(server3 instanceof Server, true);
 });

--- a/test/run_pass/test_net_httpserver_timeout.js
+++ b/test/run_pass/test_net_httpserver_timeout.js
@@ -25,6 +25,7 @@ var server = http.createServer(function(req, res) {
 });
 
 server.listen(3003);
+
 server.setTimeout(100, function(socket) {
   timeouted = true;
   socket.destroy();

--- a/test/testsets.json
+++ b/test/testsets.json
@@ -51,6 +51,7 @@
     { "name": "test_net_headers.js", "skip": ["nuttx"], "reason": "not implemented for nuttx" },
     { "name": "test_net_http_get.js", "timeout": 20, "skip": ["nuttx"], "reason": "not implemented for nuttx" },
     { "name": "test_net_http_response_twice.js", "timeout": 10, "skip": ["nuttx"], "reason": "not implemented for nuttx" },
+    { "name": "test_net_http_request_response.js", "timeout": 10, "skip": ["nuttx"], "reason": "not implemented for nuttx" },
     { "name": "test_net_http_status_codes.js", "timeout": 20, "skip": ["nuttx"], "reason": "not implemented for nuttx" },
     { "name": "test_net_httpclient_timeout_1.js", "timeout": 10, "skip": ["nuttx"], "reason": "not implemented for nuttx" },
     { "name": "test_net_httpclient_timeout_2.js", "timeout": 15, "skip": ["nuttx"], "reason": "not implemented for nuttx" },


### PR DESCRIPTION
- Add new test cases to the existing files.
- Add new test file to cover the request response messages.

Note: The setTimeout function from the outgoungMessage is deleted,
because every parents are implements their own setTimeout function.

IoT.js-DCO-1.0-Signed-off-by: Imre Kiss kissi.szeged@partner.samsung.com