### PR TITLE
Fix test_net_10.js on stm32f4-nuttx target. (version 2)

### DIFF
--- a/test/run_pass/test_net_10.js
+++ b/test/run_pass/test_net_10.js
@@ -19,18 +19,17 @@ var assert = require('assert');
 var timedout = false;
 var connected = false;
 
-// Try connect to host that is not exist (Reserved address of TEST-NET-1)
-var socket1 = net.createConnection(11111, '192.0.2.1');
-
-socket1.setTimeout(1000);
-
-socket1.on('timeout', function() {
+process.nextTick(function() {
   timedout = true;
   socket1.destroy();
 });
 
+// Try connect to host that is not exist (Reserved address of TEST-NET-1)
+var socket1 = net.createConnection(11111, '192.0.2.1');
+
 socket1.on('error', function() {
-  assert.fail();
+  if (!timedout)
+    assert.fail();
 });
 
 socket1.on('connect', function() {


### PR DESCRIPTION
This patch is the second version to fix the `test_net_10.js` test file.
A previous version can be found at #947.

So the main problem with the test is that on `NuttX` platform an error (no host found at the given IP) happens earlier than the required timeout. When NuttX resolves the IP, it caches that no host on the given IP. After that, when the connection happens, NuttX doesn't want to connect to the address since it already knows that there is no host on the given address. So this process is very fast.

In this patch I've removed the `timeout` event handling because you can't set such little time for `timeout` (e.g. 1 ms) that could be happen faster than the error for `no host found at the given IP address`. To simulate a `timeout` for the test, the process.nextTick was introduced. In this way, the test is platform independent.