### PR TITLE
Enable ENABLE_MEMORY_CONSTRAINTS for http-parser

### DIFF
--- a/cmake/http-parser.cmake
+++ b/cmake/http-parser.cmake
@@ -35,6 +35,7 @@ ExternalProject_Add(http-parser
     -DCMAKE_C_FLAGS=${CMAKE_C_FLAGS}
     -DOS=${TARGET_OS}
     ${HTTPPARSER_NUTTX_ARG}
+    -DENABLE_MEMORY_CONSTRAINTS=ON
 )
 add_library(libhttp-parser STATIC IMPORTED)
 add_dependencies(libhttp-parser http-parser)


### PR DESCRIPTION
Recently, we reduced the binary size of http-parser (Samsung/http-parser#6).
This patch enables this feature.

IoT.js-DCO-1.0-Signed-off-by: Sanggyu Lee sg5.lee@samsung.com