### PR TITLE
Improve Process and DNS API docs style

### DIFF
--- a/docs/api/IoT.js-API-DNS.md
+++ b/docs/api/IoT.js-API-DNS.md
@@ -18,28 +18,28 @@ implemented on top of the underlying operation system facilities. Please see
 The following properties are flags which can be passed as hints for the
 [`dns.lookup()`](#dnslookuphostname-options-callback) method.
 
-### `dns.ADDRCONFIG`
+### dns.ADDRCONFIG
 * `{number}`
 
 Returned address types are determined by the types of addresses supported by the current system.
 
 
-### `dns.V4MAPPED`
+### dns.V4MAPPED
 * `{number}`
 
 If the IPv6 family was specified, but no IPv6 addresses were found, then return IPv4 mapped IPv6 addresses. 
 
 
 
-### `dns.lookup(hostname[, options], callback)`
-* `hostname {string}` Hostname to be resolved.
-* `options {Object} | {number}`
-  * `family {number}` The record family. If specified must be 4. Specifies that IPv4 addresses should be returned.
-  * `hints {number}` One or more supported getaddrinfo flags. Multiple flags may be passed by bitwise `OR`ing their values.
-* `callback {Function}`
-  * `err {Error}` If there is no error the value is `null`.
-  * `address {string}` A string representation of an IPv4 address.
-  * `family {number}` 4, denoting the family of `address`.
+### dns.lookup(hostname[, options], callback)
+* `hostname` {string} Hostname to be resolved.
+* `options` {Object|number}
+  * `family` {number} The record family. If specified must be 4. Specifies that IPv4 addresses should be returned.
+  * `hints` {number} One or more supported getaddrinfo flags. Multiple flags may be passed by bitwise `OR`ing their values.
+* `callback` {Function}
+  * `err` {Error|null} If there is no error the value is `null`.
+  * `address` {string} A string representation of an IPv4 address.
+  * `family` {number} 4, denoting the family of `address`.
 
 Resolves a hostname (e.g. `iotjs.net`) into the first found A (IPv4) or AAAA (IPv6) record. All `option` properties
 are option. If `option` is a number, then it must be `4`. If `options` is not provided, then IPv4 addresses are

--- a/docs/api/IoT.js-API-Process.md
+++ b/docs/api/IoT.js-API-Process.md
@@ -16,13 +16,13 @@ The following shows process module APIs available for each platform.
 The `process` object is a global that provides information about, and control over, the current IoT.js process.
 As a global, it is always available to IoT.js applications without using `require()`.
 
-### `process.arch`
+### process.arch
 * {string}
 
 The `arch` proeprty returns the processor architercture identifier that the IoT.js process is currently running on.
 For instance `'arm'`, `'ia32'`, `'x64'`, or `'unknown'`.
 
-### `process.argv`
+### process.argv
 * {Array}
 
 The `argv` property returns an array containing the command line arguments passed when the IoT.js
@@ -40,7 +40,7 @@ process.argv.forEach(function(val, idx) {
 });
 ```
 
-### `process.env`
+### process.env
 * {Object}
 
 The `env` property returns an object containing a few environment variables.
@@ -56,15 +56,15 @@ console.log('HOME: ' + process.env.HOME);
 // prints: HOME: /home/user
 ```
 
-### `process.exitCode`
-* {integer} Default: `0`
+### process.exitCode
+* {integer} **Default:** `0`
 
 The `exitCode` property can be used to specify the exit code of the IoT.js process.
 This will be used when the process exits gracefully, or exited via `process.exit()` without specifying an exit code.
 
 Specifying an exit code for the `process.exit()` call will override any previous setting of `process.exitCode`.
 
-### `process.iotjs`
+### process.iotjs
 * {Object}
 
 The `iotjs` property holds IoT.js related information in an object.
@@ -78,14 +78,14 @@ console.log(process.iotjs.board);
 // on Raspberry 2 it prints: RP2
 ```
 
-### `process.platform`
+### process.platform
 * {string}
 
 The `platform` returns the identification of the operating system the IoT.js process
 is currently running on. For instance `'linux'`, `'darwin'`, `'nuttx'`, `'tizenrt'`, or `'unknown'`.
 
 
-### `process.chdir(path)`
+### process.chdir(path)
 * `path` {string} The path to change working directory to.
 
 The `chdir` method changes the current working directory of the IoT.js process or
@@ -102,7 +102,7 @@ try {
 // prints: invalid path
 ```
 
-### `process.cwd()`
+### process.cwd()
 * Returns: {string}
 
 The `cwd()` call returns the current working directory of the IoT.js process.
@@ -113,8 +113,8 @@ The `cwd()` call returns the current working directory of the IoT.js process.
 console.log('Current dir: ' + process.cwd());
 ```
 
-### `process.exit([code])`
-* `code` {integer} The exit code. Default is `0`
+### process.exit([code])
+* `code` {integer} The exit code. **Default:** `0`
 
 The `exit()` method instructs the IoT.js to terminate the process synchronously with an exit status of `code`.
 If `code` is not specified, exit uses the `process.exitCode` value which defaults to `0`.
@@ -146,7 +146,7 @@ doSomeWork()
 process.exitCode = 1;
 ```
 
-### `process.nextTick(callback)`
+### process.nextTick(callback)
 * `callback` {Function}
 
 The `nextTick` method adds the `callback` method to the "next tick queue".
@@ -167,7 +167,7 @@ console.log('step 3');
 // step 2
 ```
 
-### Event: `'exit'`
+### Event: 'exit'
 * `callback` {Function}
   * `code` {integer}  exitCode
 
@@ -194,7 +194,7 @@ process.on('exit', function(code) {
 });
 ```
 
-### Event: `'uncaughtException'`
+### Event: 'uncaughtException'
 * `callback` {Function}
   * `err` {Error} error object uncaught by catch handler
 


### PR DESCRIPTION
* Removed the backtick from the property/method name headers.
* Corrected 'default' value style in Process docs.