### PR TITLE
Enable ADC/DGRAM/GPIO/PWM/UART modules for Tizen RT

### DIFF
--- a/build.config
+++ b/build.config
@@ -111,7 +111,7 @@
       "nuttx": ["adc", "dgram", "gpio", "i2c", "pwm", "stm32f4dis", "uart"],
       "darwin": [],
       "tizen": ["adc", "ble", "dgram", "gpio", "i2c", "pwm", "spi", "uart", "https"],
-      "tizenrt": []
+      "tizenrt": ["adc", "dgram", "gpio", "pwm", "uart"]
     }
   }
 }


### PR DESCRIPTION
IoT.js-DCO-1.0-Signed-off-by: Youngil Choi duddlf.choi@samsung.com