### PR TITLE
Fix testrunner, remove variable `process._exiting`

### DIFF
--- a/src/js/iotjs.js
+++ b/src/js/iotjs.js
@@ -140,15 +140,11 @@ function _onUncaughtException(error) {
 
 
 process.exitCode = 0;
-process._exiting = false;
 process.emitExit = function(code) {
-  if (!process._exiting) {
-    process._exiting = true;
-    if (code || code == 0) {
-      process.exitCode = code;
-    }
-    process.emit('exit', process.exitCode || 0);
+  if (code || code == 0) {
+    process.exitCode = code;
   }
+  process.emit('exit', process.exitCode || 0);
 }
 
 

--- a/tools/test_runner.js
+++ b/tools/test_runner.js
@@ -19,8 +19,6 @@ var builtin_modules =
   Object.keys(process.native_sources).concat(Object.keys(process.binding));
 
 function Runner(driver) {
-  process._exiting = false;
-
   this.driver = driver;
   this.test = driver.currentTest();
   this.finished = false;


### PR DESCRIPTION
This legacy variable belongs to a testrun not to the testrunner, after
the last test its value has not been restored, therefore it prevent
to overwrite the default exit code.

IoT.js-DCO-1.0-Signed-off-by: Zsolt Borbély zsborbely.u-szeged@partner.samsung.com