### PR TITLE
Tizen: Fix the fusing-script url

### DIFF
--- a/docs/build/Build-for-RPi3-Tizen.md
+++ b/docs/build/Build-for-RPi3-Tizen.md
@@ -39,7 +39,7 @@ $ sudo apt-get install pv
 
 #### Downloading fusing-script and firmwares
 ``` bash
-  $ wget https://git.tizen.org/cgit/platform/kernel/linux-rpi3/plain/scripts/sd_fusing_rpi3.sh?h=tizen --output-document=sd_fusing_rpi3.sh
+  $ wget https://git.tizen.org/cgit/platform/kernel/linux-rpi3/plain/scripts/sd_fusing_rpi3.sh?h=submit/tizen/20170725.223437 --output-document=sd_fusing_rpi3.sh
   $ chmod 755 sd_fusing_rpi3.sh
   $ wget https://github.com/RPi-Distro/firmware-nonfree/raw/master/brcm80211/brcm/brcmfmac43430-sdio.bin
   $ wget https://github.com/RPi-Distro/firmware-nonfree/raw/master/brcm80211/brcm/brcmfmac43430-sdio.txt


### PR DESCRIPTION
The url of fusing-script has been updated. Previous url is not valid anymore.
IoT.js-DCO-1.0-Signed-off-by: Sumin Lim sumin.lim@samsung.com