### PR TITLE
Add a backtrace for called functions into assert

### DIFF
--- a/src/iotjs_def.h
+++ b/src/iotjs_def.h
@@ -33,10 +33,19 @@
 #ifdef NDEBUG
 #define IOTJS_ASSERT(x) ((void)(x))
 #else
-#define IOTJS_ASSERT(x) assert(x)
+extern void print_stacktrace();
+extern void force_terminate();
+#define IOTJS_ASSERT(x)                                                      \
+  do {                                                                       \
+    if (!(x)) {                                                              \
+      fprintf(stderr, "%s:%d: Assertion '%s' failed.\n", __FILE__, __LINE__, \
+              #x);                                                           \
+      print_stacktrace();                                                    \
+      force_terminate();                                                     \
+    }                                                                        \
+  } while (0)
 #endif
 #endif
-
 
 #if defined(__arm__)
 #define TARGET_ARCH "arm"


### PR DESCRIPTION
IoT.js-DCO-1.0-Signed-off-by: Daeyeon Jeong daeyeon.jeong@samsung.com