### PR TITLE
TizenRT: fix test_fs_rename.js cleanup

### DIFF
--- a/test/run_pass/test_fs_rename.js
+++ b/test/run_pass/test_fs_rename.js
@@ -42,10 +42,10 @@ fs.rename(file1, file2, function(err) {
                'Destination file not exist after renaming');
   fs.rename(file2, file1, function(err) {
     assert.equal(err, null, 'Renaming back error: ' + err);
+
+    // Cleanup after test
+    if (process.platform === 'tizenrt') {
+      fs.unlinkSync(file1);
+    }
   });
 });
-
-// Cleanup after test
-if (process.platform === 'tizenrt') {
-  fs.unlinkSync(file1);
-}


### PR DESCRIPTION
This test was failing because cleanup was performed before actual test happened.

IoT.js-DCO-1.0-Signed-off-by: Konrad Lipner k.lipner@samsung.com