### PR TITLE
Change command line arguments order

### DIFF
--- a/docs/build/Build-for-Linux.md
+++ b/docs/build/Build-for-Linux.md
@@ -187,12 +187,12 @@ To print memory statistics, follow the below steps;
 ```
 ./tools/build.py --jerry-memstat
 
-./build/x86_64-linux/debug/iotjs/iotjs ./test/run_pass/test_console.js --memstat
+./build/x86_64-linux/debug/iotjs/iotjs --memstat ./test/run_pass/test_console.js
 ```
 
 With given `show-opcodes` option, opcodes will be shown.
 ```
-./build/x86_64-linux/debug/iotjs/iotjs ./test/run_pass/test_console.js --show-opcodes
+./build/x86_64-linux/debug/iotjs/iotjs --show-opcodes ./test/run_pass/test_console.js
 ```
 
 ### 4. Clean build directory

--- a/docs/devs/Optimization-Tips.md
+++ b/docs/devs/Optimization-Tips.md
@@ -7,7 +7,7 @@ Adding below arguments when building and running IoT.js will show you the JerryS
 
 ```text
 $ ./tools/build.py --jerry-memstat
-$ ./build/bin/iotjs test.js --memstat
+$ ./build/bin/iotjs --memstat test.js
 Heap stats:
   Heap size = 262136 bytes
   Allocated = 0 bytes

--- a/docs/devs/Use-JerryScript-Debugger.md
+++ b/docs/devs/Use-JerryScript-Debugger.md
@@ -14,7 +14,7 @@ you can do so with the `--jerry-debugger-port=<PORT>` option.
 
 ### Usage
 
-To start the debugger-server: `<iotjs binary> test.js --start-debug-server`
+To start the debugger-server: `<iotjs binary> --start-debug-server test.js`
 
 Two clients are included, a [python](https://github.com/jerryscript-project/jerryscript/blob/master/jerry-debugger/jerry-client-ws.py)
 and an [HTML](https://github.com/jerryscript-project/jerryscript/blob/master/jerry-debugger/jerry-client-ws.html) variant, they can be found under `deps/jerry/jerry-debugger/`.

--- a/src/iotjs_env.c
+++ b/src/iotjs_env.c
@@ -101,17 +101,13 @@ bool iotjs_environment_parse_command_line_arguments(iotjs_environment_t* env,
   // There must be at least two arguments.
   if (argc < 2) {
     fprintf(stderr,
-            "usage: iotjs <js> [<iotjs arguments>] [-- <app arguments>]\n");
+            "Usage: iotjs [options] {script | script.js} [arguments]\n");
     return false;
   }
 
   // Parse IoT.js command line arguments.
-  uint32_t i = 2;
-  while (i < argc) {
-    if (!strcmp(argv[i], "--")) {
-      ++i;
-      break;
-    }
+  uint32_t i = 1;
+  while (i < argc && argv[i][0] == '-') {
     if (!strcmp(argv[i], "--memstat")) {
       _this->config.memstat = true;
     } else if (!strcmp(argv[i], "--show-opcodes")) {
@@ -119,7 +115,7 @@ bool iotjs_environment_parse_command_line_arguments(iotjs_environment_t* env,
     } else if (!strcmp(argv[i], "--start-debug-server")) {
       _this->config.debugger = true;
     } else {
-      fprintf(stderr, "unknown command line argument %s\n", argv[i]);
+      fprintf(stderr, "unknown command line option: %s\n", argv[i]);
       return false;
     }
     ++i;
@@ -130,7 +126,7 @@ bool iotjs_environment_parse_command_line_arguments(iotjs_environment_t* env,
   size_t buffer_size = ((size_t)(_this->argc + argc - i)) * sizeof(char*);
   _this->argv = (char**)iotjs_buffer_allocate(buffer_size);
   _this->argv[0] = argv[0];
-  _this->argv[1] = argv[1];
+  _this->argv[1] = argv[i++];
   while (i < argc) {
     _this->argv[_this->argc] = iotjs_buffer_allocate(strlen(argv[i]) + 1);
     strcpy(_this->argv[_this->argc], argv[i]);

--- a/tools/build.py
+++ b/tools/build.py
@@ -436,7 +436,7 @@ def run_checktest(options):
 
     # iot.js executable
     iotjs = fs.join(options.build_root, 'bin', 'iotjs')
-    build_args = ['--', 'quiet=' + checktest_quiet]
+    build_args = ['quiet=' + checktest_quiet]
     if options.iotjs_exclude_module:
         skip_module = ','.join(options.iotjs_exclude_module)
         build_args.append('skip-module=' + skip_module)

--- a/tools/measure_js_heap.py
+++ b/tools/measure_js_heap.py
@@ -61,15 +61,13 @@ if __name__ == "__main__":
     for test_file in os.listdir(path.RUN_PASS_DIR):
         if test_file.endswith(".js"):
             line = "| " + test_file + " | "
-            cmd = [script_args.base,
-                os.path.join(path.RUN_PASS_DIR, test_file),
-                '--memstat'
+            cmd = [script_args.base, '--memstat',
+                os.path.join(path.RUN_PASS_DIR, test_file)
             ]
             base_out = run_iotjs(cmd)
 
-            cmd = [script_args.new,
-                os.path.join(path.RUN_PASS_DIR, test_file),
-                '--memstat'
+            cmd = [script_args.new, '--memstat',
+                os.path.join(path.RUN_PASS_DIR, test_file)
             ]
             new_out = run_iotjs(cmd)
 

--- a/tools/mem_stats.sh
+++ b/tools/mem_stats.sh
@@ -69,7 +69,7 @@ function is_mem_stats_build
   [ -x "$1" ] || fail_msg "Engine '$1' is not executable"
 
   tmpfile=`mktemp`
-  "$1" $tmpfile --memstat 2>&1 | \
+  "$1" --memstat $tmpfile 2>&1 | \
     grep -- "Ignoring memory statistics option" 2>&1 > /dev/null
   code=$?
   rm $tmpfile
@@ -114,7 +114,7 @@ do
   cd `dirname $bench_canon`
 
   echo "$bench_name" | awk "$PRINT_TEST_NAME_AWK_SCRIPT"
-  MEM_STATS=$("$IOTJS_MEM_STATS" $bench_canon --memstat | \
+  MEM_STATS=$("$IOTJS_MEM_STATS" --memstat $bench_canon | \
     grep -e "Peak allocated =" | grep -o "[0-9]*")
   RSS=$($STARTDIR/deps/jerry/tools/rss-measure.sh "$IOTJS" $bench_canon | \
     tail -n 1 | grep -o "[0-9]*")


### PR DESCRIPTION
This commit changes the order of arguments passed into IoTJS as follows:

* Old: iotjs {script.js} [options] [-- {arguments}]
* New: iotjs [options] {script | script.js} [arguments]

IoT.js-DCO-1.0-Signed-off-by: Daeyeon Jeong daeyeon.jeong@samsung.com