### PR TITLE
Use smaller headers on low-memory devices in test_net_headers.js

### DIFF
--- a/test/run_pass/test_net_headers.js
+++ b/test/run_pass/test_net_headers.js
@@ -41,8 +41,15 @@ var server = http.createServer(function (req, res) {
     }
     // final res.headers = { 'h1' : 'h1', 'h3': 'h3prime' }
 
-    // Large header on response.
-    for (var i = 0; i < 500; i++) {
+    var responseSize;
+    if (process.platform === 'linux') {
+      // For Desktop and RPI, test with large header.
+      responseSize = 500;
+    } else {
+      // NuttX and TizenRt cannot handle large header.
+      responseSize = 10;
+    }
+    for (var i = 0; i < responseSize; i++) {
       res.setHeader('h' + (5 + i), 'h' + (5 + i));
     }
 

--- a/test/testsets.json
+++ b/test/testsets.json
@@ -60,7 +60,7 @@
     { "name": "test_net_9.js" },
     { "name": "test_net_10.js" },
     { "name": "test_net_connect.js", "timeout": 10 },
-    { "name": "test_net_headers.js", "skip": ["nuttx"], "reason": "not implemented for nuttx" },
+    { "name": "test_net_headers.js" },
     { "name": "test_net_http_get.js", "timeout": 20 },
     { "name": "test_net_http_response_twice.js", "timeout": 10 },
     { "name": "test_net_http_request_response.js", "timeout": 10, "skip": ["nuttx"], "reason": "not implemented for nuttx" },


### PR DESCRIPTION
Currently test_net_headers.js is skipped on NuttX.
However, IoT.js supports getHeader and setHeader on NuttX.
We can run and pass the test by setting the size of header
depending on platforms.

IoT.js-DCO-1.0-Signed-off-by: Sanggyu Lee sg5.lee@samsung.com