### PR TITLE
Check if Writeable Stream's options is undefined while setting highWaterMark

### DIFF
--- a/src/js/stream_writable.js
+++ b/src/js/stream_writable.js
@@ -37,8 +37,8 @@ function WritableState(options) {
 
   // high water mark.
   // The point where write() starts retuning false.
-  var hwm = options.highWaterMark;
-  this.highWaterMark = (hwm || hwm === 0) ? hwm : defaultHighWaterMark;
+  this.highWaterMark = (options && util.isNumber(options.highWaterMark)) ?
+    options.highWaterMark : defaultHighWaterMark;
 
   // 'true' if stream is ready to write.
   this.ready = false;


### PR DESCRIPTION
The previous code caused the program to stop if options was not defined while creating a Writable Stream.
This reverts to the default highWaterMark if options is undefined.
The options argument for Writable Constructor should ideally be an optional argument, since the only property it must supply is highWaterMark, which we have a default value for.

IoT.js-DCO-1.0-Signed-off-by: Akhil Kedia <akhil.kedia@samsung.com>