### PR TITLE
I2C port for artik05x

### DIFF
--- a/config/tizenrt/artik05x/app/iotjs_main.c
+++ b/config/tizenrt/artik05x/app/iotjs_main.c
@@ -57,6 +57,19 @@
 #include <setjmp.h>
 #include <stdio.h>
 
+#if (defined CONFIG_I2C)
+#if (defined CONFIG_ARCH_BOARD_ARTIK053) || \
+    (defined CONFIG_ARCH_BOARD_SIDK_S5JT200)
+// Forward declaration.
+struct i2c_dev_s;
+
+int up_i2cuninitialize(FAR struct i2c_dev_s *dev) {
+  return s5j_i2cbus_uninitialize(dev);
+}
+#endif // artik05x
+#endif // defined CONFIG_I2C
+
+
 #define USE_IOTJS_THREAD 1
 
 /**
@@ -77,7 +90,7 @@ int setjmp(jmp_buf buf) {
  *   ignores value argument
  */
 
-void longjmp(jmp_buf buf, int value) {
+__attribute__((__noreturn__)) void longjmp(jmp_buf buf, int value) {
   /* Must be called with 1. */
   __builtin_longjmp(buf, 1);
 } /* longjmp */

--- a/src/iotjs.c
+++ b/src/iotjs.c
@@ -21,7 +21,7 @@
 #include "iotjs_string_ext.h"
 
 #include "jerryscript-debugger.h"
-#ifndef __NUTTX__
+#if !(defined __NUTTX__) && !(defined __TIZENRT__)
 #include "jerryscript-port-default.h"
 #endif
 #include "jerryscript-port.h"

--- a/src/platform/tizenrt/artik05x/iotjs_systemio-tizenrt.c
+++ b/src/platform/tizenrt/artik05x/iotjs_systemio-tizenrt.c
@@ -1,0 +1,28 @@
+/* Copyright 2017-present Samsung Electronics Co., Ltd. and other contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifdef ENABLE_MODULE_I2C
+
+#include <tinyara/i2c.h>
+
+struct i2c_dev_s* iotjs_i2c_platform_config(int port) {
+  return up_i2cinitialize(port);
+}
+
+int iotjs_i2c_platform_unconfig(struct i2c_dev_s* i2c) {
+  return up_i2cuninitialize(i2c);
+}
+
+#endif /* ENABLE_MODULE_I2C */

--- a/src/platform/tizenrt/iotjs_module_i2c-tizenrt.c
+++ b/src/platform/tizenrt/iotjs_module_i2c-tizenrt.c
@@ -13,22 +13,20 @@
  * limitations under the License.
  */
 
-#if !defined(__NUTTX__)
-#error "Module __FILE__ is for nuttx only"
+#if !defined(__TIZENRT__)
+#error "Module " __FILE__ " should only be built with __TIZENRT__"
 #endif
 
-#include <nuttx/i2c/i2c_master.h>
-
-#include "iotjs_systemio-nuttx.h"
-
 #include "modules/iotjs_module_i2c.h"
+#include "iotjs_systemio.h"
+#include <tinyara/i2c.h>
 
 
 #define I2C_DEFAULT_FREQUENCY 400000
 
 struct iotjs_i2c_platform_data_s {
   int device;
-  struct i2c_master_s* i2c_master;
+  struct i2c_dev_s* i2c_master;
   struct i2c_config_s config;
 };
 
@@ -66,7 +64,7 @@ void OpenWorker(uv_work_t* work_req) {
   iotjs_i2c_t* i2c = iotjs_i2c_instance_from_reqwrap(req_wrap);
 
   IOTJS_I2C_METHOD_HEADER(i2c);
-  platform_data->i2c_master = iotjs_i2c_config_nuttx(platform_data->device);
+  platform_data->i2c_master = iotjs_i2c_platform_config(platform_data->device);
   if (!platform_data->i2c_master) {
     DLOG("I2C OpenWorker : cannot open");
     req_data->error = kI2cErrOpen;
@@ -80,7 +78,7 @@ void OpenWorker(uv_work_t* work_req) {
 
 void I2cClose(iotjs_i2c_t* i2c) {
   IOTJS_I2C_METHOD_HEADER(i2c);
-  iotjs_i2c_unconfig_nuttx(platform_data->i2c_master);
+  iotjs_i2c_platform_unconfig(platform_data->i2c_master);
 }
 
 void WriteWorker(uv_work_t* work_req) {

--- a/src/platform/tizenrt/iotjs_systemio.h
+++ b/src/platform/tizenrt/iotjs_systemio.h
@@ -1,0 +1,29 @@
+/* Copyright 2017-present Samsung Electronics Co., Ltd. and other contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef TIZENRT_IOTJS_SYSTEMIO_H
+#define TIZENRT_IOTJS_SYSTEMIO_H
+
+#if ENABLE_MODULE_I2C
+
+// Incomplete type to be provided by the impl.
+struct i2c_dev_s;
+
+struct i2c_dev_s* iotjs_i2c_platform_config(int port);
+int iotjs_i2c_platform_unconfig(struct i2c_dev_s* i2c);
+
+#endif /* ENABLE_MODULE_I2C */
+
+#endif /* TIZENRT_IOTJS_SYSTEMIO_H */

--- a/test/run_pass/test_i2c.js
+++ b/test/run_pass/test_i2c.js
@@ -26,6 +26,8 @@ if (process.platform === 'linux') {
   configuration.device = '/dev/i2c-1';
 } else if (process.platform === 'nuttx') {
   configuration.device = 1;
+} else if (process.platform === 'tizenrt') {
+  configuration.device = 1;
 } else {
   assert.fail();
 }
@@ -36,11 +38,11 @@ var wire = i2c.open(configuration, function(err) {
   }
 
   wire.write([0x10], function(err) {
-    assert.equal(err, null);
+    assert.equal(err, null, "write() error");
     console.log('write done');
 
     wire.read(2, function(err, res) {
-      assert.equal(err, null);
+      assert.equal(err, null, "read() error");
       assert.equal(res.length, 2, 'I2C read failed.(length is not equal)');
       console.log('read result: '+res[0]+', '+res[1]);
       wire.close();


### PR DESCRIPTION
I2C module fixes, iotjs.js slightly simplified.

This patch depends on https://github.com/Samsung/TizenRT/pull/334,
and relevant entries in TizenRT configuration (i.e.: I2C enabled and configured).
