### PR TITLE
Restore process._exiting

### DIFF
--- a/src/js/iotjs.js
+++ b/src/js/iotjs.js
@@ -140,11 +140,15 @@ function _onUncaughtException(error) {
 
 
 process.exitCode = 0;
+process._exiting = false;
 process.emitExit = function(code) {
-  if (code || code == 0) {
-    process.exitCode = code;
+  if (!process._exiting) {
+    process._exiting = true;
+    if (code || code == 0) {
+      process.exitCode = code;
+    }
+    process.emit('exit', process.exitCode || 0);
   }
-  process.emit('exit', process.exitCode || 0);
 }
 
 

--- a/tools/test_runner.js
+++ b/tools/test_runner.js
@@ -164,6 +164,7 @@ Runner.prototype.finish = function(status) {
     return;
 
   this.finished = true;
+  process._exiting = false;
 
   this.driver.emitter.emit('nextTest', this.driver, status, this.test);
 };


### PR DESCRIPTION
08f7833 works well with `check_test.js` because it has a different implementation
of `process.exit()`, but in case of manual runs when
an uncaughtException occurs fall into a loop.

IoT.js-DCO-1.0-Signed-off-by: Zsolt Borbély zsborbely.u-szeged@partner.samsung.com