### PR TITLE
Change socket error handling to fix #1078

### DIFF
--- a/test/run_pass/test_net_httpclient_error.js
+++ b/test/run_pass/test_net_httpclient_error.js
@@ -56,9 +56,8 @@ req.on('error', function() {
   server.close();
 });
 
-req.setTimeout(100, function(){
-  req.end();
-});
+req.end();
+
 
 process.on('exit', function() {
   assert.equal(recievedResponse, false);


### PR DESCRIPTION
Fixes #1078 

If net module's socket errors, the pending writes are never finished, and as such the socket 'close' event is never fired. Since HTTPClient depends on the close event to fire its on error event if the request could not be started, this error event was actually never fired.

This patch fixes the above by making net module's socket "pretend" to write everything in its stream buffer and calls end so that the socket can call close as expected by the HTTPClient class.

This same approach is also used currently in the HTTPS module to handle this very case. Please feel free to suggest alternative ways of fixing this if there is a better way.

The older test case seems to have intentionally waited before calling request.end in an attempt to bypass this issue. Removed that wait.

IoT.js-DCO-1.0-Signed-off-by: Akhil Kedia akhil.kedia@samsung.com