### PR TITLE
Guide update for RPi3/Tizen

### DIFF
--- a/docs/build/Build-for-ARTIK10-Tizen.md
+++ b/docs/build/Build-for-ARTIK10-Tizen.md
@@ -14,7 +14,7 @@ sudo apt-get install gcc-arm-linux-gnueabi g++-arm-linux-gnueabi
 ```
 
 #### Building
-1. Make sure arm-linux-gnueabi-gcc is in path. 
+1. Make sure arm-linux-gnueabi-gcc is in path.
 2. Locate Tizen SDK. Default location is: ~/tizen-studio.  
 3. In platforms/tizen-3.0/mobile there should be compatible rootstrap (eg. mobile-3.0-device)  
 
@@ -29,8 +29,8 @@ tools/build.py \
 #### Testing
 Transfer iotjs binary and test file to the device:  
 ``` bash
-sdb push ./build/arm-tizen/debug/bin/iotjs /home/owner/iotjs/
-sdb push ./test/run_pass/test_console.js /home/owner/iotjs/
+ $ sdb push ./build/arm-tizen/debug/bin/iotjs /home/owner/iotjs/
+ $ sdb push ./test/run_pass/test_console.js /home/owner/iotjs/
 ```
 
 Run the test:
@@ -38,53 +38,4 @@ Run the test:
 sdb shell
 $ cd /home/owner/iotjs
 $ ./iotjs test_console.js
-```
-
-
-### 2. Build with GBS
-
-#### Prerequisites
-* Tizen uses GBS to create RPM packages.  
-  SDB tool is in Tizen Studio. To send a file, please, install tizen studio.  
-  (https://developer.tizen.org/development/tizen-studio/download)  
-* To run GBS, please create a GBS configuration file at '~/.gbs.conf'  
- (https://source.tizen.org/documentation/reference/git-build-system/configuration-file)  
- You can use this sample, /config/tizen/sample.gbs.conf for GBS build.  
-``` bash
-sudo apt-get install gbs mic
-cp ./config/tizen/sample.gbs.conf ~/.gbs.conf
-```  
-Please add your Tizen.org id and password on this conf file.  
-
-#### Building
-* You can modify IoT.js build option on the spec file.  
- (config/tizen/packaging/iotjs.spec)  
-* Run gbsbuild.sh at first.
-Compile:
-``` bash
-cp ./config/tizen/gbsbuild.sh ./
-./gbsbuild.sh
-```
-After finishing build, move to a new working directory at '../iotjs_tizen_gbs/'.  
-Next time, build with this basic command.
-```bash
-gbs build -A armv7l --include-all
-```
-
-#### Install
-Transfer iotjs binary and test file to the device:
-``` bash
-sdb push  ~/GBS-ROOT/local/repos/tizen_unified/armv7l/RPMS/iotjs-1.0.0-0.armv7l.rpm /tmp
-sdb push ./test/run_pass/test_console.js /home/owner/iotjs/
-sdb root on
-sdb shell
-(target)$ cd /tmp
-(only in headless Tizen 4.0 target)$ mount -o remount,rw
-(target)$ rpm -ivh --force iotjs-1.0.0.rpm
-```
-
-Run the test:
-``` bash
-sdb shell
-$ iotjs test_console.js
 ```

--- a/docs/build/Build-for-RPi3-Tizen.md
+++ b/docs/build/Build-for-RPi3-Tizen.md
@@ -1,0 +1,116 @@
+
+### 1. Tizen on RPi3 GBS build
+
+#### Prerequisites
+* Tizen uses GBS to create RPM packages.  
+  SDB tool is in Tizen Studio. To send a file, please, install tizen studio.  
+  (https://developer.tizen.org/development/tizen-studio/download)  
+* To run GBS, please create a GBS configuration file at '~/.gbs.conf'  
+ (https://source.tizen.org/documentation/reference/git-build-system/configuration-file)  
+ You can use this sample, /config/tizen/sample.gbs.conf for GBS build.  
+``` bash
+sudo apt-get install gbs mic
+cp ./config/tizen/sample.gbs.conf ~/.gbs.conf
+```  
+Please add your Tizen.org id and password on this conf file.  
+
+#### Building
+* You can modify IoT.js build option on the spec file.  
+ (config/tizen/packaging/iotjs.spec)  
+* Run gbsbuild.sh at first.
+Compile:
+``` bash
+cp ./config/tizen/gbsbuild.sh ./
+./gbsbuild.sh
+```
+After finishing build, move to a new working directory at '../iotjs_tizen_gbs/'.  
+Next time, build with this basic command.
+```bash
+gbs build -A armv7l --include-all
+```
+
+### 2. Bring up RPi3 with Tizen
+This guide for the RPi3 is a temporary solution until releasing official guide of Tizen sites.
+
+#### Install pv package
+``` bash
+$ sudo apt-get install pv
+```
+
+#### Downloading fusing-script and firmwares
+``` bash
+  $ wget https://git.tizen.org/cgit/platform/kernel/linux-rpi3/plain/scripts/sd_fusing_rpi3.sh?h=tizen --output-document=sd_fusing_rpi3.sh
+  $ chmod 755 sd_fusing_rpi3.sh
+  $ wget https://github.com/RPi-Distro/firmware-nonfree/raw/master/brcm80211/brcm/brcmfmac43430-sdio.bin
+  $ wget https://github.com/RPi-Distro/firmware-nonfree/raw/master/brcm80211/brcm/brcmfmac43430-sdio.txt
+  $ wget https://github.com/OpenELEC/misc-firmware/raw/master/firmware/brcm/BCM43430A1.hcd
+```
+
+#### Downloading TizenIoT Core Image for RPi3
+
+Kernel & Module Image
+
+http://download.tizen.org/snapshots/tizen/unified/latest/images/standard/common-boot-arm64-rpi3/
+
+
+Tizen Platform Image
+
+http://download.tizen.org/snapshots/tizen/unified/latest/images/standard/common-iot_core-2parts-armv7l-rpi3/
+
+
+#### Fusing images to sd-card
+``` bash
+  $ sudo ./sd_fusing_rpi3.sh -d /dev/sdb --format
+  $ sudo ./sd_fusing_rpi3.sh -d /dev/sdb -b tizen-unified_20170704.1_common-iot_core-2parts-armv7l-rpi3.tar.gz
+  $ sudo ./sd_fusing_rpi3.sh -d /dev/sdb -b tizen-unified_20170704.1_common-boot-arm64-rpi3.tar.gz
+```
+
+#### Copying firmwares for wifi and bluetooth
+``` bash
+ $ mkdir rootfs
+ $ sudo mount /dev/sdb2 rootfs
+ $ sudo mkdir -p rootfs/usr/etc/bluetooth
+ $ sudo cp BCM43430A1.hcd rootfs/usr/etc/bluetooth
+ $ sudo mkdir -p rootfs/usr/lib/firmware/brcm
+ $ sudo cp brcmfmac43430-sdio.* rootfs/usr/lib/firmware/brcm
+ $ sync
+ $ sudo umount rootfs
+ $ rmdir rootfs
+```
+
+#### Setting up serial port
+ Please refer the tizen wiki  https://wiki.tizen.org/Raspberry_Pi#Debugging
+
+#### Setup IP
+Setup IP on RPi3 target using serial port
+``` bash
+ User id/passwd : root / tizen
+ $ ifconfig eth0 down
+ $ ifconfig eth0 192.168.1.11 netmask 255.255.255.0 up
+ $ route add default gw 192.168.1.1
+```
+
+#### SDB connection
+ Now you can connect RPi3 on Ubuntu PC
+
+``` bash
+$ sdb connect 192.168.1.11
+ ```
+
+#### Install
+Transfer iotjs binary and test file to the device:
+``` bash
+sdb push  ~/GBS-ROOT/local/repos/tizen_unified/armv7l/RPMS/iotjs-1.0.0-0.armv7l.rpm /tmp
+sdb push ./test/run_pass/test_console.js /home/owner/iotjs/
+sdb root on
+sdb shell
+(target)$ cd /tmp
+(only in headless Tizen 4.0 target)$ mount -o remount,rw
+(target)$ rpm -ivh --force iotjs-1.0.0.rpm
+```
+
+#### Run the test:
+``` bash
+sdb shell
+$ iotjs test_console.js
+```


### PR DESCRIPTION
Add a guide for using Tizen in RPi3
The official(tizen wiki) site does not support this guide yet.
So we could use this until official guide will have been released.

IoT.js-DCO-1.0-Signed-off-by: Haesik, Jun haesik.jun@samsung.com