### PR TITLE
Integrate jerryscript promise to iotjs main loop

### DIFF
--- a/src/iotjs.c
+++ b/src/iotjs.c
@@ -146,6 +146,10 @@ static bool iotjs_start(iotjs_environment_t* env) {
     if (more == false) {
       more = uv_loop_alive(iotjs_environment_loop(env));
     }
+    jerry_value_t ret_val = jerry_run_all_enqueued_jobs();
+    if (jerry_value_has_error_flag(ret_val)) {
+      DLOG("jerry_run_all_enqueued_jobs() failed");
+    }
   } while (more);
 
   iotjs_environment_go_state_exiting(env);

--- a/test/run_pass/test_promise.js
+++ b/test/run_pass/test_promise.js
@@ -1,0 +1,29 @@
+/* Copyright 2017-present Samsung Electronics Co., Ltd. and other contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+var assert = require('assert');
+var fulfill_ret;
+var p = new Promise(function(resolve, reject) {
+  // mimic asynchronous operation via setTimeout
+  setTimeout(function() { resolve("Resolved") }, 100);;
+});
+
+p.then(function (msg) {
+  // Promise does not like throwing error in fulfill handler
+  // So just set the message in global variable.
+  fulfill_ret = msg;
+});
+
+// If Promise's fulfill worked well, assertion must be valid.
+setTimeout(function() { assert.equal(fulfill_ret, "Resolved"); }, 200);

--- a/test/testsets.json
+++ b/test/testsets.json
@@ -69,6 +69,7 @@
     { "name": "test_process_next_tick.js" },
     { "name": "test_process_uncaught_order.js", "uncaught": true },
     { "name": "test_process_uncaught_simple.js", "uncaught": true },
+    { "name": "test_promise.js", "skip": ["all"], "reason": "es2015 is off by default" },
     { "name": "test_pwm.js", "skip": ["all"], "reason": "need to setup test environment" },
     { "name": "test_spi.js", "skip": ["all"], "reason": "need to setup test environment" },
     { "name": "test_stat.js", "skip": ["all"], "reason": "dynamically changing result" },


### PR DESCRIPTION
- Call the apis that runs enqueud jobs in the middle of main loop.
- Add promise test for iotjs

IoT.js-DCO-1.0-Signed-off-by: Sanggyu Lee sg5.lee@samsung.com