### PR TITLE
Fix fs.read()

### DIFF
--- a/docs/api/IoT.js-API-File-System.md
+++ b/docs/api/IoT.js-API-File-System.md
@@ -96,10 +96,10 @@ Opens file synchronously.
 * `buffer <Buffer>` - buffer that the data will be written to.
 * `offset <Number>` - offset of the buffer where to start writing.
 * `length <Number>` - number of bytes to read.
-* `position <Number>` - specifying where to start read data from the file, if `null`, read from current position.
+* `position <Number>` - specifying where to start read data from the file, if `null` or `undefined`, read from current position.
 * `callback <Function(err: null | Error, bytesRead: Number, buffer: Buffer)>`
 
-Reads data from the file specified by fd asynchronously.
+Reads data from the file specified by `fd` asynchronously.
 
 **Example**
 
@@ -124,9 +124,20 @@ fs.open('test.txt', 'r', 755, function(err, fd) {
 * `buffer <Buffer>` - buffer that the data will be written to.
 * `offset <Number>` - offset of the buffer where to start writing.
 * `length <Number>` - number of bytes to read.
-* `position <Number>` - specifying where to start read data from the file, if `null`, read from current position.
+* `position <Number>` - specifying where to start read data from the file, if `null` or `undefined`, read from current position.
+* Returns: `<Number>` Number of bytes read.
 
-Reads data from the file specified by fd synchronously.
+Reads data from the file specified by `fd` synchronously.
+
+**Example**
+
+```js
+var fs = require('fs');
+
+var buffer = new Buffer(16);
+var fd = fs.openSync('test.txt', 'r');
+var bytesRead = fs.readSync(fd, buffer, 0, buffer.length, 0);
+```
 
 
 ### `fs.readFile(path[, options], callback)`

--- a/src/js/fs.js
+++ b/src/js/fs.js
@@ -128,6 +128,10 @@ fs.openSync = function(path, flags, mode) {
 
 
 fs.read = function(fd, buffer, offset, length, position, callback) {
+  if (util.isNullOrUndefined(position)) {
+    position = -1; // Read from the current position.
+  }
+
   callback = checkArgFunction(callback, 'callback');
 
   var cb = function(err, bytesRead) {
@@ -145,8 +149,9 @@ fs.read = function(fd, buffer, offset, length, position, callback) {
 
 fs.readSync = function(fd, buffer, offset, length, position) {
   if (util.isNullOrUndefined(position)) {
-    position = -1;
+    position = -1; // Read from the current position.
   }
+
   return fsBuiltin.read(checkArgNumber(fd, 'fd'),
                         checkArgBuffer(buffer, 'buffer'),
                         checkArgNumber(offset, 'offset'),

--- a/test/run_pass/test_fs_open_read.js
+++ b/test/run_pass/test_fs_open_read.js
@@ -49,3 +49,23 @@ assert.throws(
   },
   Error
 );
+
+// test the position argument of fs.read()
+fs.open(fileName, flags, function(err, fd) {
+  if (err) {
+    throw err;
+  }
+  var buffer = new Buffer(64);
+  fs.read(fd, buffer, 0, 7, null, function(err, bytesRead, buffer) {
+    if (err) {
+      throw err;
+    }
+    fs.read(fd, buffer, 7, 7, null, function(err, bytesRead, buffer) {
+      if (err) {
+        throw err;
+      }
+      assert.equal(buffer.toString(), expectedContents);
+      fs.closeSync(fd);
+    });
+  });
+});

--- a/test/run_pass/test_fs_open_read_sync_3.js
+++ b/test/run_pass/test_fs_open_read_sync_3.js
@@ -1,0 +1,35 @@
+/* Copyright 2017-present Samsung Electronics Co., Ltd. and other contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+var fs = require('fs');
+var assert = require('assert');
+
+var fileName = process.cwd() + "/resources/greeting.txt";
+var expectedContents = "Hello IoT.js!!";
+var flags = "r";
+
+
+// test the position argument of fs.readSync()
+try {
+  var buffer = new Buffer(64);
+  var fd = fs.openSync(fileName, flags);
+  var bytes1 = fs.readSync(fd, buffer, 0, 7, null);
+  var bytes2 = fs.readSync(fd, buffer, 7, 7, null);
+
+  assert.equal(buffer.toString(), expectedContents);
+  fs.closeSync(fd);
+} catch (err) {
+  throw err;
+}

--- a/test/testsets.json
+++ b/test/testsets.json
@@ -36,6 +36,7 @@
     { "name": "test_fs_open_read.js", "skip": ["nuttx"], "reason": "not implemented for nuttx" },
     { "name": "test_fs_open_read_sync_1.js", "skip": ["nuttx"], "reason": "not implemented for nuttx" },
     { "name": "test_fs_open_read_sync_2.js", "skip": ["nuttx"], "reason": "not implemented for nuttx" },
+    { "name": "test_fs_open_read_sync_3.js", "skip": ["nuttx"], "reason": "not implemented for nuttx" },
     { "name": "test_gpio_input.js", "skip": ["all"], "reason": "needs hardware" },
     { "name": "test_gpio_output.js", "skip": ["all"], "reason": "need user input"},
     { "name": "test_i2c.js", "skip": ["all"], "reason": "need to setup test environment" },


### PR DESCRIPTION
Make the synchronous and asynchronous variant consistent.
When `position` is null should read from the current position.

IoT.js-DCO-1.0-Signed-off-by: Zsolt Borbély zsborbely.u-szeged@partner.samsung.com