### PR TITLE
Fix test_net_10.js on stm32f4-nuttx target. (version 1)

### DIFF
--- a/test/run_pass/test_net_10.js
+++ b/test/run_pass/test_net_10.js
@@ -17,6 +17,7 @@ var net = require('net');
 var assert = require('assert');
 
 var timedout = false;
+var error = false;
 var connected = false;
 
 // Try connect to host that is not exist (Reserved address of TEST-NET-1)
@@ -30,7 +31,8 @@ socket1.on('timeout', function() {
 });
 
 socket1.on('error', function() {
-  assert.fail();
+  error = true;
+  socket1.destroy();
 });
 
 socket1.on('connect', function() {
@@ -39,6 +41,11 @@ socket1.on('connect', function() {
 });
 
 process.on('exit', function() {
-  assert(timedout);
+  if (process.platform == 'nuttx' || process.platform == 'tizenrt') {
+    // Connect is synchronous on these platforms.
+    assert(error && !timedout);
+  } else {
+    assert(!error && timedout);
+  }
   assert(!connected);
 });


### PR DESCRIPTION
The `connect` function is synchronous on NuttX thus an error (non exist host) happens earlier than the required timeout.