### PR TITLE
Correctly check number of cmd line arguments

### DIFF
--- a/src/iotjs_env.c
+++ b/src/iotjs_env.c
@@ -98,13 +98,6 @@ bool iotjs_environment_parse_command_line_arguments(iotjs_environment_t* env,
                                                     char** argv) {
   IOTJS_VALIDATED_STRUCT_METHOD(iotjs_environment_t, env);
 
-  // There must be at least two arguments.
-  if (argc < 2) {
-    fprintf(stderr,
-            "Usage: iotjs [options] {script | script.js} [arguments]\n");
-    return false;
-  }
-
   // Parse IoT.js command line arguments.
   uint32_t i = 1;
   while (i < argc && argv[i][0] == '-') {
@@ -119,6 +112,13 @@ bool iotjs_environment_parse_command_line_arguments(iotjs_environment_t* env,
       return false;
     }
     ++i;
+  }
+
+  // There must be at least one argument after processing the IoT.js args.
+  if ((argc - i) < 1) {
+    fprintf(stderr,
+            "Usage: iotjs [options] {script | script.js} [arguments]\n");
+    return false;
   }
 
   // Remaining arguments are for application.


### PR DESCRIPTION
If the IoT.js binary is started with one of the
`--memstat`, `--show-opcodes`, or `--start-debug-server` arguments
the program crashes when the process module initilizes its
argv array.

The reason for the crash is that the number of arguments
are checked before the previously mentioned arguments are
processed and after they processed the environment's argc
is set to 2, regardless that there is no valid filename/module
argument.

Test case:
```
./iotjs --memstat
```

IoT.js-DCO-1.0-Signed-off-by: Peter Gal pgal.u-szeged@partner.samsung.com