### PR TITLE
Update the Makefile to build the IoT.js app in nuttx.

### DIFF
--- a/config/nuttx/stm32f4dis/app/Makefile
+++ b/config/nuttx/stm32f4dis/app/Makefile
@@ -52,14 +52,15 @@
 -include $(TOPDIR)/Make.defs
 include $(APPDIR)/Make.defs
 
+IOTJS_ABSOLUTE_ROOT_DIR := $(shell cd $(TOPDIR) && cd $(IOTJS_ROOT_DIR) && pwd)
 
 CONFIG_IOTJS_PRIORITY ?= SCHED_PRIORITY_DEFAULT
 CONFIG_IOTJS_STACKSIZE ?= 16384
 # NSH sysinfo command
 
 APPNAME = iotjs
-CFLAGS += -I$(IOTJS_ROOT_DIR)/deps/jerry/jerry-core/include
-CFLAGS += -I$(IOTJS_ROOT_DIR)/deps/jerry/jerry-ext/include
+CFLAGS += -I$(IOTJS_ABSOLUTE_ROOT_DIR)/deps/jerry/jerry-core/include
+CFLAGS += -I$(IOTJS_ABSOLUTE_ROOT_DIR)/deps/jerry/jerry-ext/include
 PRIORITY = $(CONFIG_IOTJS_PRIORITY)
 STACKSIZE = $(CONFIG_IOTJS_STACKSIZE)
 HEAPSIZE = $(CONFIG_IOTJS_HEAPSIZE)
@@ -121,7 +122,7 @@ $(COBJS): %$(OBJEXT): %.c
 	$(call COMPILE, $<, $@)
 
 copylibs :
-	cp $(IOTJS_ROOT_DIR)/build/arm-nuttx/$(BUILD_TYPE)/lib/lib*.a .
+	cp $(IOTJS_ABSOLUTE_ROOT_DIR)/build/arm-nuttx/$(BUILD_TYPE)/lib/lib*.a .
 
 $(LIBS) : copylibs
 	$(firstword $(AR)) x $@


### PR DESCRIPTION
The Makefile runs in the nuttx apps tree. It needs IOTJS_ROOT_DIR to link to IoT.js.
The commit #861 suggests to define IOTJS_ROOT_DIR to the relative path of IoT.js as seen from nuttx root, which is a good thing.
But the actual Makefile is in apps/system/iotjs, forbidding the use of a relative path ( ../../../iotjs would work, but is counter intuitive).
The patch allows to provide either an absolute path or a relative path starting from the main nuttx Makefile.

IoT.js-DCO-1.0-Signed-off-by: cedricDum duminy.cedric@gmail.com