### PR TITLE
TizenRT GPIO compilation fix

### DIFF
--- a/build.config
+++ b/build.config
@@ -111,7 +111,7 @@
       "nuttx": ["adc", "dgram", "gpio", "i2c", "pwm", "stm32f4dis", "uart"],
       "darwin": [],
       "tizen": ["adc", "ble", "dgram", "gpio", "i2c", "pwm", "spi", "uart", "https"],
-      "tizenrt": ["gpio", "pwm"]
+      "tizenrt": []
     }
   }
 }

--- a/src/platform/tizenrt/iotjs_module_gpio-tizenrt.c
+++ b/src/platform/tizenrt/iotjs_module_gpio-tizenrt.c
@@ -25,7 +25,7 @@ void iotjs_gpio_open_worker(uv_work_t* work_req) {
          _this->direction, _this->mode);
 
   // Open gpio pin
-  _this->gpio_context = iotbus_gpio_open(_this->pin);
+  _this->gpio_context = iotbus_gpio_open((int)_this->pin);
   if (_this->gpio_context == NULL) {
     req_data->result = false;
     return;


### PR DESCRIPTION
Unsigned / signed conversion error is fixed.

+ updated build.config to remove not needed module exclusion

IoT.js-DCO-1.0-Signed-off-by: Konrad Lipner k.lipner@samsung.com