### PR TITLE
Fix 'statusMessage' setup in implicit header of 'http.ServerResponse'.

### DIFF
--- a/src/js/http_server.js
+++ b/src/js/http_server.js
@@ -82,7 +82,7 @@ ServerResponse.prototype.statusMessage = undefined;
 // if user does not set Header before write(..),
 // this function set default header(200).
 ServerResponse.prototype._implicitHeader = function() {
-  this.writeHead(this.statusCode);
+  this.writeHead(this.statusCode, this.statusMessage);
 };
 
 

--- a/test/node/parallel/test-http-status-message.js
+++ b/test/node/parallel/test-http-status-message.js
@@ -1,0 +1,66 @@
+/* Copyright 2017-present Samsung Electronics Co., Ltd. and other contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// Copyright Joyent, Inc. and other Node contributors.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to permit
+// persons to whom the Software is furnished to do so, subject to the
+// following conditions:
+//
+// The above copyright notice and this permission notice shall be included
+// in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN
+// NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+// DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+// OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
+// USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+'use strict';
+
+require('node/common');
+var assert = require('assert');
+var http = require('http');
+var net = require('net');
+
+var s = http.createServer(function (req, res) {
+  res.statusCode = 200;
+  res.statusMessage = 'Custom Message';
+  res.end('');
+});
+
+s.listen(0, test);
+
+function test() {
+  var bufs = [];
+  var client = net.connect(this.address().port, function () {
+    client.write('GET / HTTP/1.1\r\nConnection: close\r\n\r\n');
+  });
+  client.on('data', function (chunk) {
+    bufs.push(chunk);
+  });
+  client.on('end', function () {
+    var head = Buffer.concat(bufs).toString().split('\r\n')[0];
+    assert.strictEqual('HTTP/1.1 200 Custom Message', head);
+    console.log('ok');
+    s.close();
+  });
+}

--- a/test/testsets.json
+++ b/test/testsets.json
@@ -113,6 +113,7 @@
   ],
   "node/parallel": [
     { "name": "test-assert.js" },
+    { "name": "test-http-status-message.js" },
     { "name": "test-http-write-head.js" },
     { "name": "test-net-bind-twice.js" },
     { "name": "test-net-end-without-connect.js" }


### PR DESCRIPTION
IoT.js-DCO-1.0-Signed-off-by: László Langó llango.u-szeged@partner.samsung.com