### PR TITLE
TizenRT: remove Nuttx EOF workaround for TizenRT

### DIFF
--- a/src/js/net.js
+++ b/src/js/net.js
@@ -400,7 +400,7 @@ function onread(socket, nread, isEOF, buffer) {
     var err = new Error('read error: ' + nread);
     stream.Readable.prototype.error.call(socket, err);
   } else if (nread > 0) {
-    if (process.platform  !== 'nuttx' && process.platform !== 'tizenrt') {
+    if (process.platform  !== 'nuttx') {
       stream.Readable.prototype.push.call(socket, buffer);
       return;
     }

--- a/src/js/stream_writable.js
+++ b/src/js/stream_writable.js
@@ -111,7 +111,7 @@ Writable.prototype.end = function(chunk, callback) {
   var state = this._writableState;
 
   // Because NuttX cannot poll 'EOF',so forcely raise EOF event.
-  if (process.platform === 'nuttx' || process.platform === 'tizenrt') {
+  if (process.platform === 'nuttx') {
     if (!state.ending) {
       if (util.isNullOrUndefined(chunk)) {
         chunk = '\\e\\n\\d';


### PR DESCRIPTION
With TizenRT/lwip fix described here:
https://github.com/Samsung/TizenRT/issues/425
results are:
PASS : 84
FAIL : 0
TIMEOUT : 0
SKIP : 38

IoT.js-DCO-1.0-Signed-off-by: Konrad Lipner k.lipner@samsung.com