### PR TITLE
Add a more secure type validator to Buffer

### DIFF
--- a/src/iotjs_binding.c
+++ b/src/iotjs_binding.c
@@ -384,6 +384,31 @@ uintptr_t iotjs_jval_get_object_native_handle(const iotjs_jval_t* jobj) {
 }
 
 
+uintptr_t iotjs_jval_get_object_from_jhandler(iotjs_jhandler_t* jhandler,
+                                              JNativeInfoType native_info) {
+  const iotjs_jval_t* jobj = JHANDLER_GET_THIS(object);
+  const IOTJS_DECLARE_THIS(iotjs_jval_t, jobj);
+
+  if (!jerry_value_is_object(_this->value)) {
+    return 0;
+  }
+
+  uintptr_t ptr = 0;
+  JNativeInfoType out_native_info;
+
+  if (jerry_get_object_native_pointer(_this->value, (void**)&ptr,
+                                      &out_native_info)) {
+    if (ptr && out_native_info == native_info) {
+      return ptr;
+    }
+  }
+
+  JHANDLER_THROW(COMMON, "Unsafe access");
+
+  return 0;
+}
+
+
 void iotjs_jval_set_property_by_index(const iotjs_jval_t* jarr, uint32_t idx,
                                       const iotjs_jval_t* jval) {
   const IOTJS_VALIDATED_STRUCT_METHOD(iotjs_jval_t, jarr);

--- a/src/iotjs_binding.h
+++ b/src/iotjs_binding.h
@@ -128,6 +128,8 @@ iotjs_jval_t iotjs_jval_get_property(THIS_JVAL, const char* name);
 void iotjs_jval_set_object_native_handle(THIS_JVAL, uintptr_t ptr,
                                          JNativeInfoType native_info);
 uintptr_t iotjs_jval_get_object_native_handle(THIS_JVAL);
+uintptr_t iotjs_jval_get_object_from_jhandler(iotjs_jhandler_t* jhandler,
+                                              JNativeInfoType native_info);
 
 void iotjs_jval_set_property_by_index(THIS_JVAL, uint32_t idx,
                                       const iotjs_jval_t* value);
@@ -306,6 +308,13 @@ static inline bool ge(uint16_t a, uint16_t b) {
 #define DJHANDLER_CHECK_ARG_IF_EXIST(index, type) \
   JHANDLER_CHECK_ARG_IF_EXIST(index, type)
 #endif
+
+#define JHANDLER_DECLARE_THIS_PTR(type, name)                                  \
+  iotjs_##type##_t* name = (iotjs_##type##_t*)                                 \
+      iotjs_jval_get_object_from_jhandler(jhandler, &this_module_native_info); \
+  if (!name) {                                                                 \
+    return;                                                                    \
+  }
 
 void iotjs_binding_initialize();
 void iotjs_binding_finalize();

--- a/src/iotjs_objectwrap.h
+++ b/src/iotjs_objectwrap.h
@@ -41,4 +41,10 @@ iotjs_jobjectwrap_t* iotjs_jobjectwrap_from_jobject(
     .free_cb = (jerry_object_native_free_callback_t)iotjs_##module##_destroy \
   }
 
+#define IOTJS_DEFINE_NATIVE_HANDLE_INFO_THIS_MODULE(name)                  \
+  static void iotjs_##name##_destroy(iotjs_##name##_t* wrap);              \
+  static const jerry_object_native_info_t this_module_native_info = {      \
+    .free_cb = (jerry_object_native_free_callback_t)iotjs_##name##_destroy \
+  }
+
 #endif /* IOTJS_OBJECTWRAP_H */

--- a/src/modules/iotjs_module_buffer.c
+++ b/src/modules/iotjs_module_buffer.c
@@ -21,8 +21,7 @@
 #include <string.h>
 
 
-static void iotjs_bufferwrap_destroy(iotjs_bufferwrap_t* bufferwrap);
-IOTJS_DEFINE_NATIVE_HANDLE_INFO(bufferwrap);
+IOTJS_DEFINE_NATIVE_HANDLE_INFO_THIS_MODULE(bufferwrap);
 
 
 iotjs_bufferwrap_t* iotjs_bufferwrap_create(const iotjs_jval_t* jbuiltin,
@@ -31,7 +30,7 @@ iotjs_bufferwrap_t* iotjs_bufferwrap_create(const iotjs_jval_t* jbuiltin,
   IOTJS_VALIDATED_STRUCT_CONSTRUCTOR(iotjs_bufferwrap_t, bufferwrap);
 
   iotjs_jobjectwrap_initialize(&_this->jobjectwrap, jbuiltin,
-                               &bufferwrap_native_info);
+                               &this_module_native_info);
   if (length > 0) {
     _this->length = length;
     _this->buffer = iotjs_buffer_allocate(length);
@@ -237,12 +236,8 @@ JHANDLER_FUNCTION(Buffer) {
 
 
 JHANDLER_FUNCTION(Compare) {
-  DJHANDLER_CHECK_THIS(object);
+  JHANDLER_DECLARE_THIS_PTR(bufferwrap, src_buffer_wrap);
   DJHANDLER_CHECK_ARGS(1, object);
-
-  const iotjs_jval_t* jsrc_builtin = JHANDLER_GET_THIS(object);
-  iotjs_bufferwrap_t* src_buffer_wrap =
-      iotjs_bufferwrap_from_jbuiltin(jsrc_builtin);
 
   const iotjs_jval_t* jdst_buffer = JHANDLER_GET_ARG(0, object);
   iotjs_bufferwrap_t* dst_buffer_wrap =
@@ -265,12 +260,8 @@ JHANDLER_FUNCTION(Compare) {
 
 
 JHANDLER_FUNCTION(Copy) {
-  DJHANDLER_CHECK_THIS(object);
+  JHANDLER_DECLARE_THIS_PTR(bufferwrap, src_buffer_wrap);
   DJHANDLER_CHECK_ARGS(4, object, number, number, number);
-
-  const iotjs_jval_t* jsrc_builtin = JHANDLER_GET_THIS(object);
-  iotjs_bufferwrap_t* src_buffer_wrap =
-      iotjs_bufferwrap_from_jbuiltin(jsrc_builtin);
 
   const iotjs_jval_t* jdst_buffer = JHANDLER_GET_ARG(0, object);
   iotjs_bufferwrap_t* dst_buffer_wrap =
@@ -301,13 +292,10 @@ JHANDLER_FUNCTION(Copy) {
 
 
 JHANDLER_FUNCTION(Write) {
+  JHANDLER_DECLARE_THIS_PTR(bufferwrap, buffer_wrap);
   DJHANDLER_CHECK_ARGS(3, string, number, number);
 
   iotjs_string_t src = JHANDLER_GET_ARG(0, string);
-
-  const iotjs_jval_t* jbuiltin = JHANDLER_GET_THIS(object);
-
-  iotjs_bufferwrap_t* buffer_wrap = iotjs_bufferwrap_from_jbuiltin(jbuiltin);
 
   size_t buffer_length = iotjs_bufferwrap_length(buffer_wrap);
   DECLARE_SIZE_T_FROM_DOUBLE(offset, JHANDLER_GET_ARG(1, number));
@@ -328,14 +316,11 @@ JHANDLER_FUNCTION(Write) {
 
 
 JHANDLER_FUNCTION(WriteUInt8) {
+  JHANDLER_DECLARE_THIS_PTR(bufferwrap, buffer_wrap);
   DJHANDLER_CHECK_ARGS(2, number, number);
 
   const char src[] = { (char)JHANDLER_GET_ARG(0, number) };
   size_t length = 1;
-
-  const iotjs_jval_t* jbuiltin = JHANDLER_GET_THIS(object);
-
-  iotjs_bufferwrap_t* buffer_wrap = iotjs_bufferwrap_from_jbuiltin(jbuiltin);
 
   size_t buffer_length = iotjs_bufferwrap_length(buffer_wrap);
   DECLARE_SIZE_T_FROM_DOUBLE(offset, JHANDLER_GET_ARG(1, number));
@@ -351,13 +336,10 @@ JHANDLER_FUNCTION(WriteUInt8) {
 
 
 JHANDLER_FUNCTION(HexWrite) {
+  JHANDLER_DECLARE_THIS_PTR(bufferwrap, buffer_wrap);
   DJHANDLER_CHECK_ARGS(3, string, number, number);
 
   iotjs_string_t src = JHANDLER_GET_ARG(0, string);
-
-  const iotjs_jval_t* jbuiltin = JHANDLER_GET_THIS(object);
-
-  iotjs_bufferwrap_t* buffer_wrap = iotjs_bufferwrap_from_jbuiltin(jbuiltin);
 
   size_t buffer_length = iotjs_bufferwrap_length(buffer_wrap);
   DECLARE_SIZE_T_FROM_DOUBLE(offset, JHANDLER_GET_ARG(1, number));
@@ -382,11 +364,8 @@ JHANDLER_FUNCTION(HexWrite) {
 
 
 JHANDLER_FUNCTION(ReadUInt8) {
+  JHANDLER_DECLARE_THIS_PTR(bufferwrap, buffer_wrap);
   DJHANDLER_CHECK_ARGS(1, number);
-
-  const iotjs_jval_t* jbuiltin = JHANDLER_GET_THIS(object);
-
-  iotjs_bufferwrap_t* buffer_wrap = iotjs_bufferwrap_from_jbuiltin(jbuiltin);
 
   size_t buffer_length = iotjs_bufferwrap_length(buffer_wrap);
   DECLARE_SIZE_T_FROM_DOUBLE(offset, JHANDLER_GET_ARG(0, number));
@@ -399,10 +378,8 @@ JHANDLER_FUNCTION(ReadUInt8) {
 
 
 JHANDLER_FUNCTION(Slice) {
+  JHANDLER_DECLARE_THIS_PTR(bufferwrap, buffer_wrap);
   DJHANDLER_CHECK_ARGS(2, number, number);
-
-  const iotjs_jval_t* jbuiltin = JHANDLER_GET_THIS(object);
-  iotjs_bufferwrap_t* buffer_wrap = iotjs_bufferwrap_from_jbuiltin(jbuiltin);
 
   int64_t start = JHANDLER_GET_ARG(0, number);
   int64_t end = JHANDLER_GET_ARG(1, number);
@@ -451,11 +428,8 @@ JHANDLER_FUNCTION(Slice) {
 
 
 JHANDLER_FUNCTION(ToString) {
-  DJHANDLER_CHECK_THIS(object);
+  JHANDLER_DECLARE_THIS_PTR(bufferwrap, buffer_wrap);
   DJHANDLER_CHECK_ARGS(2, number, number);
-
-  const iotjs_jval_t* jbuiltin = JHANDLER_GET_THIS(object);
-  iotjs_bufferwrap_t* buffer_wrap = iotjs_bufferwrap_from_jbuiltin(jbuiltin);
 
   DECLARE_SIZE_T_FROM_DOUBLE(start, JHANDLER_GET_ARG(0, number));
   start = bound_range(start, 0, iotjs_bufferwrap_length(buffer_wrap));
@@ -479,10 +453,8 @@ JHANDLER_FUNCTION(ToString) {
 
 
 JHANDLER_FUNCTION(ToHexString) {
+  JHANDLER_DECLARE_THIS_PTR(bufferwrap, buffer_wrap);
   DJHANDLER_CHECK_THIS(object);
-
-  const iotjs_jval_t* jbuiltin = JHANDLER_GET_THIS(object);
-  iotjs_bufferwrap_t* buffer_wrap = iotjs_bufferwrap_from_jbuiltin(jbuiltin);
 
   size_t length = iotjs_bufferwrap_length(buffer_wrap);
   const char* data = iotjs_bufferwrap_buffer(buffer_wrap);

--- a/test/run_pass/issue/issue-816.js
+++ b/test/run_pass/issue/issue-816.js
@@ -1,0 +1,31 @@
+/* Copyright 2017-present Samsung Electronics Co., Ltd. and other contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+var Buffer = require('buffer');
+var assert = require('assert');
+
+assert.throws(function () {
+  var buf = new Buffer("ABCDEF");
+  var o = {
+    _builtin: {
+      compare: function () {
+        buf._builtin.compare.call(this, arguments);
+      }
+    },
+    compare: buf.compare
+  };
+
+  o.compare(buf);
+}, Error);

--- a/test/testsets.json
+++ b/test/testsets.json
@@ -89,7 +89,8 @@
     { "name": "issue-198.js" },
     { "name": "issue-223.js" },
     { "name": "issue-266.js" },
-    { "name": "issue-323.js" }
+    { "name": "issue-323.js" },
+    { "name": "issue-816.js" }
   ],
   "run_fail":  [
     { "name": "test_assert_equal.js", "expected-failure": true },


### PR DESCRIPTION
This commit add a validator to check whether the execution
context on `this` is not the expected C type. #816

IoT.js-DCO-1.0-Signed-off-by: Daeyeon Jeong daeyeon.jeong@samsung.com