### PR TITLE
Fix convertMode() in fs.js

### DIFF
--- a/src/js/fs.js
+++ b/src/js/fs.js
@@ -451,7 +451,7 @@ function convertMode(mode, def) {
   if (util.isNumber(mode)) {
     return mode;
   } else if (util.isString(mode)) {
-    return parseInt(mode);
+    return parseInt(mode, 8);
   } else if (def) {
     return convertMode(def);
   }

--- a/test/run_pass/test_fs_mkdir_rmdir.js
+++ b/test/run_pass/test_fs_mkdir_rmdir.js
@@ -57,6 +57,25 @@ function unlink(path) {
       fs.rmdir(root2, function(){
         assert.equal(fs.existsSync(root2), false);
       });
+
+      // Try to create a folder in a read-only directory.
+      fs.mkdir(root, '0444', function(err) {
+        assert.equal(fs.existsSync(root), true);
+
+        var dirname = root + "/permission_test";
+        try {
+          fs.mkdirSync(dirname);
+          assert.assert(false);
+        } catch (e) {
+          assert.equal(e instanceof Error, true);
+          assert.equal(e instanceof assert.AssertionError, false);
+        }
+
+        assert.equal(fs.existsSync(dirname), false);
+        fs.rmdir(root, function() {
+          assert.equal(fs.existsSync(root), false);
+        });
+      });
     });
   });
 }


### PR DESCRIPTION
Parse mode-string as an octal number.

IoT.js-DCO-1.0-Signed-off-by: Zsolt Borbély zsborbely.u-szeged@partner.samsung.com