### PR TITLE
Arrange the build config clearer

### DIFF
--- a/build.config
+++ b/build.config
@@ -25,93 +25,9 @@
     "no-check-test": false,
     "no-parallel-build": false,
     "sysroot": "",
-    "no-snapshot": false
-  },
-  "compile_flags": {
-    "os": {
-      "linux": ["-D__LINUX__",
-                "-fno-builtin"],
-      "darwin": ["-D__DARWIN__",
-                 "-fno-builtin"],
-      "nuttx": ["-D__NUTTX__",
-                "-Os",
-                "-fno-strict-aliasing",
-                "-fno-strength-reduce",
-                "-fomit-frame-pointer"],
-      "tizen": ["-D__LINUX__",
-                "-fno-builtin"],
-      "tizenrt": ["-D__TIZENRT__",
-                "-Os",
-                "-fno-strict-aliasing",
-                "-fno-strength-reduce",
-                "-fomit-frame-pointer"]
-  },
-    "arch": {
-      "i686": ["-D__i686__",
-               "-D__x86__",
-               "-D__I686__",
-               "-D__X86__",
-               "-march=i686",
-               "-m32"],
-      "x86_64": ["-D__x86_64__",
-                 "-D__X86_64__"],
-      "arm": ["-D__ARM__",
-              "-D__arm__",
-              "-mthumb",
-              "-fno-short-enums",
-              "-mlittle-endian"]
-    },
-    "board": {
-      "stm32f4dis": ["-mcpu=cortex-m4",
-                     "-march=armv7e-m",
-                     "-mfpu=fpv4-sp-d16",
-                     "-mfloat-abi=hard",
-                     "-DTARGET_BOARD=STM32F4DIS"],
-      "rpi2": ["-mcpu=cortex-a7",
-               "-mfpu=neon-vfpv4",
-               "-DTARGET_BOARD=RP2"],
-      "artik05x": ["-mcpu=cortex-r4",
-                   "-mfpu=vfp3",
-                   "-DTARGET_BOARD=artik05x"],
-      "artik10": ["-mcpu=cortex-a7",
-                  "-mfpu=neon-vfpv4",
-                  "-mfloat-abi=softfp",
-                  "-DTARGET_BOARD=artik10"]
-    },
-    "buildtype": {
-      "release": [],
-      "debug": ["-DDEBUG",
-                "-DENABLE_DEBUG_LOG"]
-    }
-  },
-  "link_flags": {
-    "os": {
-      "linux": ["-pthread"],
-      "darwin": [],
-      "nuttx": [],
-      "tizen": ["-pthread"],
-      "tizenrt": []
-    }
-  },
-  "shared_libs": {
-    "os": {
-      "linux": ["m", "rt"],
-      "darwin": [],
-      "nuttx": [],
-      "tizen": ["m", "rt", "curl"],
-      "tizenrt": []
-    }
-  },
-  "module": {
-    "always": ["buffer", "console", "events", "fs", "module", "timers"],
-    "include": ["assert", "dns", "http", "net", "stream", "testdriver"],
-    "exclude": {
-      "all": [],
-      "linux": ["adc", "ble", "dgram", "gpio", "i2c", "pwm", "spi", "uart"],
-      "nuttx": ["adc", "dgram", "gpio", "i2c", "pwm", "stm32f4dis", "uart"],
-      "darwin": [],
-      "tizen": ["adc", "ble", "dgram", "gpio", "i2c", "pwm", "spi", "uart", "https"],
-      "tizenrt": ["adc", "dgram", "gpio", "pwm", "uart"]
-    }
+    "no-snapshot": false,
+    "iotjs-minimal-profile": false,
+    "iotjs-include-module": [],
+    "iotjs-exclude-module": []
   }
 }

--- a/build.module
+++ b/build.module
@@ -1,0 +1,23 @@
+{
+  "module": {
+    "supported": {
+      "core": ["buffer", "console", "events", "fs", "module", "timers"],
+      "basic": ["assert", "dns", "http", "net", "stream", "testdriver"],
+      "extended": {
+        "linux": ["adc", "ble", "dgram", "gpio", "i2c", "pwm", "spi", "uart"],
+        "nuttx": ["adc", "dgram", "gpio", "i2c", "pwm", "stm32f4dis", "uart"],
+        "darwin": [],
+        "tizen": ["adc", "ble", "dgram", "gpio", "i2c", "pwm", "spi", "uart", "https"],
+        "tizenrt": ["adc", "dgram", "gpio", "pwm", "uart"]
+      }
+    },
+    "disabled": {
+      "board": {
+        "rp2": ["adc"],
+        "stm32f4dis": ["ble"],
+        "artik05x": ["ble"],
+        "artik10": []
+      }
+    }
+  }
+}

--- a/build.target
+++ b/build.target
@@ -1,0 +1,77 @@
+{
+  "compile_flags": {
+    "os": {
+      "linux": ["-D__LINUX__",
+                "-fno-builtin"],
+      "darwin": ["-D__DARWIN__",
+                 "-fno-builtin"],
+      "nuttx": ["-D__NUTTX__",
+                "-Os",
+                "-fno-strict-aliasing",
+                "-fno-strength-reduce",
+                "-fomit-frame-pointer"],
+      "tizen": ["-D__LINUX__",
+                "-fno-builtin"],
+      "tizenrt": ["-D__TIZENRT__",
+                "-Os",
+                "-fno-strict-aliasing",
+                "-fno-strength-reduce",
+                "-fomit-frame-pointer"]
+  },
+    "arch": {
+      "i686": ["-D__i686__",
+               "-D__x86__",
+               "-D__I686__",
+               "-D__X86__",
+               "-march=i686",
+               "-m32"],
+      "x86_64": ["-D__x86_64__",
+                 "-D__X86_64__"],
+      "arm": ["-D__ARM__",
+              "-D__arm__",
+              "-mthumb",
+              "-fno-short-enums",
+              "-mlittle-endian"]
+    },
+    "board": {
+      "stm32f4dis": ["-mcpu=cortex-m4",
+                     "-march=armv7e-m",
+                     "-mfpu=fpv4-sp-d16",
+                     "-mfloat-abi=hard",
+                     "-DTARGET_BOARD=STM32F4DIS"],
+      "rpi2": ["-mcpu=cortex-a7",
+               "-mfpu=neon-vfpv4",
+               "-DTARGET_BOARD=RP2"],
+      "artik05x": ["-mcpu=cortex-r4",
+                   "-mfpu=vfp3",
+                   "-DTARGET_BOARD=artik05x"],
+      "artik10": ["-mcpu=cortex-a7",
+                  "-mfpu=neon-vfpv4",
+                  "-mfloat-abi=softfp",
+                  "-DTARGET_BOARD=artik10"]
+    },
+    "buildtype": {
+      "release": [],
+      "debug": ["-DDEBUG",
+                "-DENABLE_DEBUG_LOG"]
+    }
+  },
+  "link_flags": {
+    "os": {
+      "linux": ["-pthread"],
+      "darwin": [],
+      "nuttx": [],
+      "tizen": ["-pthread"],
+      "tizenrt": []
+    }
+  },
+  "shared_libs": {
+    "os": {
+      "linux": ["m", "rt"],
+      "darwin": [],
+      "nuttx": [],
+      "tizen": ["m", "rt", "curl"],
+      "tizenrt": []
+    }
+  }
+}

--- a/tools/common_py/path.py
+++ b/tools/common_py/path.py
@@ -57,3 +57,5 @@ CHECKTEST_PATH = fs.join(TOOLS_ROOT, 'check_test.js')
 
 # Build configuration file path.
 BUILD_CONFIG_PATH = fs.join(PROJECT_ROOT, 'build.config')
+BUILD_MODULE_CONFIG_PATH = fs.join(PROJECT_ROOT, 'build.module')
+BUILD_TARGET_CONFIG_PATH = fs.join(PROJECT_ROOT, 'build.target')


### PR DESCRIPTION
I divided `build.config` into three files below to resolve #750.

a) `build.module` describes the information about all the supported modules. It's used for travis build in precommit.py.
b) `build.target` describes various configurations which seems rarely be changed. Moving them to cmake and removing the file could be considered as a future task.
c) `build.config` describes user's configurable options. You can add modules you want to build with the include / exclude option. It's used for build.py.

There seems still things left to improve in the scripts. I wrote this as the first step to resolve the confusing option related to `exclude-module`. Plus, the options users rarely care about were parted. Lastly, with `build.module`, we can see all the supported features with dependencies at a glance.

IoT.js-DCO-1.0-Signed-off-by: Daeyeon Jeong daeyeon.jeong@samsung.com