### PR TITLE
Remove unnecessary redefinition of 'JHANDLER_FUNCTION'.

### DIFF
--- a/src/modules/iotjs_module_fs.c
+++ b/src/modules/iotjs_module_fs.c
@@ -20,8 +20,6 @@
 #include "iotjs_exception.h"
 #include "iotjs_reqwrap.h"
 
-#undef JHANDLER_FUNCTION
-#define JHANDLER_FUNCTION(name) static void name(iotjs_jhandler_t* jhandler)
 
 typedef struct {
   iotjs_reqwrap_t reqwrap;


### PR DESCRIPTION
IoT.js-DCO-1.0-Signed-off-by: László Langó llango.u-szeged@partner.samsung.com