### PR TITLE
[Code Coverage] Improve coverage of stream_writable.js

### DIFF
--- a/src/js/stream_writable.js
+++ b/src/js/stream_writable.js
@@ -209,10 +209,6 @@ function writeBuffered(stream) {
 function doWrite(stream, chunk, callback) {
   var state = stream._writableState;
 
-  if (state.writing) {
-    return new Error('write during writing');
-  }
-
   // The stream is now writing.
   state.writing = true;
   state.writingLength = chunk.length;

--- a/test/run_pass/test_stream_writable.js
+++ b/test/run_pass/test_stream_writable.js
@@ -1,0 +1,42 @@
+/* Copyright 2015-present Samsung Electronics Co., Ltd. and other contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+var assert = require('assert');
+
+var Writable = require('stream').Writable;
+var writable = new Writable({highWaterMark: 0});
+
+var writable2 = Writable({highWaterMark: 0});
+
+assert.throws(function() { writable._write(0, 0, 0); }, Error);
+
+writable._writableState.writing = true;
+writable._writableState.needDrain = false;
+writable._readyToWrite();
+
+writable.end('', function(){});
+
+writable2._writableState.ending = true;
+writable2.end('', function(){});
+
+var writable3 = new Writable({highWaterMark: 0});
+writable3._writableState.buffer.length=0;
+writable3._writableState.ending = true;
+writable3._writableState.ended = true;
+writable3._readyToWrite();
+
+
+process.exit(0);

--- a/test/testsets.json
+++ b/test/testsets.json
@@ -69,6 +69,7 @@
     { "name": "test_stat.js", "skip": ["all"], "reason": "dynamically changing result" },
     { "name": "test_stream.js" },
     { "name": "test_stream_duplex.js"},
+    { "name": "test_stream_writable.js" },
     { "name": "test_timers_arguments.js" },
     { "name": "test_timers_error.js" },
     { "name": "test_timers_simple.js", "timeout": 10 },


### PR DESCRIPTION
Removed the if check, since it would never be called, as doWrite only happens when state.writing is false.
IoT.js-DCO-1.0-Signed-off-by: Daniel Balla dballa@inf.u-szeged.hu