### PR TITLE
Add `node_module` and `coverage` as skip dirs for check_tidy

### DIFF
--- a/tools/check_tidy.py
+++ b/tools/check_tidy.py
@@ -168,7 +168,7 @@ def check_tidy(src_dir, options=None):
     allowed_exts = ['.c', '.h', '.js', '.py', '.sh', '.cmake']
     allowed_files = ['CMakeLists.txt']
     clang_format_exts = ['.c', '.h']
-    skip_dirs = ['deps', 'build', '.git']
+    skip_dirs = ['deps', 'build', '.git', 'node_modules', 'coverage']
     skip_files = ['check_signed_off.sh', '__init__.py',
                   'iotjs_js.c', 'iotjs_js.h', 'iotjs_string_ext.inl.h',
                   'ble.js',


### PR DESCRIPTION
IoT.js-DCO-1.0-Signed-off-by: Daeyeon Jeong daeyeon.jeong@samsung.com