### PR TITLE
Adding an additional argument validation to Buffer module

### DIFF
--- a/src/iotjs_binding.c
+++ b/src/iotjs_binding.c
@@ -409,6 +409,37 @@ uintptr_t iotjs_jval_get_object_from_jhandler(iotjs_jhandler_t* jhandler,
 }
 
 
+uintptr_t iotjs_jval_get_arg_obj_from_jhandler(iotjs_jhandler_t* jhandler,
+                                               uint16_t index,
+                                               JNativeInfoType native_info) {
+  IOTJS_VALIDATED_STRUCT_METHOD(iotjs_jhandler_t, jhandler);
+
+  if (index >= _this->jargc) {
+    return 0;
+  }
+
+  const iotjs_jval_t jobj = _this->jargv[index];
+
+  if (!jerry_value_is_object(jobj.unsafe.value)) {
+    return 0;
+  }
+
+  uintptr_t ptr = 0;
+  JNativeInfoType out_native_info;
+
+  if (jerry_get_object_native_pointer(jobj.unsafe.value, (void**)&ptr,
+                                      &out_native_info)) {
+    if (ptr && out_native_info == native_info) {
+      return ptr;
+    }
+  }
+
+  JHANDLER_THROW(COMMON, "Unsafe access");
+
+  return 0;
+}
+
+
 void iotjs_jval_set_property_by_index(const iotjs_jval_t* jarr, uint32_t idx,
                                       const iotjs_jval_t* jval) {
   const IOTJS_VALIDATED_STRUCT_METHOD(iotjs_jval_t, jarr);

--- a/src/iotjs_binding.h
+++ b/src/iotjs_binding.h
@@ -130,6 +130,9 @@ void iotjs_jval_set_object_native_handle(THIS_JVAL, uintptr_t ptr,
 uintptr_t iotjs_jval_get_object_native_handle(THIS_JVAL);
 uintptr_t iotjs_jval_get_object_from_jhandler(iotjs_jhandler_t* jhandler,
                                               JNativeInfoType native_info);
+uintptr_t iotjs_jval_get_arg_obj_from_jhandler(iotjs_jhandler_t* jhandler,
+                                               uint16_t index,
+                                               JNativeInfoType native_info);
 
 void iotjs_jval_set_property_by_index(THIS_JVAL, uint32_t idx,
                                       const iotjs_jval_t* value);
@@ -314,6 +317,14 @@ static inline bool ge(uint16_t a, uint16_t b) {
       iotjs_jval_get_object_from_jhandler(jhandler, &this_module_native_info); \
   if (!name) {                                                                 \
     return;                                                                    \
+  }
+
+#define JHANDLER_DECLARE_OBJECT_PTR(index, type, name)                \
+  iotjs_##type##_t* name = (iotjs_##type##_t*)                        \
+      iotjs_jval_get_arg_obj_from_jhandler(jhandler, index,           \
+                                           &this_module_native_info); \
+  if (!name) {                                                        \
+    return;                                                           \
   }
 
 void iotjs_binding_initialize();

--- a/src/js/buffer.js
+++ b/src/js/buffer.js
@@ -130,7 +130,7 @@ Buffer.prototype.equals = function(otherBuffer) {
     throw new TypeError('Bad arguments: buffer.equals(Buffer)');
   }
 
-  return this._builtin.compare(otherBuffer) == 0;
+  return this._builtin.compare(otherBuffer._builtin) == 0;
 };
 
 
@@ -140,7 +140,7 @@ Buffer.prototype.compare = function(otherBuffer) {
     throw new TypeError('Bad arguments: buffer.compare(Buffer)');
   }
 
-  return this._builtin.compare(otherBuffer);
+  return this._builtin.compare(otherBuffer._builtin);
 };
 
 

--- a/src/modules/iotjs_module_buffer.c
+++ b/src/modules/iotjs_module_buffer.c
@@ -237,11 +237,7 @@ JHANDLER_FUNCTION(Buffer) {
 
 JHANDLER_FUNCTION(Compare) {
   JHANDLER_DECLARE_THIS_PTR(bufferwrap, src_buffer_wrap);
-  DJHANDLER_CHECK_ARGS(1, object);
-
-  const iotjs_jval_t* jdst_buffer = JHANDLER_GET_ARG(0, object);
-  iotjs_bufferwrap_t* dst_buffer_wrap =
-      iotjs_bufferwrap_from_jbuffer(jdst_buffer);
+  JHANDLER_DECLARE_OBJECT_PTR(0, bufferwrap, dst_buffer_wrap);
 
   int compare = iotjs_bufferwrap_compare(src_buffer_wrap, dst_buffer_wrap);
   iotjs_jhandler_return_number(jhandler, compare);


### PR DESCRIPTION
This commit adds an additional check to Buffer module's Compare function.
Before it only checked if the given argument was an object, now it also verifies that the type is correct.

This is a sample patch only, if it succeeds I'll start implementing it in the other functions too.

IoT.js-DCO-1.0-Signed-off-by: Daniel Balla dballa@inf.u-szeged.hu