### PR TITLE
Add storing json results for check_test.js

### DIFF
--- a/tools/test_runner.js
+++ b/tools/test_runner.js
@@ -150,6 +150,7 @@ Runner.prototype.run = function() {
       throw e;
     } else {
       console.error(e);
+      this.test.reason = '' + e;
       this.finish('fail');
     }
   } finally {


### PR DESCRIPTION
With this one it is easy to get results in JSON format and then do something about it.

example output
```
{"bin":{"text":0,"total":0,"data":0,"bss":0,"rodata":0},
"date":"2017-08-11T13:01:52.976Z","tests":[{"name":"test_adc.js","result":"skip","output":"unsupported module by iotjs build"},
{"name":"test_assert.js","result":"pass"},
{"name":"test_ble_advertisement.js","result":"skip","output":"unsupported module by iotjs build"},
{"name":"test_ble_setservices.js","result":"skip","output":"unsupported module by iotjs build"},
{"name":"test_ble_setservices_central.js","result":"skip","output":"unsupported module by iotjs build"},
{"name":"test_buffer_builtin.js","result":"pass"},
{"name":"test_buffer.js","result":"pass"},
{"name":"test_console.js","result":"pass"},
{"name":"test_dgram_1_server_1_client.js","result":"skip","output":"unsupported module by iotjs build"},
{"name":"test_dgram_1_server_n_clients.js","result":"skip","output":"unsupported module by iotjs build"},
{"name":"test_dgram_address.js","result":"skip","output":"unsupported module by iotjs build"},
{"name":"test_dgram_broadcast.js","result":"skip","output":"unsupported module by iotjs build"},
{"name":"test_dgram_multicast_membership.js","result":"skip","output":"unsupported module by iotjs build"},
{"name":"test_dgram_multicast_set_multicast_loop.js","result":"skip","output":"unsupported module by iotjs build"},
{"name":"test_dgram_setttl_client.js","result":"skip","output":"unsupported module by iotjs build"},
{"name":"test_dgram_setttl_server.js","result":"skip","output":"unsupported module by iotjs build"},
{"name":"test_dns.js","result":"pass"},
{"name":"test_dns_lookup.js","result":"skip","output":"not implemented for nuttx/TizenRT"},
{"name":"test_events.js","result":"pass"},
{"name":"test_events_assert_emit_error.js","result":"pass"},
{"name":"test_events_uncaught_error.js","result":"pass"},
{"name":"test_fs_exists.js","result":"pass"},
{"name":"test_fs_exists_sync.js","result":"pass"},
{"name":"test_fs_fstat.js","result":"skip","output":"not implemented for nuttx/TizenRT"},
{"name":"test_fs_fstat_sync.js","result":"skip","output":"not implemented for nuttx/TizenRT"},
{"name":"test_fs_mkdir_rmdir.js","result":"pass"},
{"name":"test_fs_open_close.js","result":"pass"},
{"name":"test_fs_readdir.js","result":"skip","output":"not implemented for nuttx/TizenRT"},
{"name":"test_fs_readfile.js","result":"pass"},
{"name":"test_fs_readfile_sync.js","result":"pass"},
{"name":"test_fs_rename.js","result":"pass"},
{"name":"test_fs_rename_sync.js","result":"pass"},
{"name":"test_fs_stat.js","result":"pass"},
{"name":"test_fs_write.js","result":"pass"},
{"name":"test_fs_writefile.js","result":"pass"},
{"name":"test_fs_writefile_sync.js","result":"pass"},
{"name":"test_fs_writefile_unlink.js","result":"pass"},
{"name":"test_fs_writefile_unlink_sync.js","result":"pass"},
{"name":"test_fs_event.js","result":"pass"},
{"name":"test_fs_open_read.js","result":"pass"},
{"name":"test_fs_open_read_sync_1.js","result":"pass"},
{"name":"test_fs_open_read_sync_2.js","result":"pass"},
{"name":"test_fs_open_read_sync_3.js","result":"pass"},
{"name":"test_gpio_input.js","result":"skip","output":"needs hardware"},
{"name":"test_gpio_output.js","result":"skip","output":"need user input"},
{"name":"test_https_get.js","result":"skip","output":"unsupported module by iotjs build"},
{"name":"test_https_post_status_codes.js","result":"skip","output":"unsupported module by iotjs build"},
{"name":"test_https_request_response.js","result":"skip","output":"unsupported module by iotjs build"},
{"name":"test_https_timeout.js","result":"skip","output":"unsupported module by iotjs build"},
{"name":"test_i2c.js","result":"skip","output":"unsupported module by iotjs build"},
{"name":"test_iotjs_promise.js","result":"skip","output":"es2015 is off by default"},
{"name":"test_module_cache.js","result":"skip","output":"not implemented for nuttx/TizenRT"},
{"name":"test_module_require.js","result":"skip","output":"not implemented for nuttx/TizenRT"},
{"name":"test_net_1.js","result":"pass"},
{"name":"test_net_2.js","result":"pass"},
{"name":"test_net_3.js","result":"skip","output":"requires too many socket descriptors and too large buffers"},
{"name":"test_net_4.js","result":"pass"},
{"name":"test_net_5.js","result":"pass"},
{"name":"test_net_6.js","result":"pass"},
{"name":"test_net_7.js","result":"skip","output":"requires too many socket descriptors"},
{"name":"test_net_8.js","result":"pass"},
{"name":"test_net_9.js","result":"pass"},
{"name":"test_net_10.js","result":"pass"},
{"name":"test_net_connect.js","result":"pass"},
{"name":"test_net_headers.js","result":"pass"},
{"name":"test_net_http_get.js","result":"pass"},
{"name":"test_net_http_response_twice.js","result":"pass"},
{"name":"test_net_http_request_response.js","result":"skip","output":"not implemented for nuttx/TizenRT"},
{"name":"test_net_http_status_codes.js","result":"skip","output":"not implemented for nuttx/TizenRT"},
{"name":"test_net_httpclient_error.js","result":"skip","output":"not implemented for nuttx/TizenRT"},
{"name":"test_net_httpclient_parse_error.js","result":"pass"},
{"name":"test_net_httpclient_timeout_1.js","result":"pass"},
{"name":"test_net_httpclient_timeout_2.js","result":"pass"},
{"name":"test_net_httpserver_timeout.js","result":"pass"},
{"name":"test_net_httpserver.js","result":"skip","output":"not implemented for nuttx/TizenRT"},
{"name":"test_process.js","result":"pass"},
{"name":"test_process_chdir.js","result":"pass"},
{"name":"test_process_cwd.js","result":"pass"},
{"name":"test_process_exit.js","result":"pass"},
{"name":"test_process_experimental_off.js","result":"pass"},
{"name":"test_process_experimental_on.js","result":"skip","output":"needed if testing stablity is set with experimental"},
{"name":"test_process_next_tick.js","result":"pass"},
{"name":"test_process_readsource.js","result":"pass"},
{"name":"test_process_uncaught_order.js","result":"pass"},
{"name":"test_process_uncaught_simple.js","result":"pass"},
{"name":"test_pwm.js","result":"skip","output":"need to setup test environment"},
{"name":"test_spi.js","result":"skip","output":"unsupported module by iotjs build"},
{"name":"test_stream.js","result":"pass"},
{"name":"test_stream_duplex.js","result":"pass"},
{"name":"test_timers_arguments.js","result":"pass"},
{"name":"test_timers_error.js","result":"pass"},
{"name":"test_timers_simple.js","result":"pass"},
{"name":"test_uart.js","result":"skip","output":"need to setup test environment"},
{"name":"test_util.js","result":"pass"},
{"name":"issue-133.js","result":"pass"},
{"name":"issue-137.js","result":"pass"},
{"name":"issue-198.js","result":"pass"},
{"name":"issue-223.js","result":"pass"},
{"name":"issue-266.js","result":"pass"},
{"name":"issue-323.js","result":"pass"},
{"name":"issue-816.js","result":"pass"},
{"name":"issue-1046.js","result":"pass"},
{"name":"test_assert_equal.js","result":"pass"},
{"name":"test_assert_fail.js","result":"pass"},
{"name":"test_assert_notequal.js","result":"pass"},
{"name":"test_events_emit_error.js","result":"pass"},
{"name":"test_fs_callbacks_called.js","result":"pass"},
{"name":"test_iotjs_runtime_error.js","result":"pass"},
{"name":"test_iotjs_syntax_error.js","result":"skip","output":"Core dump on TizenRT"},
{"name":"test_module_require_invalid_file.js","result":"pass"},
{"name":"test_process_exitcode_arg.js","result":"pass"},
{"name":"test_process_exitcode_var.js","result":"pass"},
{"name":"test_process_explicit_exit.js","result":"pass"},
{"name":"test_process_implicit_exit.js","result":"pass"},
{"name":"test-assert.js","result":"pass"},
{"name":"test-http-catch-uncaughtexception.js","result":"pass"},
{"name":"test-http-status-message.js","result":"fail"},
{"name":"test-http-write-head.js","result":"pass"},
{"name":"test-net-bind-twice.js","result":"skip","output":"cause TizeRT to hung and crash other tests"},
{"name":"test-net-end-without-connect.js","result":"pass"},
{"name":"test-net-keepalive.js","result":"pass"},
{"name":"test-timers-clear-null-does-not-throw-error.js","result":"pass"}],"submodules":[]}

```

IoT.js-DCO-1.0-Signed-off-by: Konrad Lipner k.lipner@samsung.com