### PR TITLE
Free the jval of exitcode

### DIFF
--- a/src/iotjs_binding_helper.c
+++ b/src/iotjs_binding_helper.c
@@ -127,6 +127,7 @@ int iotjs_process_exitcode() {
   IOTJS_ASSERT(iotjs_jval_is_number(&jexitcode));
 
   const int exitcode = (int)iotjs_jval_as_number(&jexitcode);
+  iotjs_jval_destroy(&jexitcode);
 
   return exitcode;
 }


### PR DESCRIPTION
IoT.js-DCO-1.0-Signed-off-by: Zsolt Borbély zsborbely.u-szeged@partner.samsung.com