### PR TITLE
Add a more secure type validator to ADC module based on #911

### DIFF
--- a/src/modules/iotjs_module_adc.c
+++ b/src/modules/iotjs_module_adc.c
@@ -18,15 +18,15 @@
 #include "iotjs_objectwrap.h"
 
 
-static void iotjs_adc_destroy(iotjs_adc_t* adc);
-IOTJS_DEFINE_NATIVE_HANDLE_INFO(adc);
+IOTJS_DEFINE_NATIVE_HANDLE_INFO_THIS_MODULE(adc);
 static iotjs_adc_t* iotjs_adc_instance_from_jval(const iotjs_jval_t* jadc);
 
 
 static iotjs_adc_t* iotjs_adc_create(const iotjs_jval_t* jadc) {
   iotjs_adc_t* adc = IOTJS_ALLOC(iotjs_adc_t);
   IOTJS_VALIDATED_STRUCT_CONSTRUCTOR(iotjs_adc_t, adc);
-  iotjs_jobjectwrap_initialize(&_this->jobjectwrap, jadc, &adc_native_info);
+  iotjs_jobjectwrap_initialize(&_this->jobjectwrap, jadc,
+                               &this_module_native_info);
 
   return adc;
 }
@@ -46,14 +46,14 @@ static void iotjs_adc_destroy(iotjs_adc_t* adc) {
 
 
 static iotjs_adc_reqwrap_t* iotjs_adc_reqwrap_create(
-    const iotjs_jval_t* jcallback, const iotjs_jval_t* jadc, AdcOp op) {
+    const iotjs_jval_t* jcallback, iotjs_adc_t* adc, AdcOp op) {
   iotjs_adc_reqwrap_t* adc_reqwrap = IOTJS_ALLOC(iotjs_adc_reqwrap_t);
   IOTJS_VALIDATED_STRUCT_CONSTRUCTOR(iotjs_adc_reqwrap_t, adc_reqwrap);
 
   iotjs_reqwrap_initialize(&_this->reqwrap, jcallback, (uv_req_t*)&_this->req);
 
   _this->req_data.op = op;
-  _this->adc_instance = iotjs_adc_instance_from_jval(jadc);
+  _this->adc_instance = adc;
   return adc_reqwrap;
 }
 
@@ -204,11 +204,11 @@ static void iotjs_adc_close_worker(uv_work_t* work_req) {
 }
 
 
-#define ADC_ASYNC(call, jthis, jcallback, op)                                  \
+#define ADC_ASYNC(call, this, jcallback, op)                                   \
   do {                                                                         \
     uv_loop_t* loop = iotjs_environment_loop(iotjs_environment_get());         \
     iotjs_adc_reqwrap_t* req_wrap =                                            \
-        iotjs_adc_reqwrap_create(jcallback, jthis, op);                        \
+        iotjs_adc_reqwrap_create(jcallback, this, op);                         \
     uv_work_t* req = iotjs_adc_reqwrap_req(req_wrap);                          \
     uv_queue_work(loop, req, iotjs_adc_##call##_worker, iotjs_adc_after_work); \
   } while (0)
@@ -226,20 +226,18 @@ JHANDLER_FUNCTION(AdcConstructor) {
   iotjs_adc_set_configuration(adc, JHANDLER_GET_ARG(0, object));
 
   const iotjs_jval_t* jcallback = JHANDLER_GET_ARG(1, function);
-  ADC_ASYNC(open, jadc, jcallback, kAdcOpOpen);
+  ADC_ASYNC(open, adc, jcallback, kAdcOpOpen);
 }
 
 
 JHANDLER_FUNCTION(Read) {
-  DJHANDLER_CHECK_THIS(object);
+  JHANDLER_DECLARE_THIS_PTR(adc, adc);
   DJHANDLER_CHECK_ARG_IF_EXIST(0, function);
 
   const iotjs_jval_t* jcallback = JHANDLER_GET_ARG_IF_EXIST(0, function);
-  const iotjs_jval_t* jadc = JHANDLER_GET_THIS(object);
-  iotjs_adc_t* adc = iotjs_adc_instance_from_jval(jadc);
 
   if (jcallback) {
-    ADC_ASYNC(read, jadc, jcallback, kAdcOpRead);
+    ADC_ASYNC(read, adc, jcallback, kAdcOpRead);
   } else {
     int32_t value = iotjs_adc_read(adc);
     if (value < 0) {
@@ -252,15 +250,13 @@ JHANDLER_FUNCTION(Read) {
 
 
 JHANDLER_FUNCTION(Close) {
-  DJHANDLER_CHECK_THIS(object);
+  JHANDLER_DECLARE_THIS_PTR(adc, adc);
   DJHANDLER_CHECK_ARG_IF_EXIST(0, function);
 
   const iotjs_jval_t* jcallback = JHANDLER_GET_ARG_IF_EXIST(0, function);
-  const iotjs_jval_t* jadc = JHANDLER_GET_THIS(object);
-  iotjs_adc_t* adc = iotjs_adc_instance_from_jval(jadc);
 
   if (jcallback) {
-    ADC_ASYNC(close, jadc, jcallback, kAdcOpClose);
+    ADC_ASYNC(close, adc, jcallback, kAdcOpClose);
   } else {
     if (!iotjs_adc_close(adc)) {
       JHANDLER_THROW(COMMON, "ADC Close Error");


### PR DESCRIPTION
I could not test the ADC module itself, as it is on the skiplist by default.
Manual testing doesn't reproduce unsafe access errors, however this is only a speculative fix.

IoT.js-DCO-1.0-Signed-off-by: Daniel Balla dballa@inf.u-szeged.hu