### PR TITLE
Implement SPI module on NuttX

### DIFF
--- a/docs/api/IoT.js-API-SPI.md
+++ b/docs/api/IoT.js-API-SPI.md
@@ -4,16 +4,19 @@ The following shows spi module APIs available for each platform.
 
 |  | Linux<br/>(Ubuntu) | Raspbian<br/>(Raspberry Pi) | NuttX<br/>(STM32F4-Discovery) |
 | :---: | :---: | :---: | :---: |
-| spi.open | O | O | X |
-| spibus.transfer | O | O | X |
-| spibus.transferSync | O | O | X |
-| spibus.close | O | O | X |
-| spibus.closeSync | O | O | X |
+| spi.open | O | O | O |
+| spibus.transfer | O | O | O |
+| spibus.transferSync | O | O | O |
+| spibus.close | O | O | O |
+| spibus.closeSync | O | O | O |
 
 
 ## Class: SPI
 
 SPI (Serial Peripheral Interface) is a communication protocol which defines a way to communicate between devices.
+
+On NuttX, you have to know the number of pins that is defined on the target board module. For more information, please see the list below.
+  * [STM32F4-discovery](../targets/nuttx/stm32f4dis/IoT.js-API-Stm32f4dis.md)
 
 ### new SPI()
 
@@ -42,7 +45,8 @@ Sets the order of the bits shifted out of and into the SPI bus, either MSB (most
 
 ### spi.open(configuration[, callback])
 * `configuration` {Object}
-  * `device` {string} The specified path for `spidev`.
+  * `device` {string} The specified path for `spidev`. (only on Linux)
+  * `bus` {number} The specified bus number. (only on NuttX)
   * `mode` {SPI.MODE} The combinations of the polarity and phase. **Default:** `SPI.MODE[0]`.
   * `chipSelect` {SPI.CHIPSELECT} Chip select state. **Default:** `SPI.CHIPSELECT.NONE`.
   * `maxSpeed` {number} Maximum transfer speed. **Default:** `500000`.

--- a/docs/targets/nuttx/stm32f4dis/IoT.js-API-Stm32f4dis.md
+++ b/docs/targets/nuttx/stm32f4dis/IoT.js-API-Stm32f4dis.md
@@ -171,7 +171,21 @@ In order to use the I2C on stm32f4-discovery board, you must use proper pins.
 Currently only I2C1 is supported.
 
 The following table shows the I2C pin map:
+
 | I2C Pin Name | GPIO Name |
 | :--- | :---: |
 | I2C1_SCL | PB8 |
 | I2C1_SDA | PB7 |
+
+
+## SPI Bus Information
+
+The following table shows currently supported SPI pin number list.
+Currently only SPI1 is supported.
+
+| SPI Pin Name | GPIO Name |
+| :--- | :---: |
+| SPI1_SCK | PA5 |
+| SPI1_MISO | PA6 |
+| SPI1_MOSI | PA7 |
+| SPI1_NSS | PA15 |

--- a/docs/targets/nuttx/stm32f4dis/README.md
+++ b/docs/targets/nuttx/stm32f4dis/README.md
@@ -132,6 +132,10 @@ Followings are the options to set:
   * Enable `System Type -> STM32 Peripheral Support -> I2C1`
   * Enable `Device Drivers -> I2C Driver Support`
 
+* For `spi` module
+  * Enable `System Type -> STM32 Peripheral Support -> SPI1`
+  * Enable `Device Drivers -> SPI exchange`  
+
 #### 4. Build IoT.js for NuttX
 
 ##### Follow the instruction

--- a/src/iotjs_magic_strings.h
+++ b/src/iotjs_magic_strings.h
@@ -41,6 +41,7 @@
 #define IOTJS_MAGIC_STRING_BUFFER "Buffer"
 #define IOTJS_MAGIC_STRING__BUFFER "_buffer"
 #define IOTJS_MAGIC_STRING__BUILTIN "_builtin"
+#define IOTJS_MAGIC_STRING_BUS "bus"
 #define IOTJS_MAGIC_STRING_BYTELENGTH "byteLength"
 #define IOTJS_MAGIC_STRING_BYTEPARSED "byteParsed"
 #define IOTJS_MAGIC_STRING_CA "ca"

--- a/src/js/spi.js
+++ b/src/js/spi.js
@@ -47,14 +47,14 @@ function spiBusOpen(configuration, callback) {
   function SpiBus(configuration, callback) {
     var self = this;
 
-    // validate device
-    if (util.isObject(configuration)) {
+    if (process.platform === 'linux') {
       if (!util.isString(configuration.device)) {
-        throw new TypeError(
-          'Bad configuration - device is mandatory and String');
+        throw new TypeError('Bad configuration - device: String');
       }
-    } else {
-      throw new TypeError('Bad arguments - configuration should be Object');
+    } else if (process.platform === 'nuttx') {
+      if (!util.isNumber(configuration.bus)) {
+        throw new TypeError('Bad configuration - bus: Number');
+      }
     }
 
     // validate mode
@@ -202,9 +202,10 @@ function spiBusOpen(configuration, callback) {
       throw new Error('SPI bus is not opened');
     }
 
-    return _binding.close(function(err) {
+    _binding.close(function(err) {
       util.isFunction(callback) && callback.call(self, err);
     });
+    _binding = null;
   };
 
   SpiBus.prototype.closeSync = function() {
@@ -212,7 +213,8 @@ function spiBusOpen(configuration, callback) {
       throw new Error('SPI bus is not opened');
     }
 
-    return _binding.close();
+    _binding.close();
+    _binding = null;
   };
 
   return new SpiBus(configuration, callback);

--- a/src/modules/iotjs_module_spi.h
+++ b/src/modules/iotjs_module_spi.h
@@ -23,9 +23,14 @@
 #include "iotjs_reqwrap.h"
 
 
+#if defined(__NUTTX__)
+#include <nuttx/spi/spi.h>
+#endif
+
 typedef enum {
   kSpiOpOpen,
-  kSpiOpTransfer,
+  kSpiOpTransferArray,
+  kSpiOpTransferBuffer,
   kSpiOpClose,
 } SpiOp;
 
@@ -46,9 +51,14 @@ typedef enum { kSpiOrderMsb, kSpiOrderLsb } SpiOrder;
 
 typedef struct {
   iotjs_jobjectwrap_t jobjectwrap;
+#if defined(__linux__)
   iotjs_string_t device;
   int32_t device_fd;
-
+#elif defined(__NUTTX__)
+  int bus;
+  uint32_t cs_chip;
+  struct spi_dev_s* spi_dev;
+#endif
   SpiMode mode;
   SpiChipSelect chip_select;
   SpiOrder bit_order;

--- a/src/platform/nuttx/iotjs_module_spi-nuttx.c
+++ b/src/platform/nuttx/iotjs_module_spi-nuttx.c
@@ -1,4 +1,4 @@
-/* Copyright 2016-present Samsung Electronics Co., Ltd. and other contributors
+/* Copyright 2017-present Samsung Electronics Co., Ltd. and other contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,33 +15,71 @@
 
 #if defined(__NUTTX__)
 
+#include <nuttx/board.h>
 
+#include "iotjs_systemio-nuttx.h"
+#include "chip.h"
 #include "modules/iotjs_module_spi.h"
 
 
 bool iotjs_spi_transfer(iotjs_spi_t* spi) {
-  IOTJS_ASSERT(!"Not implemented");
-  return false;
+  IOTJS_VALIDATED_STRUCT_METHOD(iotjs_spi_t, spi);
+
+  struct spi_dev_s* spi_dev = _this->spi_dev;
+
+  SPI_LOCK(spi_dev, true);
+
+  SPI_SETFREQUENCY(spi_dev, _this->max_speed);
+
+  SPI_SETMODE(spi_dev, _this->mode);
+  SPI_SETBITS(spi_dev, _this->bits_per_word);
+
+  // Select the SPI
+  iotjs_gpio_write_nuttx(_this->cs_chip, false);
+
+  SPI_EXCHANGE(spi_dev, _this->tx_buf_data, _this->rx_buf_data, _this->buf_len);
+
+  // Unselect the SPI device
+  iotjs_gpio_write_nuttx(_this->cs_chip, true);
+
+  SPI_LOCK(spi_dev, false);
+
+  return true;
 }
 
 
 bool iotjs_spi_close(iotjs_spi_t* spi) {
-  IOTJS_ASSERT(!"Not implemented");
-  return false;
+  IOTJS_VALIDATED_STRUCT_METHOD(iotjs_spi_t, spi);
+
+  iotjs_gpio_unconfig_nuttx(_this->cs_chip);
+
+  return true;
 }
+
 
 void iotjs_spi_open_worker(uv_work_t* work_req) {
-  IOTJS_ASSERT(!"Not implemented");
-}
+  SPI_WORKER_INIT;
+  IOTJS_VALIDATED_STRUCT_METHOD(iotjs_spi_t, spi);
 
+  switch (_this->bus) {
+    case 1:
+      _this->cs_chip = (GPIO_OUTPUT | GPIO_PUSHPULL | GPIO_SPEED_50MHz |
+                        GPIO_PORTA | GPIO_PIN15 | GPIO_OUTPUT_SET);
+      break;
+    default:
+      req_data->result = false;
+      return;
+  }
 
-void iotjs_spi_transfer_worker(uv_work_t* work_req) {
-  IOTJS_ASSERT(!"Not implemented");
-}
+  iotjs_gpio_config_nuttx(_this->cs_chip);
 
+  if (!(_this->spi_dev = iotjs_spi_config_nuttx(_this->bus, _this->cs_chip))) {
+    DLOG("%s - SPI open failed %d", __func__, _this->bus);
+    req_data->result = false;
+    return;
+  }
 
-void iotjs_spi_close_worker(uv_work_t* work_req) {
-  IOTJS_ASSERT(!"Not implemented");
+  req_data->result = true;
 }
 
 

--- a/src/platform/nuttx/iotjs_systemio-nuttx.h
+++ b/src/platform/nuttx/iotjs_systemio-nuttx.h
@@ -18,7 +18,11 @@
 
 #include <stdint.h>
 
+#include "iotjs_def.h"
+
+void iotjs_gpio_config_nuttx(uint32_t pin);
 void iotjs_gpio_unconfig_nuttx(uint32_t pin);
+void iotjs_gpio_write_nuttx(uint32_t pin, bool value);
 
 
 #if ENABLE_MODULE_ADC || ENABLE_MODULE_PWM
@@ -63,6 +67,15 @@ int iotjs_i2c_unconfig_nuttx(struct i2c_master_s* i2c);
 struct pwm_lowerhalf_s* iotjs_pwm_config_nuttx(int timer, uint32_t pin);
 
 #endif /* ENABLE_MODULE_PWM */
+
+
+#if ENABLE_MODULE_SPI
+
+#include <nuttx/spi/spi.h>
+
+struct spi_dev_s* iotjs_spi_config_nuttx(int bus, uint32_t cs_chip);
+
+#endif /* ENABLE_MODULE_SPI */
 
 
 #endif /* IOTJS_SYSTEMIO_ARM_NUTTX_H */

--- a/src/platform/nuttx/stm32f4dis/iotjs_systemio-nuttx-stm32f4dis.c
+++ b/src/platform/nuttx/stm32f4dis/iotjs_systemio-nuttx-stm32f4dis.c
@@ -21,8 +21,18 @@
 #include "stm32_gpio.h"
 
 
+void iotjs_gpio_config_nuttx(uint32_t pin) {
+  stm32_configgpio(pin);
+}
+
+
 void iotjs_gpio_unconfig_nuttx(uint32_t pin) {
   stm32_unconfiggpio(pin);
+}
+
+
+void iotjs_gpio_write_nuttx(uint32_t pin, bool value) {
+  stm32_gpiowrite(pin, value);
 }
 
 
@@ -66,6 +76,19 @@ struct pwm_lowerhalf_s* iotjs_pwm_config_nuttx(int timer, uint32_t pin) {
 
   // PWM initialize
   return stm32_pwminitialize(timer);
+}
+
+#endif /* ENABLE_MODULE_PWM */
+
+
+#if ENABLE_MODULE_SPI
+
+#include "stm32_spi.h"
+
+struct spi_dev_s* iotjs_spi_config_nuttx(int bus, uint32_t cs_chip) {
+  stm32_configgpio(cs_chip);
+
+  return stm32_spibus_initialize(bus);
 }
 
 #endif /* ENABLE_MODULE_PWM */

--- a/test/run_pass/test_spi_buffer.js
+++ b/test/run_pass/test_spi_buffer.js
@@ -18,8 +18,18 @@ var Spi = require('spi');
 
 var spi = new Spi();
 
+var configuration = {};
+
+if (process.platform === 'linux') {
+  configuration.device = '/dev/spidev0.0';
+} else if (process.platform === 'nuttx') {
+  configuration.bus = 1;
+} else {
+  assert.fail();
+}
+
 // Buffer test
-var spi1 = spi.open({device: '/dev/spidev0.0'}, function() {
+var spi1 = spi.open(configuration, function() {
   var data = 'Hello IoTjs';
   var tx = new Buffer(data);
   var rx = new Buffer(11);

--- a/test/run_pass/test_spi_mcp3008.js
+++ b/test/run_pass/test_spi_mcp3008.js
@@ -18,11 +18,19 @@ var Spi = require('spi');
 
 var spi = new Spi();
 
+var configuration = {};
+
+if (process.platform === 'linux') {
+  configuration.device = '/dev/spidev0.0';
+} else if (process.platform === 'nuttx') {
+  configuration.bus = 1;
+} else {
+  assert.fail();
+}
+
 //  mcp3008 test
 var channel = 0;
-var spi0 = spi.open({
-  device: '/dev/spidev0.0'
-}, function() {
+var spi0 = spi.open(configuration, function() {
   var mode = (8 + channel) << 4;
   var tx = [1, mode, 0];
   var rx = [0, 0, 0];


### PR DESCRIPTION
- implement SPI on NuttX
- fix an invalid buffer release: buffer created in javascript are released by the GC,
  so do not need to release them in the transfer function of SPI
- update documents
- tested on stm32f4-discovery

IoT.js-DCO-1.0-Signed-off-by: Hosung Kim hs852.kim@samsung.com