### PR TITLE
tizen: Fix tagname to use project release- prefix

### DIFF
--- a/.gbs.conf
+++ b/.gbs.conf
@@ -1,4 +1,4 @@
 [general]
-upstream_branch = ${upstreamversion}
-upstream_tag = ${upstreamversion}
+upstream_branch = master
+upstream_tag = release_${upstreamversion}
 packaging_dir = config/tizen/packaging


### PR DESCRIPTION
Currently Git tag is not matching version (release_1.0),
so GBS must align to this scheme.

This is needed for "gbs export" to generate tarballs
from upstream git tag (with patches serie on top of it if present).

If tag is not in master branch, then a native tarball (without patches)
will be exported and built.

IoT.js-DCO-1.0-Signed-off-by: Philippe Coval philippe.coval@osg.samsung.com