### PR TITLE
UART refactored for Tizen IoT support

### DIFF
--- a/src/modules/iotjs_module_uart.h
+++ b/src/modules/iotjs_module_uart.h
@@ -58,25 +58,34 @@ typedef struct {
   iotjs_uart_t* uart_instance;
 } IOTJS_VALIDATED_STRUCT(iotjs_uart_reqwrap_t);
 
-#define THIS iotjs_uart_reqwrap_t* uart_reqwrap
+typedef struct {
+  iotjs_uart_reqwrap_t* req_wrap;
+  iotjs_uart_reqdata_t* req_data;
+  iotjs_uart_t* uart;
+} iotjs_worker_t;
+
+void iotjs_uart_worker_init(uv_work_t* work_req, iotjs_worker_t* worker_fields);
+
 
 iotjs_uart_reqwrap_t* iotjs_uart_reqwrap_from_request(uv_work_t* req);
-iotjs_uart_reqdata_t* iotjs_uart_reqwrap_data(THIS);
+iotjs_uart_reqdata_t* iotjs_uart_reqwrap_data(
+    iotjs_uart_reqwrap_t* uart_reqwrap);
 
-iotjs_uart_t* iotjs_uart_instance_from_reqwrap(THIS);
-
-#undef THIS
-
-
-#define UART_WORKER_INIT                                                      \
-  iotjs_uart_reqwrap_t* req_wrap = iotjs_uart_reqwrap_from_request(work_req); \
-  iotjs_uart_reqdata_t* req_data = iotjs_uart_reqwrap_data(req_wrap);         \
-  iotjs_uart_t* uart = iotjs_uart_instance_from_reqwrap(req_wrap);
-
+iotjs_uart_t* iotjs_uart_instance_from_reqwrap(
+    iotjs_uart_reqwrap_t* uart_reqwrap);
 
 void iotjs_uart_read_cb(uv_poll_t* req, int status, int events);
 
-void iotjs_uart_open_worker(uv_work_t* work_req);
-bool iotjs_uart_write(iotjs_uart_t* uart);
+
+// These two functions you can use to implement close functions
+// for file descriptor base libtuv data pulling
+bool iotjs_uart_libtuv_close(iotjs_uart_t* uart);
+void iotjs_uart_libtuv_close_worker(uv_work_t* work_req);
+
+// These four functions you should provide to port UART to new platform
+void iotjs_uart_platform_open_worker(uv_work_t* work_req);
+void iotjs_uart_platform_close_worker(uv_work_t* work_req);
+bool iotjs_uart_platform_close(iotjs_uart_t* uart);
+bool iotjs_uart_platform_write(iotjs_uart_t* uart);
 
 #endif /* IOTJS_MODULE_UART_H */

--- a/src/platform/nuttx/iotjs_module_uart-nuttx.c
+++ b/src/platform/nuttx/iotjs_module_uart-nuttx.c
@@ -19,15 +19,16 @@
 #include "modules/iotjs_module_uart.h"
 
 
-void iotjs_uart_open_worker(uv_work_t* work_req) {
-  UART_WORKER_INIT;
-  IOTJS_VALIDATED_STRUCT_METHOD(iotjs_uart_t, uart);
+void iotjs_uart_platform_open_worker(uv_work_t* work_req) {
+  iotjs_worker_t worker;
+  iotjs_uart_worker_init(work_req, &worker);
+  IOTJS_VALIDATED_STRUCT_METHOD(iotjs_uart_t, worker.uart);
 
   int fd = open(iotjs_string_data(&_this->device_path),
                 O_RDWR | O_NOCTTY | O_NDELAY);
 
   if (fd < 0) {
-    req_data->result = false;
+    worker.req_data->result = false;
     return;
   }
 
@@ -36,14 +37,14 @@ void iotjs_uart_open_worker(uv_work_t* work_req) {
 
   uv_loop_t* loop = iotjs_environment_loop(iotjs_environment_get());
   uv_poll_init(loop, poll_handle, fd);
-  poll_handle->data = uart;
+  poll_handle->data = worker.uart;
   uv_poll_start(poll_handle, UV_READABLE, iotjs_uart_read_cb);
 
-  req_data->result = true;
+  worker.req_data->result = true;
 }
 
 
-bool iotjs_uart_write(iotjs_uart_t* uart) {
+bool iotjs_uart_platform_write(iotjs_uart_t* uart) {
   IOTJS_VALIDATED_STRUCT_METHOD(iotjs_uart_t, uart);
   int bytesWritten = 0;
   unsigned offset = 0;
@@ -72,6 +73,16 @@ bool iotjs_uart_write(iotjs_uart_t* uart) {
   } while (_this->buf_len > offset);
 
   return true;
+}
+
+
+bool iotjs_uart_platform_close(iotjs_uart_t* uart) {
+  return iotjs_uart_libtuv_close(uart);
+}
+
+
+void iotjs_uart_platform_close_worker(uv_work_t* work_req) {
+  iotjs_uart_libtuv_close_worker(work_req);
 }
 
 

--- a/src/platform/tizenrt/iotjs_module_uart-tizenrt.c
+++ b/src/platform/tizenrt/iotjs_module_uart-tizenrt.c
@@ -18,15 +18,16 @@
 
 #include "modules/iotjs_module_uart.h"
 
-void iotjs_uart_open_worker(uv_work_t* work_req) {
-  UART_WORKER_INIT;
-  IOTJS_VALIDATED_STRUCT_METHOD(iotjs_uart_t, uart);
+void iotjs_uart_platform_open_worker(uv_work_t* work_req) {
+  iotjs_worker_t worker;
+  iotjs_uart_worker_init(work_req, &worker);
+  IOTJS_VALIDATED_STRUCT_METHOD(iotjs_uart_t, worker.uart);
 
   int fd = open(iotjs_string_data(&_this->device_path),
                 O_RDWR | O_NOCTTY | O_NDELAY);
 
   if (fd < 0) {
-    req_data->result = false;
+    worker.req_data->result = false;
     return;
   }
 
@@ -35,14 +36,14 @@ void iotjs_uart_open_worker(uv_work_t* work_req) {
 
   uv_loop_t* loop = iotjs_environment_loop(iotjs_environment_get());
   uv_poll_init(loop, poll_handle, fd);
-  poll_handle->data = uart;
+  poll_handle->data = worker.uart;
   uv_poll_start(poll_handle, UV_READABLE, iotjs_uart_read_cb);
 
-  req_data->result = true;
+  worker.req_data->result = true;
 }
 
 
-bool iotjs_uart_write(iotjs_uart_t* uart) {
+bool iotjs_uart_platform_write(iotjs_uart_t* uart) {
   IOTJS_VALIDATED_STRUCT_METHOD(iotjs_uart_t, uart);
   int bytesWritten = 0;
   unsigned offset = 0;
@@ -73,5 +74,14 @@ bool iotjs_uart_write(iotjs_uart_t* uart) {
   return true;
 }
 
+
+bool iotjs_uart_platform_close(iotjs_uart_t* uart) {
+  return iotjs_uart_libtuv_close(uart);
+}
+
+
+void iotjs_uart_platform_close_worker(uv_work_t* work_req) {
+  iotjs_uart_libtuv_close_worker(work_req);
+}
 
 #endif // __TIZENRT__


### PR DESCRIPTION
1. UART fails to support close operations, which are specific
   for platform.
2. Some UART macros obfuscate code and fail to provide a strict type safe
   compilation. They where replaced with functions and structures.
3. Code was tested at Linux. Not merge YET.

IoT.js-DCO-1.0-Signed-off-by: Piotr Marcinkiewicz p.marcinkiew@samsung.com