### PR TITLE
Skip the test_uart.js test file.

### DIFF
--- a/test/run_pass/test_uart_api.js
+++ b/test/run_pass/test_uart_api.js
@@ -1,0 +1,24 @@
+/* Copyright 2017-present Samsung Electronics Co., Ltd. and other contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+var assert = require('assert');
+var Uart = require('uart');
+var uart = new Uart();
+
+// ------ Test API existence
+assert.equal(typeof Uart, 'function',
+             'uart module does not export construction function');
+assert.equal(typeof uart.open, 'function',
+             'uart does not provide \'open\' function');

--- a/test/testsets.json
+++ b/test/testsets.json
@@ -92,7 +92,8 @@
     { "name": "test_timers_arguments.js" },
     { "name": "test_timers_error.js" },
     { "name": "test_timers_simple.js", "timeout": 10 },
-    { "name": "test_uart.js", "timeout": 10},
+    { "name": "test_uart.js", "timeout": 10, "skip": ["nuttx", "linux"], "reason": "need to setup test environment" },
+    { "name": "test_uart_api.js" },
     { "name": "test_util.js" }
   ],
   "run_pass/issue": [


### PR DESCRIPTION
This file fails on [nuttx-stm32f4 target](https://samsung.github.io/iotjs-test-results/). As you can see in the reason, the binary does not contain the `uart` module. But, when enabling `uart` module, the test is waiting for a test device (that will cause a timeout if the test device is not available).

Since test environment is not established everywhere, we should skip all similar test files.