### PR TITLE
GPIO peripheral API introduced for Tizen

### DIFF
--- a/config/tizen/packaging/iotjs.spec
+++ b/config/tizen/packaging/iotjs.spec
@@ -71,7 +71,7 @@ cp %{SOURCE1001} .
  --target-os=tizen --target-board=artik10 \
  --external-shared-lib=capi-system-peripheral-io \
  --compile-flag=-D__TIZEN__ \
- --iotjs-include-module=dgram,i2c \
+ --iotjs-include-module=dgram,gpio,i2c \
  --no-init-submodule --no-parallel-build --no-check-test
 
 %install

--- a/src/modules/iotjs_module_gpio.c
+++ b/src/modules/iotjs_module_gpio.c
@@ -30,15 +30,15 @@ static iotjs_gpio_t* iotjs_gpio_create(const iotjs_jval_t* jgpio) {
   IOTJS_VALIDATED_STRUCT_CONSTRUCTOR(iotjs_gpio_t, gpio);
   iotjs_jobjectwrap_initialize(&_this->jobjectwrap, jgpio,
                                &this_module_native_info);
-#if defined(__linux__)
-  _this->value_fd = -1;
-#endif
+
+  iotjs_gpio_platform_create(_this);
   return gpio;
 }
 
 
 static void iotjs_gpio_destroy(iotjs_gpio_t* gpio) {
   IOTJS_VALIDATED_STRUCT_DESTRUCTOR(iotjs_gpio_t, gpio);
+  iotjs_gpio_platform_destroy(_this);
   iotjs_jobjectwrap_destroy(&_this->jobjectwrap);
   IOTJS_RELEASE(gpio);
 }

--- a/src/modules/iotjs_module_gpio.h
+++ b/src/modules/iotjs_module_gpio.h
@@ -22,9 +22,6 @@
 #include "iotjs_objectwrap.h"
 #include "iotjs_reqwrap.h"
 
-#if defined(__TIZENRT__)
-#include <iotbus_gpio.h>
-#endif
 
 typedef enum {
   kGpioDirectionIn = 0,
@@ -64,6 +61,7 @@ typedef struct {
   GpioOp op;
 } iotjs_gpio_reqdata_t;
 
+typedef struct _iotjs_gpio_module_platform_t* iotjs_gpio_module_platform_t;
 
 // This Gpio class provides interfaces for GPIO operation.
 typedef struct {
@@ -72,13 +70,7 @@ typedef struct {
   GpioDirection direction;
   GpioMode mode;
   GpioEdge edge;
-#if defined(__linux__)
-  int value_fd;
-  uv_thread_t thread;
-  uv_mutex_t mutex;
-#elif defined(__TIZENRT__)
-  iotbus_gpio_context_h gpio_context;
-#endif
+  iotjs_gpio_module_platform_t platform;
 } IOTJS_VALIDATED_STRUCT(iotjs_gpio_t);
 
 
@@ -110,5 +102,7 @@ void iotjs_gpio_open_worker(uv_work_t* work_req);
 bool iotjs_gpio_write(iotjs_gpio_t* gpio, bool value);
 int iotjs_gpio_read(iotjs_gpio_t* gpio);
 bool iotjs_gpio_close(iotjs_gpio_t* gpio);
+void iotjs_gpio_platform_create(iotjs_gpio_t_impl_t* gpio);
+void iotjs_gpio_platform_destroy(iotjs_gpio_t_impl_t* gpio);
 
 #endif /* IOTJS_MODULE_GPIO_H */

--- a/src/platform/nuttx/stm32f4dis/iotjs_module_gpio-nuttx-stm32f4dis.c
+++ b/src/platform/nuttx/stm32f4dis/iotjs_module_gpio-nuttx-stm32f4dis.c
@@ -34,6 +34,14 @@ uint32_t gpioMode[] = {
 };
 
 
+void iotjs_gpio_platform_create(iotjs_gpio_t_impl_t* _this) {
+}
+
+
+void iotjs_gpio_platform_destroy(iotjs_gpio_t_impl_t* _this) {
+}
+
+
 bool iotjs_gpio_write(iotjs_gpio_t* gpio, bool value) {
   IOTJS_VALIDATED_STRUCT_METHOD(iotjs_gpio_t, gpio);
 

--- a/src/platform/tizen/iotjs_module_gpio-tizen.c
+++ b/src/platform/tizen/iotjs_module_gpio-tizen.c
@@ -1,0 +1,106 @@
+/* Copyright 2017-present Samsung Electronics Co., Ltd. and other contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <peripheral_io.h>
+#include <stdlib.h>
+
+#include "modules/iotjs_module_gpio.h"
+
+struct _iotjs_gpio_module_platform_t {
+  peripheral_gpio_h peripheral_gpio;
+};
+
+void iotjs_gpio_platform_create(iotjs_gpio_t_impl_t* _this) {
+  size_t private_mem = sizeof(struct _iotjs_gpio_module_platform_t);
+  _this->platform = (iotjs_gpio_module_platform_t)malloc(private_mem);
+}
+
+void iotjs_gpio_platform_destroy(iotjs_gpio_t_impl_t* _this) {
+  iotjs_buffer_release((char*)_this->platform);
+}
+
+bool iotjs_gpio_write(iotjs_gpio_t* gpio, bool value) {
+  IOTJS_VALIDATED_STRUCT_METHOD(iotjs_gpio_t, gpio);
+  int retVal = peripheral_gpio_write(_this->platform->peripheral_gpio, value);
+  return PERIPHERAL_ERROR_NONE == retVal;
+}
+
+
+int iotjs_gpio_read(iotjs_gpio_t* gpio) {
+  IOTJS_VALIDATED_STRUCT_METHOD(iotjs_gpio_t, gpio);
+  int value;
+  int retVal = peripheral_gpio_read(_this->platform->peripheral_gpio, &value);
+  if (PERIPHERAL_ERROR_NONE == retVal) {
+    return value;
+  } else {
+    return -1;
+  }
+}
+
+
+bool iotjs_gpio_close(iotjs_gpio_t* gpio) {
+  IOTJS_VALIDATED_STRUCT_METHOD(iotjs_gpio_t, gpio);
+  peripheral_gpio_close(_this->platform->peripheral_gpio);
+  return true;
+}
+
+
+void iotjs_gpio_open_worker(uv_work_t* work_req) {
+  GPIO_WORKER_INIT;
+  IOTJS_VALIDATED_STRUCT_METHOD(iotjs_gpio_t, gpio);
+
+  peripheral_gpio_h _gpio;
+  int retVal = peripheral_gpio_open((int)_this->pin, &_gpio);
+  if (retVal != PERIPHERAL_ERROR_NONE) {
+    req_data->result = false;
+    return;
+  }
+  _this->platform->peripheral_gpio = _gpio;
+  peripheral_gpio_direction_e _direction;
+  if (_this->direction == kGpioDirectionIn) {
+    _direction = PERIPHERAL_GPIO_DIRECTION_IN;
+  } else {
+    _direction = PERIPHERAL_GPIO_DIRECTION_OUT;
+  }
+  retVal = peripheral_gpio_set_direction(_gpio, _direction);
+  if (retVal != PERIPHERAL_ERROR_NONE) {
+    req_data->result = false;
+    return;
+  }
+  // Mode is not supported by Peripheral API for Tizen
+  peripheral_gpio_edge_e _edge;
+  switch (_this->edge) {
+    case kGpioEdgeNone:
+      _edge = PERIPHERAL_GPIO_EDGE_NONE;
+      break;
+    case kGpioEdgeRising:
+      _edge = PERIPHERAL_GPIO_EDGE_RISING;
+      break;
+    case kGpioEdgeFalling:
+      _edge = PERIPHERAL_GPIO_EDGE_FALLING;
+      break;
+    case kGpioEdgeBoth:
+      _edge = PERIPHERAL_GPIO_EDGE_BOTH;
+      break;
+    default:
+      _edge = PERIPHERAL_GPIO_EDGE_NONE;
+  }
+  retVal = peripheral_gpio_set_edge_mode(_gpio, _edge);
+  if (retVal != PERIPHERAL_ERROR_NONE) {
+    req_data->result = false;
+    return;
+  }
+  req_data->result = true;
+}


### PR DESCRIPTION
1. The new platform module for Tizen was created using CAPI System
   Peripheral API.
2. The iotjs.spec was extended with peripheral dependencies.
3. The operating system flag for Tizen build was changed from
   Linux to Tizen. We use Tizen specific APIs for hardware
   so this change is reasonable.
4. The compiler flag __linux__ was used in many places to check for
   Linux specific features. This flag is set in compiler not in our
   build environment. We need a way to distinguish between
   pure Linux (e.g. Raspbian) and Tizen, which is very specific flavour.
5. Tizen GPIO was tested using test_gpio_xx test executed manually.