### PR TITLE
Fix the test-net-bind-twice.js test

### DIFF
--- a/test/node/parallel/test-net-bind-twice.js
+++ b/test/node/parallel/test-net-bind-twice.js
@@ -46,7 +46,12 @@ server1.listen(0, '127.0.0.1', common.mustCall(function() {
   var server2 = net.createServer(common.fail);
 
   server2.on('error', common.mustCall(function(e) {
-    assert.strictEqual(e, -98); // EADDRINUSE
+    // EADDRINUSE have different value on OSX.
+    if (common.isOSX) {
+      assert.strictEqual(e, -48);
+    } else {
+      assert.strictEqual(e, -98);
+    }
 
     server1.close();
   }));


### PR DESCRIPTION
On OSX the EADDRINUSE have a different value.

IoT.js-DCO-1.0-Signed-off-by: Peter Gal pgal.u-szeged@partner.samsung.com