### PR TITLE
Added timeout for uart test to prevent hanging.

### DIFF
--- a/test/testsets.json
+++ b/test/testsets.json
@@ -91,7 +91,7 @@
     { "name": "test_timers_arguments.js" },
     { "name": "test_timers_error.js" },
     { "name": "test_timers_simple.js", "timeout": 10 },
-    { "name": "test_uart.js", "skip": ["all"], "reason": "need to setup test environment" },
+    { "name": "test_uart.js", "timeout": 10},
     { "name": "test_util.js" }
   ],
   "run_pass/issue": [


### PR DESCRIPTION
In case the uart is not responding (for example due to lack of set up environment) after 10 seconds the test is skipped with TIMEOUT status.
The IoT.js test suite was run and checked for this test on Raspberry Pi 3. 

```
FAIL : test_stream.js
PASS : test_stream_duplex.js
PASS : test_timers_arguments.js
PASS : test_timers_error.js
PASS : test_timers_simple.js
TIMEOUT : test_uart.js                            # here after change
PASS : test_util.js


>>>> run_pass/issue
PASS : issue-133.js
PASS : issue-137.js
```