### PR TITLE
I2c for tizen

### DIFF
--- a/config/tizen/gbsbuild.sh
+++ b/config/tizen/gbsbuild.sh
@@ -41,7 +41,7 @@ then
   rm ./cmake/config/arm-tizen.cmake
   echo "include(CMakeForceCompiler)
 
-  set(CMAKE_SYSTEM_NAME Linux)
+  set(CMAKE_SYSTEM_NAME Tizen)
   set(CMAKE_SYSTEM_PROCESSOR armv7l)"\
    >> ./cmake/config/arm-tizen.cmake
 

--- a/config/tizen/packaging/iotjs.spec
+++ b/config/tizen/packaging/iotjs.spec
@@ -18,6 +18,7 @@ BuildRequires: pkgconfig(capi-appfw-service-application)
 BuildRequires: pkgconfig(capi-appfw-app-common)
 BuildRequires: pkgconfig(capi-appfw-package-manager)
 BuildRequires: pkgconfig(capi-appfw-application)
+BuildRequires: pkgconfig(capi-system-peripheral-io)
 BuildRequires: pkgconfig(dlog)
 #for https
 BuildRequires:  openssl-devel
@@ -68,6 +69,9 @@ cp %{SOURCE1001} .
 %build
 ./tools/build.py --clean --buildtype=%{build_mode} --target-arch=arm \
  --target-os=tizen --target-board=artik10 \
+ --external-shared-lib=capi-system-peripheral-io \
+ --compile-flag=-D__TIZEN__ \
+ --iotjs-include-module=dgram,i2c \
  --no-init-submodule --no-parallel-build --no-check-test
 
 %install

--- a/src/js/i2c.js
+++ b/src/js/i2c.js
@@ -66,7 +66,8 @@ function i2cBusOpen(configurable, callback) {
         if (!util.isString(configurable.device)) {
           throw new TypeError('Bad configurable - device: String');
         }
-      } else if (process.platform === 'nuttx') {
+      } else if (process.platform === 'nuttx' ||
+                 process.platform === 'tizen') {
         if (!util.isNumber(configurable.device)) {
           throw new TypeError('Bad configurable - device: Number');
         }

--- a/src/modules/iotjs_module_i2c.h
+++ b/src/modules/iotjs_module_i2c.h
@@ -21,10 +21,6 @@
 #include "iotjs_objectwrap.h"
 #include "iotjs_reqwrap.h"
 
-#if defined(__NUTTX__)
-#include <nuttx/i2c/i2c_master.h>
-#endif
-
 typedef enum {
   kI2cOpSetAddress,
   kI2cOpOpen,
@@ -40,13 +36,7 @@ typedef enum {
   kI2cErrWrite = -3,
 } I2cError;
 
-
 typedef struct {
-#if defined(__linux__) || defined(__APPLE__)
-  iotjs_string_t device;
-#elif defined(__NUTTX__)
-  int device;
-#endif
   char* buf_data;
   uint8_t buf_len;
   uint8_t byte;
@@ -57,19 +47,14 @@ typedef struct {
   I2cError error;
 } iotjs_i2c_reqdata_t;
 
-
+// Forward declaration of platform data. These are only used by platform code.
+// Generic I2C module never dereferences platform data pointer.
+typedef struct iotjs_i2c_platform_data_s iotjs_i2c_platform_data_t;
 // This I2c class provides interfaces for I2C operation.
 typedef struct {
   iotjs_jobjectwrap_t jobjectwrap;
-#if defined(__linux__)
-  int device_fd;
-  uint8_t addr;
-#elif defined(__NUTTX__)
-  struct i2c_master_s* i2c_master;
-  struct i2c_config_s config;
-#endif
+  iotjs_i2c_platform_data_t* platform_data;
 } IOTJS_VALIDATED_STRUCT(iotjs_i2c_t);
-
 
 typedef struct {
   iotjs_reqwrap_t reqwrap;
@@ -79,20 +64,15 @@ typedef struct {
 } IOTJS_VALIDATED_STRUCT(iotjs_i2c_reqwrap_t);
 
 
-iotjs_i2c_t* iotjs_i2c_create(const iotjs_jval_t* ji2c);
 iotjs_i2c_t* iotjs_i2c_instance_from_jval(const iotjs_jval_t* ji2c);
-
+iotjs_i2c_reqwrap_t* iotjs_i2c_reqwrap_from_request(uv_work_t* req);
 #define THIS iotjs_i2c_reqwrap_t* i2c_reqwrap
-iotjs_i2c_reqwrap_t* iotjs_i2c_reqwrap_create(const iotjs_jval_t* jcallback,
-                                              iotjs_i2c_t* i2c, I2cOp op);
 void iotjs_i2c_reqwrap_dispatched(THIS);
 uv_work_t* iotjs_i2c_reqwrap_req(THIS);
 const iotjs_jval_t* iotjs_i2c_reqwrap_jcallback(THIS);
-iotjs_i2c_reqwrap_t* iotjs_i2c_reqwrap_from_request(uv_work_t* req);
 iotjs_i2c_reqdata_t* iotjs_i2c_reqwrap_data(THIS);
 iotjs_i2c_t* iotjs_i2c_instance_from_reqwrap(THIS);
 #undef THIS
-
 
 void I2cSetAddress(iotjs_i2c_t* i2c, uint8_t address);
 void OpenWorker(uv_work_t* work_req);
@@ -100,5 +80,10 @@ void I2cClose(iotjs_i2c_t* i2c);
 void WriteWorker(uv_work_t* work_req);
 void ReadWorker(uv_work_t* work_req);
 
+// Platform-related functions; they are implemented
+// by platform code (i.e.: linux, nuttx, tizen).
+void i2c_create_platform_data(iotjs_jhandler_t* jhandler, iotjs_i2c_t* i2c,
+                              iotjs_i2c_platform_data_t** ppdata);
+void i2c_destroy_platform_data(iotjs_i2c_platform_data_t* platform_data);
 
 #endif /* IOTJS_MODULE_I2C_H */

--- a/src/platform/tizen/iotjs_module_i2c-tizen.c
+++ b/src/platform/tizen/iotjs_module_i2c-tizen.c
@@ -1,0 +1,120 @@
+/* Copyright 2017-present Samsung Electronics Co., Ltd. and other contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "modules/iotjs_module_i2c.h"
+#include <peripheral_io.h>
+#include <stdint.h>
+
+
+#define I2C_WORKER_INIT_TEMPLATE                                            \
+  iotjs_i2c_reqwrap_t* req_wrap = iotjs_i2c_reqwrap_from_request(work_req); \
+  iotjs_i2c_reqdata_t* req_data = iotjs_i2c_reqwrap_data(req_wrap);
+
+#define IOTJS_I2C_METHOD_HEADER(arg)              \
+  IOTJS_VALIDATED_STRUCT_METHOD(iotjs_i2c_t, arg) \
+  iotjs_i2c_platform_data_t* platform_data = _this->platform_data;
+
+typedef struct _peripheral_i2c_s* peripheral_i2c_h;
+
+struct iotjs_i2c_platform_data_s {
+  int bus;
+  int address;
+  peripheral_i2c_h handle;
+};
+
+void i2c_create_platform_data(iotjs_jhandler_t* jhandler, iotjs_i2c_t* i2c,
+                              iotjs_i2c_platform_data_t** ppdata) {
+  iotjs_i2c_platform_data_t* pdata = IOTJS_ALLOC(iotjs_i2c_platform_data_t);
+
+  // TODO: consider allowing one step init: new I2C.open(bus, address, callback)
+  // as opposed to current new I2C.open(bus, callback)
+  DJHANDLER_CHECK_ARGS(2, number, function);
+  pdata->bus = JHANDLER_GET_ARG(0, number);
+
+  pdata->address = -1;
+  pdata->handle = NULL;
+  // Note: address still unset, presumably will be
+  // done by callback invoked by AfterI2CWork.
+  *ppdata = pdata;
+}
+
+void i2c_destroy_platform_data(iotjs_i2c_platform_data_t* pdata) {
+  (void)pdata;
+}
+
+// The address can be set just once.
+void I2cSetAddress(iotjs_i2c_t* i2c, uint8_t address) {
+  IOTJS_I2C_METHOD_HEADER(i2c);
+
+  if (platform_data->address == -1) {
+    // Perform delayed construction.
+    platform_data->address = address;
+    if (peripheral_i2c_open(platform_data->bus, platform_data->address,
+                            &platform_data->handle) < 0) {
+      // TODO: report the error at this point
+    }
+  } else if (platform_data->address != address) {
+    // TODO: report error OR recreate the object with new slave address
+  }
+}
+
+void OpenWorker(uv_work_t* work_req) {
+  I2C_WORKER_INIT_TEMPLATE;
+  // Tizen does not allow to control the master, just individual devices.
+  // Because of this, construction is delayed until the address is known.
+  req_data->error = kI2cErrOk;
+}
+
+void I2cClose(iotjs_i2c_t* i2c) {
+  IOTJS_I2C_METHOD_HEADER(i2c);
+
+  if (platform_data->handle != NULL) {
+    peripheral_i2c_close(platform_data->handle);
+    platform_data->handle = NULL;
+  }
+}
+
+void WriteWorker(uv_work_t* work_req) {
+  I2C_WORKER_INIT_TEMPLATE;
+  iotjs_i2c_t* i2c = iotjs_i2c_instance_from_reqwrap(req_wrap);
+  IOTJS_I2C_METHOD_HEADER(i2c);
+
+  req_data->error = kI2cErrOk;
+  if (peripheral_i2c_write(platform_data->handle,
+                           (unsigned char*)req_data->buf_data,
+                           req_data->buf_len) < 0) {
+    req_data->error = kI2cErrWrite;
+  }
+
+  if (req_data->buf_data != NULL) {
+    iotjs_buffer_release(req_data->buf_data);
+  }
+}
+
+void ReadWorker(uv_work_t* work_req) {
+  I2C_WORKER_INIT_TEMPLATE;
+  iotjs_i2c_t* i2c = iotjs_i2c_instance_from_reqwrap(req_wrap);
+  IOTJS_I2C_METHOD_HEADER(i2c);
+
+  uint8_t len = req_data->buf_len;
+  req_data->buf_data = iotjs_buffer_allocate(len);
+
+  req_data->error = kI2cErrOk;
+  if (peripheral_i2c_read(platform_data->handle,
+                          (unsigned char*)req_data->buf_data,
+                          req_data->buf_len) < 0) {
+    req_data->error = kI2cErrWrite;
+  }
+}


### PR DESCRIPTION
I2C rework:
 - decouple platform data from generic I2C request handling
 - move platform data into platform component
 - add Tizen I2C port (Tizen API used, NOT linux device APIs)
