### PR TITLE
Fix to remove dots from module path before caching.

### DIFF
--- a/src/js/module.js
+++ b/src/js/module.js
@@ -33,25 +33,27 @@ iotjs_module_t.wrap = Native.wrap;
 
 
 var cwd;
-try { cwd = process.cwd(); } catch (e) { }
+try {
+  cwd = process.cwd();
+} catch (e) { }
 
-var moduledirs = [""]
-if(cwd){
+var moduledirs = [""];
+if (cwd) {
   moduledirs.push(cwd + "/");
   moduledirs.push(cwd + "/iotjs_modules/");
 }
-if(process.env.HOME){
+if (process.env.HOME) {
   moduledirs.push(process.env.HOME + "/iotjs_modules/");
 }
-if(process.env.IOTJS_PATH){
-  moduledirs.push(process.env.IOTJS_PATH + "/iotjs_modules/")
+if (process.env.IOTJS_PATH) {
+  moduledirs.push(process.env.IOTJS_PATH + "/iotjs_modules/");
 }
 
 
 iotjs_module_t.resolveDirectories = function(id, parent) {
   var dirs = moduledirs;
-  if(parent) {
-    if(!parent.dirs){
+  if (parent) {
+    if (!parent.dirs) {
       parent.dirs = [];
     }
     dirs = parent.dirs.concat(dirs);
@@ -61,8 +63,7 @@ iotjs_module_t.resolveDirectories = function(id, parent) {
 
 
 iotjs_module_t.resolveFilepath = function(id, directories) {
-
-  for(var i = 0; i<directories.length ; i++) {
+  for (var i = 0; i < directories.length; i++) {
     var dir = directories[i];
     var modulePath = dir + id;
 
@@ -76,30 +77,30 @@ iotjs_module_t.resolveFilepath = function(id, directories) {
     // 1. 'id'
     var filepath = iotjs_module_t.tryPath(modulePath);
 
-    if(filepath){
+    if (filepath) {
       return filepath;
     }
 
     // 2. 'id.js'
     filepath = iotjs_module_t.tryPath(modulePath + '.js');
 
-    if(filepath){
+    if (filepath) {
       return filepath;
     }
 
     // 3. package path id/
     var jsonpath = modulePath + "/package.json";
     filepath = iotjs_module_t.tryPath(jsonpath);
-    if(filepath){
+    if (filepath) {
       var pkgSrc = process.readSource(jsonpath);
       var pkgMainFile = JSON.parse(pkgSrc).main;
       filepath = iotjs_module_t.tryPath(modulePath + "/" + pkgMainFile);
-      if(filepath){
+      if (filepath) {
         return filepath;
       }
       // index.js
       filepath = iotjs_module_t.tryPath(modulePath + "/" + "index.js");
-      if(filepath){
+      if (filepath) {
         return filepath;
       }
     }
@@ -117,28 +118,56 @@ iotjs_module_t.resolveModPath = function(id, parent) {
 
   var filepath = iotjs_module_t.resolveFilepath(id, directories);
 
-  if(filepath){
-    return filepath;
+  if (filepath) {
+    return iotjs_module_t.normalizePath(filepath);
   }
 
   return false;
 };
 
 
+iotjs_module_t.normalizePath = function(path) {
+  var beginning = '';
+  if (path.indexOf('/') === 0) {
+    beginning = '/';
+  }
+
+  var input = path.split('/');
+  var output = [];
+  while (input.length > 0) {
+    if (input[0] === '.' || (input[0] === '' && input.length > 1)) {
+      input.shift();
+      continue;
+    }
+    if (input[0] === '..') {
+      input.shift();
+      if (output.length > 0 && output[output.length - 1] !== '..') {
+        output.pop();
+      } else {
+        throw new Error('Requested path is below root: ' + path);
+      }
+      continue;
+    }
+    output.push(input.shift());
+  }
+  return beginning + output.join('/');
+};
+
+
 iotjs_module_t.tryPath = function(path) {
   try {
     var stats = fs.statSync(path);
-    if(stats && !stats.isDirectory()) {
+    if (stats && !stats.isDirectory()) {
       return path;
     }
-  } catch (ex) {}
+  } catch (ex) { }
 
   return false;
 };
 
 
 iotjs_module_t.load = function(id, parent, isMain) {
-  if(process.native_sources[id]){
+  if (process.native_sources[id]) {
     return Native.require(id);
   }
   var module = new iotjs_module_t(id, parent);
@@ -171,9 +200,9 @@ iotjs_module_t.prototype.compile = function() {
 };
 
 
-iotjs_module_t.runMain = function(){
+iotjs_module_t.runMain = function() {
   iotjs_module_t.load(process.argv[1], null, true);
-  while(process._onNextTick());
+  while (process._onNextTick());
 };
 
 iotjs_module_t.prototype.require = function(id) {

--- a/test/run_fail/test_module_require_path_below_root.js
+++ b/test/run_fail/test_module_require_path_below_root.js
@@ -1,0 +1,28 @@
+/* Copyright 2015-present Samsung Electronics Co., Ltd. and other contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+require('../../../../../../../../../../../../../../../../../../../../../../' +
+  '../../../../../../../../../../../../../../../../../../../../../../../../' +
+  '../../../../../../../../../../../../../../../../../../../../../../../../' +
+  '../../../../../../../../../../../../../../../../../../../../../../../../' +
+  '../../../../../../../../../../../../../../../../../../../../../../../../' +
+  '../../../../../../../../../../../../../../../../../../../../../../../../' +
+  '../../../../../../../../../../../../../../../../../../../../../../../../' +
+  '../../../../../../../../../../../../../../../../../../../../../../../../' +
+  '../../../../../../../../../../../../../../../../../../../../../../../../' +
+  '../../../../../../../../../../../../../../../../../../../../../../../../' +
+  '../../../../../../../../../../../../../../../../../../../../../../../../' +
+  '../../../../../../../../../../../../file path below root');

--- a/test/run_pass/test_module_cache.js
+++ b/test/run_pass/test_module_cache.js
@@ -15,8 +15,18 @@
 
 var assert = require('assert');
 
-var module_cache = require('run_pass/require1/module_cache.js');
-module_cache.i = 100;
-module_cache = require('run_pass/require1/module_cache.js');
+var dir = process.cwd() + '/run_pass/require1/';
+var dirDoubleDot = dir + '../require1/';
+var dirDot = dir + './';
 
-assert.equal(module_cache.i, 100);
+var moduleCache = require(dir + 'module_cache.js');
+moduleCache.i = 100;
+
+moduleCache = require(dir + 'module_cache.js');
+assert.equal(moduleCache.i, 100);
+
+moduleCache = require(dirDoubleDot + 'module_cache.js');
+assert.equal(moduleCache.i, 100);
+
+moduleCache = require(dirDot + 'module_cache.js');
+assert.equal(moduleCache.i, 100);

--- a/test/testsets.json
+++ b/test/testsets.json
@@ -115,6 +115,7 @@
     { "name": "test_iotjs_runtime_error.js", "expected-failure": true },
     { "name": "test_iotjs_syntax_error.js", "expected-failure": true, "skip": ["tizenrt"], "reason": "Core dump on TizenRT" },
     { "name": "test_module_require_invalid_file.js", "expected-failure": true },
+    { "name": "test_module_require_path_below_root.js", "expected-failure": true },
     { "name": "test_process_exitcode_arg.js", "expected-failure": true },
     { "name": "test_process_exitcode_var.js", "expected-failure": true },
     { "name": "test_process_explicit_exit.js", "expected-failure": true },


### PR DESCRIPTION
Previously, several paths pointing to the same module could be cached
by module.js as it did not realize the absolute paths for them were the same.

This resulted in Significantly higher memory usage as the same module was
loaded repeatedly if 'required' by files in different folders.

IoT.js-DCO-1.0-Signed-off-by: Akhil Kedia akhil.kedia@samsung.com