### PR TITLE
TizenRT: turn on dns test

### DIFF
--- a/test/testsets.json
+++ b/test/testsets.json
@@ -16,7 +16,7 @@
     { "name": "test_dgram_multicast_set_multicast_loop.js", "skip": ["all"], "reason": "need to setup test environment" },
     { "name": "test_dgram_setttl_client.js", "skip": ["all"], "reason": "need to setup test environment" },
     { "name": "test_dgram_setttl_server.js", "skip": ["all"], "reason": "need to setup test environment" },
-    { "name": "test_dns.js", "skip": ["tizenrt"], "reason": "On TizenRT this test hungs. Temporarly skipped" },
+    { "name": "test_dns.js" },
     { "name": "test_dns_lookup.js", "skip": ["nuttx", "tizenrt"], "reason": "not implemented for nuttx/TizenRT" },
     { "name": "test_events.js" },
     { "name": "test_events_assert_emit_error.js", "uncaught": true },


### PR DESCRIPTION
After recent net fixes(#1108) it works OK on TizenRT

IoT.js-DCO-1.0-Signed-off-by: Konrad Lipner k.lipner@samsung.com