### PR TITLE
Add dgram.setTTL test cases

### DIFF
--- a/test/run_pass/test_dgram_setttl_client.js
+++ b/test/run_pass/test_dgram_setttl_client.js
@@ -1,0 +1,48 @@
+/* Copyright 2017-present Samsung Electronics Co., Ltd. and other contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+var assert = require('assert');
+var dgram = require('dgram');
+
+var port = 41234;
+var msg = 'Hello IoT.js';
+var addr = '192.168.0.1'; // Change to your ip address
+var server = dgram.createSocket('udp4');
+
+var client = dgram.createSocket('udp4');
+
+client.send(msg, port, addr, function(err, len) {
+  assert.equal(err, null);
+  assert.equal(len, msg.length);
+});
+
+client.on('error', function(err) {
+  assert.fail();
+});
+
+client.on('listening', function(err) {
+  client.setTTL(1);
+});
+
+client.on('message', function(data, rinfo) {
+  console.log('client got data : ' + data);
+  console.log('server address : ' + rinfo.address);
+  console.log('server port : ' + rinfo.port);
+  console.log('server family : ' + rinfo.family);
+  assert.equal(port, rinfo.port);
+  assert.equal(data, msg);
+  client.close();
+});
+

--- a/test/run_pass/test_dgram_setttl_server.js
+++ b/test/run_pass/test_dgram_setttl_server.js
@@ -1,0 +1,50 @@
+/* Copyright 2017-present Samsung Electronics Co., Ltd. and other contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+var assert = require('assert');
+var dgram = require('dgram');
+
+var port = 41234;
+var msg = 'Hello IoT.js';
+var server = dgram.createSocket('udp4');
+
+server.on('error', function(err) {
+  assert.fail();
+  server.close();
+});
+
+server.on('message', function(data, rinfo) {
+  console.log('server got data : ' + data);
+  console.log('client address : ' + rinfo.address);
+  console.log('client port : ' + rinfo.port);
+  console.log('client family : ' + rinfo.family);
+  assert.equal(data, msg);
+  server.send(msg, rinfo.port, rinfo.address, function (err, len) {
+    assert.equal(err, null);
+    assert.equal(len, msg.length);
+  });
+});
+
+server.on('listening', function() {
+  console.log('listening');
+});
+
+server.bind(port, function() {
+  server.setTTL(1);
+});
+
+process.on('exit', function(code) {
+  assert.equal(code, 0);
+});

--- a/test/testsets.json
+++ b/test/testsets.json
@@ -13,6 +13,8 @@
     { "name": "test_dgram_broadcast.js", "skip": ["all"], "reason": "need to setup test environment" },
     { "name": "test_dgram_multicast_membership.js", "skip": ["all"], "reason": "need to setup test environment" },
     { "name": "test_dgram_multicast_set_multicast_loop.js", "skip": ["all"], "reason": "need to setup test environment" },
+    { "name": "test_dgram_setttl_client.js", "skip": ["all"], "reason": "need to setup test environment" },
+    { "name": "test_dgram_setttl_server.js", "skip": ["all"], "reason": "need to setup test environment" },
     { "name": "test_dns.js", "skip": ["nuttx"], "reason": "not implemented for nuttx" },
     { "name": "test_dns_lookup.js", "skip": ["nuttx"], "reason": "not implemented for nuttx" },
     { "name": "test_events.js", "skip": ["nuttx"], "reason": "not implemented for nuttx" },


### PR DESCRIPTION
setTTL test cases consist of server and client pair.

- Set server ip address in client source.
- Run server in one terminal
- Run client in another.

If the number of hops between server and client is 2+, it prints nothing.
Otherwise (i.e., there is no hop between server and client), it prints
messages like followings:

```
listening
server got data : Hello IoT.js
client address : _your address_
client port : 36130
client family : IPv4
```

IoT.js-DCO-1.0-Signed-off-by: Sanggyu Lee sg5.lee@samsung.com