### PR TITLE
Romfs patch for artik053

### DIFF
--- a/config/tizenrt/artik05x/romfs.patch
+++ b/config/tizenrt/artik05x/romfs.patch
@@ -1,0 +1,41 @@
+diff --git apps/system/init/init.c apps/system/init/init.c
+index 5d5e360..430e2f5 100644
+--- apps/system/init/init.c
++++ apps/system/init/init.c
+@@ -130,6 +130,10 @@ int preapp_start(int argc, char *argv[])
+ 	}
+ #endif
+ 
++#ifdef CONFIG_FS_ROMFS
++	mount("/dev/smart4rom9", "/rom", "romfs", 0, NULL);
++#endif
++
+ #if defined(CONFIG_LIB_USRWORK) || defined(CONFIG_TASH)
+ error_out:
+ 	return pid;
+diff --git build/configs/artik053/artik053_download.sh build/configs/artik053/artik053_download.sh
+index 711d131..7f8eee0 100755
+--- build/configs/artik053/artik053_download.sh
++++ build/configs/artik053/artik053_download.sh
+@@ -72,6 +72,7 @@ main()
+ 				flash_write sssfw ../../bin/sssfw.bin; 		\
+ 				flash_write wlanfw ../../bin/wlanfw.bin;	\
+ 				flash_write os ../../../../output/bin/tinyara_head.bin;	\
++				flash_write rom ../../../../output/bin/rom.img;	\
+ 			exit'
+ 			popd
+ 			;;
+diff --git build/configs/artik053/tools/openocd/partition_map.cfg build/configs/artik053/tools/openocd/partition_map.cfg
+index 10455a4..8f66487 100644
+--- build/configs/artik053/tools/openocd/partition_map.cfg
++++ build/configs/artik053/tools/openocd/partition_map.cfg
+@@ -11,7 +11,8 @@ set partition_list {
+ 	os	{ "OS"			0x040C8000	0x00258000	0 }
+ 	factory	{ "Factory Reset"	0x04320000	0x00180000	0 }
+ 	ota	{ "OTA download"	0x044A0000	0x00180000	0 }
+-	user	{ "USER R/W"		0x04620000	0x0015E000	0 }
++	user	{ "USER R/W"		0x04620000	0x000FA000	0 }
++	rom	{ "ROM FS"		0x0471A000	0x00064000	0 }
+ 	nvram	{ "WiFi NVRAM"		0x0477E000	0x00002000	1 }
+ 	sssrw	{ "SSS R/W Key"		0x04780000	0x00080000	1 }
+ }


### PR DESCRIPTION
- Currently, the size of romfs on artik053 is not decided yet, 
  We can use this patch temporary. 
  If TizenRT supports ROMFS officialy, I will delete this patch.
- Please copy the attached file into the TIzenRT root folder and patch it 
  $ patch -p0 < romfs.patch

IoT.js-DCO-1.0-Signed-off-by: Haesik, Jun haesik.jun@samsung.com