### PR TITLE
FileSystem fix: writeFile/writeFileSync now accept string values as data

### DIFF
--- a/docs/api/IoT.js-API-File-System.md
+++ b/docs/api/IoT.js-API-File-System.md
@@ -222,7 +222,7 @@ Writes buffer to the file specified by fd synchronously.
 
 ### `fs.writeFile(path, data, [, options], callback)`
 * `path <String>` - file path that the `data` will be written
-* `data <Buffer>` - buffer that contains data
+* `data <String> | <Buffer>` - buffer or string that contains data
 * `options <Object>` - options for the operation
 * `callback <Function(err: null | Error)>`
 
@@ -239,7 +239,7 @@ fs.writeFile('test.txt', 'IoT.js', function(err) {
 
 ### `fs.writeFileSync(path, data, [, options])`
 * `path <String>` - file path that the `data` will be written
-* `data <Buffer>` - buffer that contains data
+* `data <String> | <Buffer>` - buffer or string that contains data
 * `options <Object>` - options for the operation
 
 Writes entire `data` to the file specified by `path` synchronously.

--- a/test/run_pass/test_fs_writefile.js
+++ b/test/run_pass/test_fs_writefile.js
@@ -1,0 +1,50 @@
+/* Copyright 2016-present Samsung Electronics Co., Ltd. and other contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+ /*
+  @STDOUT=Pass
+ */
+
+var fs = require('fs');
+var assert = require('assert');
+
+var file = process.cwd() + '/resources/test';
+var buff1 = new Buffer('test string1');
+var str = 'test string2';
+var num = 1;
+
+fs.writeFile(file, buff1, function (err) {
+  assert.equal(err, null);
+  fs.readFile(file, function (err, buff2) {
+    assert.equal(err, null);
+      assert.equal(buff2.equals(buff1), true);
+      fs.writeFile(file, str, function (err) {
+        assert.equal(err, null);
+        fs.readFile(file, function (err, buff2) {
+          assert.equal(err, null);
+          assert.equal(str.valueOf(), buff2.toString('utf8'));
+            fs.writeFile(file, num, function (err) {
+            assert.equal(err, null);
+              fs.readFile(file, function (err, buff2) {
+                assert.equal(err, null);
+                assert.equal(num, parseInt(buff2.toString('utf8'), 10));
+                console.log('Pass');
+                fs.unlinkSync(file);
+              });
+            });
+        });
+      });
+    });
+});

--- a/test/run_pass/test_fs_writefile_sync.js
+++ b/test/run_pass/test_fs_writefile_sync.js
@@ -1,0 +1,45 @@
+
+/* Copyright 2016-present Samsung Electronics Co., Ltd. and other contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+ /*
+  @STDOUT=Pass
+ */
+
+var fs = require('fs');
+var assert = require('assert');
+
+var file = process.cwd() + '/resources/test';
+var buff1 = new Buffer('test string1');
+var buff2 = null;
+var str = 'test string2';
+var num = 1;
+
+fs.writeFileSync(file, buff1);
+buff2 = fs.readFileSync(file);
+assert.equal(buff2.equals(buff1), true);
+
+fs.writeFileSync(file, str);
+buff2 = fs.readFileSync(file);
+assert.equal(str.valueOf(), buff2.toString('utf8'));
+
+
+fs.writeFileSync(file, num);
+buff2 = fs.readFileSync(file);
+assert.equal(num, parseInt(buff2.toString('utf8'), 10));
+
+console.log('Pass');
+
+fs.unlinkSync(file);

--- a/test/testsets.json
+++ b/test/testsets.json
@@ -28,6 +28,8 @@
     { "name": "test_fs_rename.js" },
     { "name": "test_fs_rename_sync.js" },
     { "name": "test_fs_stat.js", "skip": ["nuttx"], "reason": "not implemented for nuttx" },
+    { "name": "test_fs_writefile.js" },
+    { "name": "test_fs_writefile_sync.js" },
     { "name": "test_fs_writefile_unlink.js" },
     { "name": "test_fs_writefile_unlink_sync.js" },
     { "name": "test_fs_event.js", "skip": ["nuttx"], "reason": "not implemented for nuttx" },


### PR DESCRIPTION
FileSystem fix: writeFile/writeFileSync now accept string values as data

IoT.js-DCO-1.0-Signed-off-by: Krzysztof Antoszek k.antoszek@samsung.com