### PR TITLE
GBS Tizen configuration - work around for ambigous packages definitions

### DIFF
--- a/config/tizen/packaging/iotjs.spec
+++ b/config/tizen/packaging/iotjs.spec
@@ -19,6 +19,7 @@ BuildRequires: pkgconfig(capi-appfw-app-common)
 BuildRequires: pkgconfig(capi-appfw-package-manager)
 BuildRequires: pkgconfig(capi-appfw-application)
 BuildRequires: pkgconfig(dlog)
+BuildRequires: terminfo-base-mini
 #for https
 BuildRequires:  openssl-devel
 BuildRequires:  libcurl-devel


### PR DESCRIPTION
This additional dependency is not mandatory for IoT.js but it clarifies
ambiguous dependencies in some packages. This work around provides
easy solution to compile IoT.js with .gbs.conf included with GIT repo.

IoT.js-DCO-1.0-Signed-off-by: Piotr Marcinkiewicz p.marcinkiew@samsung.com