### PR TITLE
Rework Nuttx config

### DIFF
--- a/config/nuttx/stm32f4dis/app/Makefile
+++ b/config/nuttx/stm32f4dis/app/Makefile
@@ -58,24 +58,23 @@ CONFIG_IOTJS_STACKSIZE ?= 16384
 # NSH sysinfo command
 
 APPNAME = iotjs
-IOTJS_ROOT_DIR = ../../../iotjs
+CFLAGS += -I$(IOTJS_ROOT_DIR)/deps/jerry/jerry-core/include
+CFLAGS += -I$(IOTJS_ROOT_DIR)/deps/jerry/jerry-ext/include
 PRIORITY = $(CONFIG_IOTJS_PRIORITY)
 STACKSIZE = $(CONFIG_IOTJS_STACKSIZE)
 HEAPSIZE = $(CONFIG_IOTJS_HEAPSIZE)
 
 ASRCS = setjmp.S
-CSRCS =
-CXXSRCS =
-MAINSRC = iotjs_main.cxx
-LIBS = libhttpparser.a libiotjs.a libjerry-core.a libtuv.a libjerry-libm.a libjerry-port-default.a libjerry-libc.a
+CSRCS = jerry_port.c
+MAINSRC = iotjs_main.c
+LIBS = libhttpparser.a libiotjs.a libjerry-core.a libtuv.a libjerry-libm.a
 
 AOBJS = $(ASRCS:.S=$(OBJEXT))
 COBJS = $(CSRCS:.c=$(OBJEXT))
-CXXOBJS = $(CXXSRCS:.cxx=$(OBJEXT))
-MAINOBJ = $(MAINSRC:.cxx=$(OBJEXT))
+MAINOBJ = $(MAINSRC:.c=$(OBJEXT))
 
-SRCS = $(ASRCS) $(CSRCS) $(CXXSRCS) $(MAINSRC)
-OBJS = $(AOBJS) $(COBJS) $(CXXOBJS)
+SRCS = $(ASRCS) $(CSRCS) $(MAINSRC)
+OBJS = $(AOBJS) $(COBJS)
 
 ifeq ($(R),1)
   BUILD_TYPE = release
@@ -115,27 +114,11 @@ VPATH =
 all: .built
 .PHONY: context depend clean distclean
 
-chkcxx:
-ifneq ($(CONFIG_HAVE_CXX),y)
-  @echo ""
-  @echo "In order to use this example, you toolchain must support must"
-  @echo ""
-  @echo "  (1) Explicitly select CONFIG_HAVE_CXX to build in C++ support"
-  @echo "  (2) Define CXX, CXXFLAGS, and COMPILEXX in the Make.defs file"
-  @echo "      of the configuration that you are using."
-  @echo ""
-  @exit 1
-endif
-
-
 $(AOBJS): %$(OBJEXT): %.S
 	$(call ASSEMBLE, $<, $@)
 
 $(COBJS): %$(OBJEXT): %.c
 	$(call COMPILE, $<, $@)
-
-$(CXXOBJS) $(MAINOBJ): %$(OBJEXT): %.cxx
-	$(call COMPILEXX, $<, $@)
 
 copylibs :
 	cp $(IOTJS_ROOT_DIR)/build/arm-nuttx/$(BUILD_TYPE)/lib/lib*.a .
@@ -143,7 +126,7 @@ copylibs :
 $(LIBS) : copylibs
 	$(firstword $(AR)) x $@
 
-.built: chkcxx $(LIBS) $(OBJS)
+.built: $(LIBS) $(OBJS)
 	$(eval OBJS += $(shell find . -name "*.obj"))
 	$(call ARCHIVE, $(BIN), $(OBJS))
 	$(Q) touch .built
@@ -175,7 +158,7 @@ endif
 # Create dependencies
 
 .depend: Makefile $(SRCS)
-	$(Q) $(MKDEP) $(ROOTDEPPATH) "$(CXX)" -- $(CXXFLAGS) -- $(SRCS) >Make.dep
+	$(Q) $(MKDEP) $(ROOTDEPPATH) "$(CC)" -- $(CFLAGS) -- $(SRCS) >Make.dep
 	$(Q) touch $@
 
 depend: .depend

--- a/config/nuttx/stm32f4dis/app/iotjs_main.c
+++ b/config/nuttx/stm32f4dis/app/iotjs_main.c
@@ -50,35 +50,26 @@
  * Included Files
  ****************************************************************************/
 
-#include <nuttx/config.h>
 #include <nuttx/arch.h>
+#include <nuttx/config.h>
 
 #include <stdio.h>
 #include "setjmp.h"
-
-#ifdef CONFIG_IOTJS
-# if !defined(CONFIG_HAVE_CXX) || !defined(CONFIG_HAVE_CXXINITIALIZE)
-#   error Need CONFIG_HAVE_CXX and CONFIG_HAVE_CXXINITIALIZE
-# endif
-#endif
 
 /****************************************************************************
  * Public Functions
  ****************************************************************************/
 
-
-
-extern "C" int iotjs_entry(int argc, char *argv[]);
-extern "C" int tuv_cleanup(void);
+extern int iotjs_entry(int argc, char *argv[]);
+extern int tuv_cleanup(void);
 
 #ifdef CONFIG_BUILD_KERNEL
-extern "C" int main(int argc, FAR char *argv[])
+extern int main(int argc, FAR char *argv[])
 #else
-extern "C" int iotjs_main(int argc, char *argv[])
+extern int iotjs_main(int argc, char *argv[])
 #endif
 {
   int ret = 0;
-  up_cxxinitialize();
   ret = iotjs_entry(argc, argv);
   tuv_cleanup();
   return ret;

--- a/config/nuttx/stm32f4dis/app/jerry_port.c
+++ b/config/nuttx/stm32f4dis/app/jerry_port.c
@@ -1,0 +1,68 @@
+/* Copyright 2017-present Samsung Electronics Co., Ltd. and other contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "jerryscript-ext/handler.h"
+#include "jerryscript-port.h"
+#include "jerryscript.h"
+
+/**
+ * Aborts the program.
+ */
+void jerry_port_fatal(jerry_fatal_code_t code) {
+  exit(1);
+} /* jerry_port_fatal */
+
+/**
+ * Provide log message implementation for the engine.
+ */
+void jerry_port_log(jerry_log_level_t level, /**< log level */
+                    const char *format,      /**< format string */
+                    ...) {                   /**< parameters */
+  /* Drain log messages since IoT.js has not support log levels yet. */
+} /* jerry_port_log */
+
+/**
+ * Dummy function to get the time zone.
+ *
+ * @return true
+ */
+bool jerry_port_get_time_zone(jerry_time_zone_t *tz_p) {
+  /* We live in UTC. */
+  tz_p->offset = 0;
+  tz_p->daylight_saving_time = 0;
+
+  return true;
+} /* jerry_port_get_time_zone */
+
+/**
+ * Dummy function to get the current time.
+ *
+ * @return 0
+ */
+double jerry_port_get_current_time(void) {
+  return 0;
+} /* jerry_port_get_current_time */
+
+/**
+ * Provide the implementation of jerryx_port_handler_print_char.
+ * Uses 'printf' to print a single character to standard output.
+ */
+void jerryx_port_handler_print_char(char c) { /**< the character to print */
+  printf("%c", c);
+} /* jerryx_port_handler_print_char */

--- a/src/iotjs.c
+++ b/src/iotjs.c
@@ -21,7 +21,9 @@
 #include "iotjs_string_ext.h"
 
 #include "jerryscript-debugger.h"
+#ifndef __NUTTX__
 #include "jerryscript-port-default.h"
+#endif
 #include "jerryscript-port.h"
 #include "jerryscript.h"
 
@@ -38,12 +40,16 @@ static bool iotjs_jerry_initialize(const iotjs_environment_t* env) {
 
   if (iotjs_environment_config(env)->memstat) {
     jerry_flag |= JERRY_INIT_MEM_STATS;
+#ifndef __NUTTX__
     jerry_port_default_set_log_level(JERRY_LOG_LEVEL_DEBUG);
+#endif
   }
 
   if (iotjs_environment_config(env)->show_opcode) {
     jerry_flag |= JERRY_INIT_SHOW_OPCODES;
+#ifndef __NUTTX__
     jerry_port_default_set_log_level(JERRY_LOG_LEVEL_DEBUG);
+#endif
   }
 
   if (iotjs_environment_config(env)->debugger) {


### PR DESCRIPTION
Nuttx build should use it's own JerryScript port instead of
the default port from JerryScript. Nuttx build should not use
jerry-libc. Use gcc only for Nuttx builds.

IoT.js-DCO-1.0-Signed-off-by: László Langó llango.u-szeged@partner.samsung.com