### PR TITLE
Use AF_INET by default on NuttX when no address family specified.

### DIFF
--- a/src/modules/iotjs_module_dns.c
+++ b/src/modules/iotjs_module_dns.c
@@ -123,7 +123,11 @@ JHANDLER_FUNCTION(GetAddrInfo) {
 
   int family;
   if (option == 0) {
+#if defined(__NUTTX__) || defined(__TIZENRT__)
+    family = AF_INET;
+#else
     family = AF_UNSPEC;
+#endif
   } else if (option == 4) {
     family = AF_INET;
   } else if (option == 6) {


### PR DESCRIPTION
Added `AF_INET` as a default family on NuttX because the `inet_pton` function can handle only `AF_INET` or `AF_INET6` families. You can check it in the [NuttX source code](https://bitbucket.org/nuttx/nuttx/src/710376291a7a4f2201a77137bd9ccdcc4405180d/libc/net/lib_inetpton.c?at=master&fileviewer=file-view-default#lib_inetpton.c-372).

This patch is a fix for the #862.