### PR TITLE
Update API platform support table for NuttX limitation

### DIFF
--- a/docs/api/IoT.js-API-DGRAM.md
+++ b/docs/api/IoT.js-API-DGRAM.md
@@ -4,19 +4,21 @@ The following shows dgram module APIs available for each platform.
 
 |  | Linux<br/>(Ubuntu) | Raspbian<br/>(Raspberry Pi) | NuttX<br/>(STM32F4-Discovery) |
 | :---: | :---: | :---: | :---: |
-| dgram.createSocket | O | O | O |
+| dgram.createSocket | O | O | △ ¹ |
 | dgram.Socket.addMembership | O | O | X |
 | dgram.Socket.address | O | O | X |
-| dgram.Socket.bind | O | O | O |
-| dgram.Socket.close | O | O | O |
+| dgram.Socket.bind | O | O | △ ¹ |
+| dgram.Socket.close | O | O | △ ² |
 | dgram.Socket.dropMembership | O | O | X |
-| dgram.Socket.send | O | O | O |
+| dgram.Socket.send | O | O | △ ¹ |
 | dgram.Socket.setBroadcast | O | O | X |
 | dgram.Socket.setMulticastLoopback | O | O | X |
 | dgram.Socket.setMulticastTTL | X | X | X |
 | dgram.Socket.setTTL | O | O | X |
 
-※ On NuttX/STM32F4-Discovery, even a couple of sockets/server/requests might not work properly.
+1. On NuttX/STM32F4-Discovery, even a couple of sockets/server/requests might not work properly.
+
+2. On NuttX/STM32F4-Discovery, close() may block due to a bug in poll().
 
 # Dgram
 

--- a/docs/api/IoT.js-API-HTTP.md
+++ b/docs/api/IoT.js-API-HTTP.md
@@ -4,11 +4,11 @@
 
  |  | Linux<br/>(Ubuntu) | Raspbian<br/>(Raspberry Pi) | NuttX<br/>(STM32F4-Discovery) |
  | :---: | :---: | :---: | :---: |
- | http.createServer | O | O | O |
- | http.request | O | O | O |
- | http.get | O | O | O |
+ | http.createServer | O | O | △ ¹ |
+ | http.request | O | O | △ ¹ |
+ | http.get | O | O | △ ¹ |
 
-※ On NuttX/STM32F4-Discovery, even a couple of sockets/server/requests might not work properly.
+1. On NuttX/STM32F4-Discovery, even a couple of sockets/server/requests might not work properly.
 
 # Http
 

--- a/docs/api/IoT.js-API-Net.md
+++ b/docs/api/IoT.js-API-Net.md
@@ -4,24 +4,27 @@ The following shows net module APIs available for each platform.
 
 |  | Linux<br/>(Ubuntu) | Raspbian<br/>(Raspberry Pi) | NuttX<br/>(STM32F4-Discovery) |
 | :---: | :---: | :---: | :---: |
-| net.createServer | O | O | O |
-| net.connect | O | O | O |
-| net.createConnection | O | O | O |
-| net.Server.listen | O | O | O |
-| net.Server.close | O | O | O |
-| net.Socket.connect | O | O | O |
-| net.Socket.write | O | O | O |
-| net.Socket.end | O | O | O |
-| net.Socket.destroy | O | O | O |
-| net.Socket.pause | O | O | O |
-| net.Socket.resume | O | O | O |
-| net.Socket.setTimeout | O | O | O |
+| net.createServer | O | O | △ ¹ |
+| net.connect | O | O | △ ¹ |
+| net.createConnection | O | O | △ ¹ |
+| net.Server.listen | O | O | △ ¹ |
+| net.Server.close | O | O | △ ²|
+| net.Socket.connect | O | O | △ ¹ |
+| net.Socket.write | O | O | △ ¹ |
+| net.Socket.end | O | O | △ ¹ ³ |
+| net.Socket.destroy | O | O | △ ¹ ³ |
+| net.Socket.pause | O | O | △ ¹ |
+| net.Socket.resume | O | O | △ ¹ |
+| net.Socket.setTimeout | O | O | △ ¹ |
 | net.Socket.setKeepAlive | X | X | X |
 
-※ When writable stream is finished but readable stream is still alive, IoT.js tries to shutdown the socket, not destroy.
+1. On NuttX/STM32F4-Discovery, even a couple of sockets/server/requests might not work properly.
+
+2. On NuttX/STM32F4-Discovery, close() may block due to a bug in poll().
+
+3. When writable stream is finished but readable stream is still alive, IoT.js tries to shutdown the socket, not destroy.
 However on `NuttX` due to lack of implementation, it does nothing inside.
 
-※ On NuttX/STM32F4-Discovery, even a couple of sockets/server/requests might not work properly.
 
 # Net
 


### PR DESCRIPTION
We would like to specify the limitation on NuttX more explicitly.
So we introduced the notation `△` for partial/unstable support.

IoT.js-DCO-1.0-Signed-off-by: Sanggyu Lee sg5.lee@samsung.com