### PR TITLE
Add a log for elapsed time per each test

### DIFF
--- a/tools/check_test.js
+++ b/tools/check_test.js
@@ -22,6 +22,7 @@ var EventEmitter = require('events').EventEmitter;
 
 var root = 'test';
 var parent = '..';
+var watch = new util.Watch();
 
 function Driver() {
   this.results = {
@@ -33,6 +34,8 @@ function Driver() {
 
   this.emitter = new EventEmitter();
   this.emitter.addListener('nextTest', function(driver, status, test) {
+    var elapsedTime = ' (' + watch.delta().toFixed(2) + 's) ';
+
     if (driver.runner) {
       driver.runner.cleanup();
     }
@@ -40,17 +43,17 @@ function Driver() {
 
     if (status == 'pass') {
       driver.results.pass++;
-      driver.logger.message('PASS : ' + filename, status);
+      driver.logger.message('PASS : ' + filename + elapsedTime, status);
     } else if (status == 'fail') {
       driver.results.fail++;
-      driver.logger.message('FAIL : ' + filename, status);
+      driver.logger.message('FAIL : ' + filename + elapsedTime, status);
     } else if (status == 'skip') {
       driver.results.skip++;
       driver.logger.message('SKIP : ' + filename +
                    '   (reason : ' + test.reason + ")", status);
     } else if (status == 'timeout') {
       driver.results.timeout++;
-      driver.logger.message('TIMEOUT : ' + filename, status);
+      driver.logger.message('TIMEOUT : ' + filename + elapsedTime, status);
     }
     driver.fIdx++;
     driver.runNextTest();
@@ -258,5 +261,6 @@ process.exit = function(code) {
 
 var conf = driver.config();
 if (conf) {
+  watch.delta();
   driver.runNextTest();
 }

--- a/tools/common_js/util.js
+++ b/tools/common_js/util.js
@@ -25,5 +25,25 @@ function join() {
   return path;
 }
 
+function Watch() {
+  this.reset();
+}
+
+Watch.prototype.reset = function() {
+  this.startTime = 0;
+  this.elapsedTime = 0;
+}
+
+Watch.prototype.delta = function() {
+  if (this.startTime) {
+    this.elapsedTime = (Date.now() - this.startTime) / 1000;
+  }
+
+  this.startTime = Date.now();
+
+  return this.elapsedTime;
+}
+
 module.exports.absolutePath = absolutePath;
 module.exports.join = join;
+module.exports.Watch = Watch;


### PR DESCRIPTION
This is mainly for seeing the bottlenecks of the testing on Travis.

IoT.js-DCO-1.0-Signed-off-by: Daeyeon Jeong daeyeon.jeong@samsung.com