### PR TITLE
Fix EventEmitter.removeListener()

### DIFF
--- a/src/js/events.js
+++ b/src/js/events.js
@@ -106,13 +106,15 @@ EventEmitter.prototype.removeListener = function(type, listener) {
       if (list[i] == listener ||
           (list[i].listener && list[i].listener == listener)) {
         list.splice(i, 1);
+        if (!list.length) {
+          delete this._events[type];
+        }
         break;
       }
     }
   }
 
   return this;
-
 };
 
 

--- a/test/run_pass/test_events.js
+++ b/test/run_pass/test_events.js
@@ -39,22 +39,22 @@ assert.equal(onceCnt, 1);
 
 {
   var emit_test = new EventEmitter();
-  emit_test._events=false;
+  emit_test._events = false;
   emit_test.emit();
 }
 {
   var emit_test = new EventEmitter();
-  emit_test._events.error=false;
+  emit_test._events.error = false;
   emit_test.emit(null);
 }
 {
   var emit_test = new EventEmitter();
-  emit_test._events=false;
+  emit_test._events = false;
   assert.throws(function() { emit_test.addListener(null, null); }, TypeError);
 }
 {
   var emit_test = new EventEmitter();
-  emit_test._events=false;
+  emit_test._events = false;
   emit_test.addListener('event', function() { });
 }
 {
@@ -228,4 +228,22 @@ assert.equal(removableListenerCnt, 0);
 emitter.removeListener('onceRemove', removableListener);
 emitter.emit('onceRemove');
 assert.equal(removableListenerCnt, 0,
-    'a listener for a "once" typed evet should be removable');
+    'a listener for a "once" typed event should be removable');
+
+/*
+ * Test when the last listener is removed from an object,
+ * the related property doesn't exist anymore.
+ */
+var listener1 = function() {
+};
+
+emitter.addListener('event1', listener1);
+emitter.removeListener('event1', listener1);
+var res = emitter.emit('event1');
+assert.equal(res, false);
+
+emitter.addListener('event2', listener1);
+emitter.addListener('event2', listener1);
+emitter.removeAllListeners('event2');
+res = emitter.emit('event2');
+assert.equal(res, false);


### PR DESCRIPTION
Remove the <event> property also, when there is no other listener for that event.
Now the EventEmitter.emit() returns with the correct value.
Fix minor style issues as well.

IoT.js-DCO-1.0-Signed-off-by: Zsolt Borbély zsborbely.u-szeged@partner.samsung.com