### PR TITLE
Add a return value of `net.Server.listen` for method chaining

### DIFF
--- a/docs/api/IoT.js-API-Net.md
+++ b/docs/api/IoT.js-API-Net.md
@@ -245,6 +245,7 @@ server.close();
 * `host` {string} Host the client should connect to.
 * `backlog` {number} The maximum length of the queue of pending connections. **Default:** `511`.
 * `listenListener` {Function} Listener for the `'listening'` event.
+* Returns: {Object} The self instance of `net.Server`.
 
 Begin accepting connections on the specified port and hostname.
 If the hostname is omitted, the server will accept connections on any IPv4 address (0.0.0.0).

--- a/src/js/net.js
+++ b/src/js/net.js
@@ -523,6 +523,8 @@ Server.prototype.listen = function() {
       self.emit('listening');
     }
   });
+
+  return this;
 };
 
 

--- a/test/run_pass/test_net_connect.js
+++ b/test/run_pass/test_net_connect.js
@@ -25,9 +25,7 @@ var server = net.createServer({
   function(socket) {
     server.close();
   }
-);
-
-server.listen(port);
+).listen(port);
 
 server.on('connection', function(socket) {
   var data = '';


### PR DESCRIPTION
IoT.js-DCO-1.0-Signed-off-by: Daeyeon Jeong daeyeon.jeong@samsung.com