### PR TITLE
Update API Reference on limitation on NuttX

### DIFF
--- a/docs/api/IoT.js-API-ADC.md
+++ b/docs/api/IoT.js-API-ADC.md
@@ -2,7 +2,7 @@
 
 The following table shows ADC module APIs available for each platform.
 
-|  | Linux<br/>(Ubuntu) | Raspbian<br/>(Raspberry Pi) | Nuttx<br/>(STM32F4-Discovery) |
+|  | Linux<br/>(Ubuntu) | Raspbian<br/>(Raspberry Pi) | NuttX<br/>(STM32F4-Discovery) |
 | :---: | :---: | :---: | :---: |
 | adc.open | O | O | O |
 | adcpin.read | O | O | O |
@@ -17,7 +17,7 @@ This class allows reading analogue data from hardware pins.
 
 The hardware pins can be read from or written to, therefore they are called bidirectional IO pins. This module provides the reading part.
 
-On Nuttx, you have to know the number of pins that is defined on the target board module. For more information, please see the list below.
+On NuttX, you have to know the number of pins that is defined on the target board module. For more information, please see the list below.
   * [STM32F4-discovery](../targets/nuttx/stm32f4dis/IoT.js-API-Stm32f4dis.md#adc-pin)
 
 
@@ -29,7 +29,7 @@ Returns a new ADC object which can open an ADC pin.
 ### adc.open(configuration[, callback])
 * `configuration` {Object}
   * `device` {string} mandatory configuration on Linux
-  * `pin` {int} mandatory configuration on Nuttx
+  * `pin` {int} mandatory configuration on NuttX
 * `callback` {Function}
   * `err`: {Error|null}
 * Returns: `AdcPin` {adc.AdcPin}

--- a/docs/api/IoT.js-API-Assert.md
+++ b/docs/api/IoT.js-API-Assert.md
@@ -2,7 +2,7 @@
 
 The following shows Assert module APIs available for each platform.
 
-|  | Linux<br/>(Ubuntu) | Raspbian<br/>(Raspberry Pi) | Nuttx<br/>(STM32F4-Discovery) |
+|  | Linux<br/>(Ubuntu) | Raspbian<br/>(Raspberry Pi) | NuttX<br/>(STM32F4-Discovery) |
 | :---: | :---: | :---: | :---: |
 | assert.assert | O | O | O |
 | assert.doesNotThrow | O | O | O |

--- a/docs/api/IoT.js-API-BLE.md
+++ b/docs/api/IoT.js-API-BLE.md
@@ -2,7 +2,7 @@
 
 The following shows ble module APIs available for each platform.
 
-|  | Linux<br/>(Ubuntu) | Raspbian<br/>(Raspberry Pi) | Nuttx<br/>(STM32F4-Discovery) |
+|  | Linux<br/>(Ubuntu) | Raspbian<br/>(Raspberry Pi) | NuttX<br/>(STM32F4-Discovery) |
 | :---: | :---: | :---: | :---: |
 | ble.startAdvertising | O | O | X |
 | ble.stopAdvertising | O | O | X |

--- a/docs/api/IoT.js-API-Buffer.md
+++ b/docs/api/IoT.js-API-Buffer.md
@@ -2,7 +2,7 @@
 
 The following shows Buffer module APIs available for each platform.
 
-|  | Linux<br/>(Ubuntu) | Raspbian<br/>(Raspberry Pi) | Nuttx<br/>(STM32F4-Discovery) |
+|  | Linux<br/>(Ubuntu) | Raspbian<br/>(Raspberry Pi) | NuttX<br/>(STM32F4-Discovery) |
 | :---: | :---: | :---: | :---: |
 | buf.compare | O | O | O |
 | buf.copy | O | O | O |

--- a/docs/api/IoT.js-API-DGRAM.md
+++ b/docs/api/IoT.js-API-DGRAM.md
@@ -2,7 +2,7 @@
 
 The following shows dgram module APIs available for each platform.
 
-|  | Linux<br/>(Ubuntu) | Raspbian<br/>(Raspberry Pi) | Nuttx<br/>(STM32F4-Discovery) |
+|  | Linux<br/>(Ubuntu) | Raspbian<br/>(Raspberry Pi) | NuttX<br/>(STM32F4-Discovery) |
 | :---: | :---: | :---: | :---: |
 | dgram.createSocket | O | O | O |
 | dgram.Socket.addMembership | O | O | X |
@@ -15,6 +15,8 @@ The following shows dgram module APIs available for each platform.
 | dgram.Socket.setMulticastLoopback | O | O | X |
 | dgram.Socket.setMulticastTTL | X | X | X |
 | dgram.Socket.setTTL | O | O | X |
+
+※ On NuttX/STM32F4-Discovery, even a couple of sockets/server/requests might not work properly.
 
 # Dgram
 

--- a/docs/api/IoT.js-API-DNS.md
+++ b/docs/api/IoT.js-API-DNS.md
@@ -2,7 +2,7 @@
 
 The following shows dns module APIs available for each platform.
 
-|  | Linux<br/>(Ubuntu) | Raspbian<br/>(Raspberry Pi) | Nuttx<br/>(STM32F4-Discovery) |
+|  | Linux<br/>(Ubuntu) | Raspbian<br/>(Raspberry Pi) | NuttX<br/>(STM32F4-Discovery) |
 | :---: | :---: | :---: | :---: |
 | dns.lookup | O | O | X |
 
@@ -75,5 +75,5 @@ dns.lookup ('iotjs.net', options, function(err, ip, family) {
 
 The current implementation only supports host name resolution to IPv4 addresses.
 
-On Nuttx currently only valid IPv4 addresses are allowed for the
+On NuttX currently only valid IPv4 addresses are allowed for the
 [`dns.lookup()`](#dnslookuphostname-options-callback) method.

--- a/docs/api/IoT.js-API-Events.md
+++ b/docs/api/IoT.js-API-Events.md
@@ -2,7 +2,7 @@
 
 The following shows Event module APIs available for each platform.
 
-|  | Linux<br/>(Ubuntu) | Raspbian<br/>(Raspberry Pi) | Nuttx<br/>(STM32F4-Discovery) |
+|  | Linux<br/>(Ubuntu) | Raspbian<br/>(Raspberry Pi) | NuttX<br/>(STM32F4-Discovery) |
 | :---: | :---: | :---: | :---: |
 | emitter.addListener | O | O | O |
 | emitter.on | O | O | O |

--- a/docs/api/IoT.js-API-GPIO.md
+++ b/docs/api/IoT.js-API-GPIO.md
@@ -2,7 +2,7 @@
 
 The following shows GPIO module APIs available for each platform.
 
-|  | Linux<br/>(Ubuntu) | Raspbian<br/>(Raspberry Pi) | Nuttx<br/>(STM32F4-Discovery) |
+|  | Linux<br/>(Ubuntu) | Raspbian<br/>(Raspberry Pi) | NuttX<br/>(STM32F4-Discovery) |
 | :---: | :---: | :---: | :---: |
 | gpio.open | O | O | O |
 | gpiopin.write | O | O | O |
@@ -23,7 +23,7 @@ The logical number might be different from the physical
 pin number of the board. The mapping is available
 in the documentation of a given board.
 
-On Nuttx, the pin number is defined in target board
+On NuttX, the pin number is defined in target board
 module. For more information, please check the
 following list:
 [STM32F4-discovery](../targets/nuttx/stm32f4dis/IoT.js-API-Stm32f4dis.md#gpio-pin)

--- a/docs/api/IoT.js-API-HTTP.md
+++ b/docs/api/IoT.js-API-HTTP.md
@@ -2,12 +2,13 @@
 
  The following shows Http module APIs available for each platform.
 
- |  | Linux<br/>(Ubuntu) | Raspbian<br/>(Raspberry Pi) | Nuttx<br/>(STM32F4-Discovery) |
+ |  | Linux<br/>(Ubuntu) | Raspbian<br/>(Raspberry Pi) | NuttX<br/>(STM32F4-Discovery) |
  | :---: | :---: | :---: | :---: |
  | http.createServer | O | O | O |
  | http.request | O | O | O |
  | http.get | O | O | O |
 
+※ On NuttX/STM32F4-Discovery, even a couple of sockets/server/requests might not work properly.
 
 # Http
 

--- a/docs/api/IoT.js-API-Net.md
+++ b/docs/api/IoT.js-API-Net.md
@@ -2,7 +2,7 @@
 
 The following shows net module APIs available for each platform.
 
-|  | Linux<br/>(Ubuntu) | Raspbian<br/>(Raspberry Pi) | Nuttx<br/>(STM32F4-Discovery) |
+|  | Linux<br/>(Ubuntu) | Raspbian<br/>(Raspberry Pi) | NuttX<br/>(STM32F4-Discovery) |
 | :---: | :---: | :---: | :---: |
 | net.createServer | O | O | O |
 | net.connect | O | O | O |
@@ -19,7 +19,9 @@ The following shows net module APIs available for each platform.
 | net.Socket.setKeepAlive | X | X | X |
 
 ※ When writable stream is finished but readable stream is still alive, IoT.js tries to shutdown the socket, not destroy.
-However on `nuttx` due to lack of implementation, it does nothing inside.
+However on `NuttX` due to lack of implementation, it does nothing inside.
+
+※ On NuttX/STM32F4-Discovery, even a couple of sockets/server/requests might not work properly.
 
 # Net
 

--- a/docs/api/IoT.js-API-PWM.md
+++ b/docs/api/IoT.js-API-PWM.md
@@ -2,7 +2,7 @@
 
 The following shows PWM module APIs available for each platform.
 
-|  | Linux<br/>(Ubuntu) | Raspbian<br/>(Raspberry Pi) | Nuttx<br/>(STM32F4-Discovery) |
+|  | Linux<br/>(Ubuntu) | Raspbian<br/>(Raspberry Pi) | NuttX<br/>(STM32F4-Discovery) |
 | :---: | :---: | :---: | :---: |
 | pwm.open | O | O | O |
 | pwmpin.setPeriod | O | O | O |
@@ -41,7 +41,7 @@ Opens PWM pin with the specified configuration.
 
 To correctly open a PWM pin one must know the correct pin number:
 * On Linux, `pin` is a number which is `0` or `1`.
-* On Nuttx, you have to know pin name. The pin name is defined in target board module. For more module information, please see below list.
+* On NuttX, you have to know pin name. The pin name is defined in target board module. For more module information, please see below list.
   * [STM32F4-discovery](../targets/nuttx/stm32f4dis/IoT.js-API-Stm32f4dis.md#pwm-pin)
 
 

--- a/docs/api/IoT.js-API-Process.md
+++ b/docs/api/IoT.js-API-Process.md
@@ -2,14 +2,14 @@
 
 The following shows process module APIs available for each platform.
 
-|  | Linux<br/>(Ubuntu) | Raspbian<br/>(Raspberry Pi) | Nuttx<br/>(STM32F4-Discovery) |
+|  | Linux<br/>(Ubuntu) | Raspbian<br/>(Raspberry Pi) | NuttX<br/>(STM32F4-Discovery) |
 | :---: | :---: | :---: | :---: |
 | process.nextTick | O | O | O |
 | process.exit | O | O | O |
 | process.cwd | O | O | O |
 | process.chdir | O | O | O |
 
-※ On nuttx, you should pass absolute path to `process.chdir`.
+※ On NuttX, you should pass absolute path to `process.chdir`.
 
 # Process
 

--- a/docs/api/IoT.js-API-SPI.md
+++ b/docs/api/IoT.js-API-SPI.md
@@ -2,7 +2,7 @@
 
 The following shows spi module APIs available for each platform.
 
-|  | Linux<br/>(Ubuntu) | Raspbian<br/>(Raspberry Pi) | Nuttx<br/>(STM32F4-Discovery) |
+|  | Linux<br/>(Ubuntu) | Raspbian<br/>(Raspberry Pi) | NuttX<br/>(STM32F4-Discovery) |
 | :---: | :---: | :---: | :---: |
 | spi.open | O | O | X |
 | spibus.transfer | O | O | X |

--- a/docs/api/IoT.js-API-Stream.md
+++ b/docs/api/IoT.js-API-Stream.md
@@ -2,7 +2,7 @@
 
 The following shows stream module APIs available for each platform.
 
-|  | Linux<br/>(Ubuntu) | Raspbian<br/>(Raspberry Pi) | Nuttx<br/>(STM32F4-Discovery) |
+|  | Linux<br/>(Ubuntu) | Raspbian<br/>(Raspberry Pi) | NuttX<br/>(STM32F4-Discovery) |
 | :---: | :---: | :---: | :---: |
 | readable.isPaused | O | O | O |
 | readable.pause | O | O | O |

--- a/docs/api/IoT.js-API-Timers.md
+++ b/docs/api/IoT.js-API-Timers.md
@@ -2,7 +2,7 @@
 
 The following shows timer module APIs available for each platform.
 
-|  | Linux<br/>(Ubuntu) | Raspbian<br/>(Raspberry Pi) | Nuttx<br/>(STM32F4-Discovery) |
+|  | Linux<br/>(Ubuntu) | Raspbian<br/>(Raspberry Pi) | NuttX<br/>(STM32F4-Discovery) |
 | :---: | :---: | :---: | :---: |
 | setTimeout | O | O | O |
 | clearTimeout | O | O | O |

--- a/docs/api/IoT.js-API-UART.md
+++ b/docs/api/IoT.js-API-UART.md
@@ -2,13 +2,13 @@
 
 The following shows uart module APIs available for each platform.
 
-|  | Linux<br/>(Ubuntu) | Raspbian<br/>(Raspberry Pi) | Nuttx<br/>(STM32F4-Discovery) |
+|  | Linux<br/>(Ubuntu) | Raspbian<br/>(Raspberry Pi) | NuttX<br/>(STM32F4-Discovery) |
 | :---: | :---: | :---: | :---: |
 | uart.open | O | O | O |
 | uartport.write | O | O | O |
 | uartport.writeSync | O | O | O |
-| uartport.close | O | O | O |
-| uartport.closeSync | O | O | O |
+| uartport.close | O | O | X |
+| uartport.closeSync | O | O | X |
 
 ## Class: UART
 
@@ -33,7 +33,7 @@ The `baudRate` must be equal to one of these values: [0, 50, 75, 110, 134, 150, 
 
 The `dataBits` must be equal to one of these values: [5, 6, 7, 8].
 
-On Nuttx, you also need to set the properties of the `configuration` in the NuttX configuration file. Using the NuttX menuconfig, it can be found at the `Device Drivers -> Serial Driver Support -> U[S]ART(N) Configuration` section.
+On NuttX, you also need to set the properties of the `configuration` in the NuttX configuration file. Using the NuttX menuconfig, it can be found at the `Device Drivers -> Serial Driver Support -> U[S]ART(N) Configuration` section.
 
 You can read more information about the usage of the UART on stm32f4-discovery board: [STM32F4-discovery](../targets/nuttx/stm32f4dis/IoT.js-API-Stm32f4dis.md#uart).
 
@@ -100,9 +100,15 @@ serial.close();
 
 Closes the UART device asynchronously.
 
+On NuttX/STM32F4Discovery, Uart.close() blocks after close().
+It seems that poll() does not work properly on NuttX for some cases.
+
 ### uartport.closeSync()
 
 Closes the UART device synchronously.
+
+On NuttX/STM32F4Discovery, Uart.close() blocks after close().
+It seems that poll() does not work properly on NuttX for some cases.
 
 ### Event: 'data'
 * `callback` {Function}

--- a/docs/build/Build-for-Linux.md
+++ b/docs/build/Build-for-Linux.md
@@ -98,7 +98,7 @@ To give options, please use two dashes '--' before the option name as described 
 Options that may need explanations.
 * builddir: compile intermediate and output files are generated here.
 * buildlib: generating _iotjs_ to a library if True(e.g. for NuttX). give __--buildlib__ to make it True.
-* jerry-heaplimit: JerryScript default heap size (as of today) is 256Kbytes. This option is to change the size for embedded systems, nuttx for now, and current default is 81KB. For linux, this has no effect. While building nuttx if you see an error `region sram overflowed by xxxx bytes`, you may have to decrease about that amount.
+* jerry-heaplimit: JerryScript default heap size (as of today) is 256Kbytes. This option is to change the size for embedded systems, NuttX for now, and current default is 81KB. For linux, this has no effect. While building nuttx if you see an error `region sram overflowed by xxxx bytes`, you may have to decrease about that amount.
 * jerry-memstat: turn on the flag so that jerry dumps byte codes and literals and memory usage while parsing and execution.
 * no-check-tidy: no checks codes are tidy. we recommend to check tidy.
 * no-check-test: do not run all tests in test folder after build.

--- a/docs/build/Build-for-NuttX.md
+++ b/docs/build/Build-for-NuttX.md
@@ -48,7 +48,7 @@ $ brew install gcc-arm-none-eabi libusb minicom
 
 ### 2. Build NuttX (For the first time)
 
-To generate headers which are required to build IoT.js, for the first time, you need to build NuttX at least once. This time nuttx build will be failed. But don't worry at this time. After one execution, you don't need this sequence any more.
+To generate headers which are required to build IoT.js, for the first time, you need to build NuttX at least once. This time NuttX build will be failed. But don't worry at this time. After one execution, you don't need this sequence any more.
 
 #### Supported Nuttx version
 |Repository|Tag Name|


### PR DESCRIPTION
We've found API limitations on NuttX.
It will provide the information on API reference.

Also, I update Nuttx and nuttx to NuttX.

IoT.js-DCO-1.0-Signed-off-by: Sanggyu Lee sg5.lee@samsung.com