### PR TITLE
Minor fix in the documentation of NuttX build.

### DIFF
--- a/docs/targets/nuttx/stm32f4dis/README.md
+++ b/docs/targets/nuttx/stm32f4dis/README.md
@@ -138,7 +138,7 @@ Followings are the options to set:
 ```bash
 # assuming you are in iotjs-nuttx folder
 $ cd nuttx/
-$ make
+$ make IOTJS_ROOT_DIR=../iotjs
 ```
 For release version, you can type R=1 make on the command shell.
 


### PR DESCRIPTION
IoT.js-DCO-1.0-Signed-off-by: László Langó llango.u-szeged@partner.samsung.com