### PR TITLE
TizenRT fix net problems

### DIFF
--- a/src/js/net.js
+++ b/src/js/net.js
@@ -386,7 +386,7 @@ function onread(socket, nread, isEOF, buffer) {
     var err = new Error('read error: ' + nread);
     stream.Readable.prototype.error.call(socket, err);
   } else if (nread > 0) {
-    if (process.platform  != 'nuttx') {
+    if (process.platform  !== 'nuttx' && process.platform !== 'tizenrt') {
       stream.Readable.prototype.push.call(socket, buffer);
       return;
     }

--- a/src/js/stream_writable.js
+++ b/src/js/stream_writable.js
@@ -111,7 +111,7 @@ Writable.prototype.end = function(chunk, callback) {
   var state = this._writableState;
 
   // Because NuttX cannot poll 'EOF',so forcely raise EOF event.
-  if (process.platform == 'nuttx') {
+  if (process.platform === 'nuttx' || process.platform === 'tizenrt') {
     if (!state.ending) {
       if (util.isNullOrUndefined(chunk)) {
         chunk = '\\e\\n\\d';


### PR DESCRIPTION
Seems that like in Nuttx TizenRT can't poll EOF.
Solves test_net_connect.js and test_net_2.js fails.

Current status:
PASS : 82
FAIL : 1
TIMEOUT : 0
SKIP : 39

IoT.js-DCO-1.0-Signed-off-by: Konrad Lipner k.lipner@samsung.com