### PR TITLE
Guide updated after ADC refactoring

### DIFF
--- a/docs/devs/Extended-API-Guidelines.md
+++ b/docs/devs/Extended-API-Guidelines.md
@@ -9,15 +9,18 @@ However, extended APIs need a guideline because they are implemented by many con
 2. Basically, all APIs are async API. If you want to make sync API, you need to add `Sync` as a suffix.<br>For example, `readSync()`, `writeSync()`, and so on.
 
 ## Generating an object 
-1. The module object should be generated using `open()` API for consistent usability. (Do not use `New` constructor)
-2. `open()` API should have configuable as first argument and callback function as second argument.<br>callback function is always optional.
+1. The module object should be generated using `new' API for consistent usability.
+2. `new` API should have configuable as first argument and callback function as second argument.<br>callback function is always optional.
 
 For example, GPIO module generate an object like below:
 ```javascript
-var gpio = require('gpio');
+var Gpio = require('gpio');
 
-var gpio10 = gpio.open({pin: 10, direction: gpio.DIRECTION.OUT}, 
+var gpio10 = new Gpio({pin: 10, direction: gpio.DIRECTION.OUT},
                        function(err){console.log(err);});
+gpio10.writeSync(1);
+
+
 ```
 
 ## Minimize event generation


### PR DESCRIPTION
This change updated guide to match new APIs implementations started with ADC

https://github.com/Samsung/iotjs/pull/1012

IoT.js-DCO-1.0-Signed-off-by: Piotr Marcinkiewicz <p.marcinkiew@samsung.com>

I had some trouble with overwriting change crated internally by GITHUB markup editor. I created new pull request. Please see https://github.com/Samsung/iotjs/pull/1029 for reference.