### PR TITLE
ADC implemented and tested for TizenRT port.

### DIFF
--- a/src/modules/iotjs_module_adc.c
+++ b/src/modules/iotjs_module_adc.c
@@ -212,7 +212,7 @@ JHANDLER_FUNCTION(AdcConstructor) {
 #if defined(__linux__)
   DJHANDLER_GET_REQUIRED_CONF_VALUE(jconfiguration, _this->device,
                                     IOTJS_MAGIC_STRING_DEVICE, string);
-#elif defined(__NUTTX__)
+#elif defined(__NUTTX__) || defined(__TIZENRT__)
   DJHANDLER_GET_REQUIRED_CONF_VALUE(jconfiguration, _this->pin,
                                     IOTJS_MAGIC_STRING_PIN, number);
 #endif

--- a/src/modules/iotjs_module_adc.h
+++ b/src/modules/iotjs_module_adc.h
@@ -34,7 +34,7 @@ typedef struct {
 
 #if defined(__linux__)
   iotjs_string_t device;
-#elif defined(__NUTTX__)
+#elif defined(__NUTTX__) || defined(__TIZENRT__)
   uint32_t pin;
 #endif
   int32_t device_fd;

--- a/src/platform/tizenrt/iotjs_module_adc-tizenrt.c
+++ b/src/platform/tizenrt/iotjs_module_adc-tizenrt.c
@@ -1,0 +1,96 @@
+/* Copyright 2017-present Samsung Electronics Co., Ltd. and other contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#if defined(__TIZENRT__)
+
+#include <errno.h>
+#include <fcntl.h>
+#include <stdlib.h>
+#include <sys/ioctl.h>
+#include <tinyara/analog/adc.h>
+#include <tinyara/analog/ioctl.h>
+
+#include "iotjs_def.h"
+#include "modules/iotjs_module_adc.h"
+
+#define S5J_ADC_MAX_CHANNELS 4
+
+// There is one file for all ADC inputs so wee need one common file descriptor
+static int32_t device_fd;
+// This is simple ref counter. Each time ADC is opened, it is increased.
+static size_t device_fd_counter = 0;
+// Path of ADC device.
+#define TIZENRT_ADC_DEVICE "/dev/adc0"
+
+int32_t iotjs_adc_read(iotjs_adc_t* adc) {
+  IOTJS_VALIDATED_STRUCT_METHOD(iotjs_adc_t, adc);
+  int ret, nbytes;
+  size_t readsize, i, nsamples;
+  struct adc_msg_s samples[S5J_ADC_MAX_CHANNELS];
+  ret = ioctl(_this->device_fd, ANIOC_TRIGGER, 0);
+  if (ret < 0) {
+    return -1;
+  }
+  readsize = sizeof(samples);
+  while (true) {
+    nbytes = read(_this->device_fd, samples, readsize);
+    if (nbytes > 0) {
+      nsamples = (size_t)nbytes / sizeof(struct adc_msg_s);
+      int sample = -1;
+      for (i = 0; i < nsamples; ++i) {
+        if (_this->pin == samples[i].am_channel) {
+          sample = samples[i].am_data;
+        }
+      }
+      if (-1 != sample) {
+        return sample;
+      }
+    } /* else {
+      // The read function is blocking but there are events,
+      // which can interrupt it. The function will return
+      // non-positive number of obtained samples. We can ignore it and
+      // wait for next samples returned from ADC.
+    } */
+  }
+}
+
+bool iotjs_adc_close(iotjs_adc_t* adc) {
+  IOTJS_VALIDATED_STRUCT_METHOD(iotjs_adc_t, adc);
+  if (_this->device_fd > 0) {
+    device_fd_counter--;
+  }
+  if (0 == device_fd_counter) {
+    close(_this->device_fd);
+  }
+  return true;
+}
+
+
+void iotjs_adc_open_worker(uv_work_t* work_req) {
+  ADC_WORKER_INIT;
+  IOTJS_VALIDATED_STRUCT_METHOD(iotjs_adc_t, adc);
+  if (0 == device_fd_counter) {
+    device_fd = open(TIZENRT_ADC_DEVICE, O_RDONLY);
+  }
+  _this->device_fd = device_fd;
+  if (_this->device_fd < 0) {
+    req_data->result = false;
+    return;
+  }
+  device_fd_counter++;
+  req_data->result = true;
+}
+
+#endif // __TIZENRT__

--- a/test/run_pass/test_adc.js
+++ b/test/run_pass/test_adc.js
@@ -23,6 +23,8 @@ if (process.platform === 'linux') {
     '/sys/devices/12d10000.adc/iio:device0/in_voltage0_raw';
 } else if (process.platform === 'nuttx') {
   configuration.pin = require('stm32f4dis').pin.ADC1_3;
+} else if (process.platform === 'tizenrt') {
+  configuration.pin = 0;
 } else {
   assert.fail();
 }


### PR DESCRIPTION
1. Pin field enabled for TizenRT in iotjs_module_adc.
2. New binding for TizenRT introduced based on sensorboard demo from
   TizenRT.

IoT.js-DCO-1.0-Signed-off-by: Piotr Marcinkiewicz p.marcinkiew@samsung.com