### PR TITLE
[Enhancement] [HTTPS] Added support for option.rejectUnauthorized in HTTPS.request

### DIFF
--- a/docs/api/IoT.js-API-HTTPS.md
+++ b/docs/api/IoT.js-API-HTTPS.md
@@ -14,16 +14,17 @@ IoT.js provides HTTPS to support HTTPS clients enabling users to send HTTPS requ
 
 ### https.request(options[, callback])
 * `options` {Object}
-  * `host` {string} A domain name or IP address of the server to issue the request to. **Deafult:** 'localhost'.
+  * `host` {string} A domain name or IP address of the server to issue the request to. **Default:** 'localhost'.
   * `hostname` {string} Alias for host.
-  * `port` {number} Port of remote server. **Deafult:** 80.
-  * `method` {string} A string specifying the HTTPS request method. **Deafult:** 'GET'.
-  * `path` {string} Request path. **Deafult:** '/'. Should include query string if any. E.G. '/index.html?page=12'. An exception is thrown when the request path contains illegal characters. Currently, only spaces are rejected but that may change in the future.
+  * `port` {number} Port of remote server. **Default:** 80.
+  * `method` {string} A string specifying the HTTPS request method. **Default:** 'GET'.
+  * `path` {string} Request path. **Default:** '/'. Should include query string if any. E.G. '/index.html?page=12'. An exception is thrown when the request path contains illegal characters. Currently, only spaces are rejected but that may change in the future.
   * `headers` {Object} An object containing request headers.
   * `auth` {string} Optional Basic Authentication in the form `username:password`. Used to compute HTTPS Basic Authentication header.
   * `ca` {string} Optional file path to CA certificate. Allows to override system trusted CA certificates.
   * `cert` {string} Optional file path to client authentication certificate in PEM format.
   * `key` {string} Optional file path to private keys for client cert in PEM format.
+  * `rejectUnauthorized` {boolean} Optional Specify whether to verify the Server's certificate against CA certificates. WARNING - Making this `false` may be a security risk. **Default:** `true`
 * `callback` {Function}
   * `response` {https.IncomingMessage}
 * Returns: {https.ClientRequest}
@@ -47,16 +48,17 @@ Note that in the example `req.end()` was called. With `https.request()` one must
 
 ### https.get(options[, callback])
 * `options` {Object}
-  * `host` {string} A domain name or IP address of the server to issue the request to. **Deafult:** 'localhost'.
+  * `host` {string} A domain name or IP address of the server to issue the request to. **Default:** 'localhost'.
   * `hostname` {string} Alias for host.
-  * `port` {number} Port of remote server. **Deafult:** 80.
-  * `method` {string} A string specifying the HTTPS request method. **Deafult:** 'GET'.
-  * `path` {string} Request path. **Deafult:** '/'. Should include query string if any. E.G. '/index.html?page=12'. An exception is thrown when the request path contains illegal characters. Currently, only spaces are rejected but that may change in the future.
+  * `port` {number} Port of remote server. **Default:** 80.
+  * `method` {string} A string specifying the HTTPS request method. **Default:** 'GET'.
+  * `path` {string} Request path. **Default:** '/'. Should include query string if any. E.G. '/index.html?page=12'. An exception is thrown when the request path contains illegal characters. Currently, only spaces are rejected but that may change in the future.
   * `headers` {Object} An object containing request headers.
   * `auth` {string} Optional Basic Authentication in the form `username:password`. Used to compute HTTPS Basic Authentication header.
   * `ca` {string} Optional file path to CA certificate. Allows to override system trusted CA certificates.
   * `cert` {string} Optional file path to client authentication certificate in PEM format.
   * `key` {string} Optional file path to private keys for client cert in PEM format.
+  * `rejectUnauthorized` {boolean} Optional Specify whether to verify the Server's certificate against CA certificates. WARNING - Making this `false` may be a security risk. **Default:** `true`
 * `callback` {Function}
   * `response` {https.IncomingMessage}
 * Returns: {https.ClientRequest}

--- a/src/iotjs_magic_strings.h
+++ b/src/iotjs_magic_strings.h
@@ -43,6 +43,7 @@
 #define IOTJS_MAGIC_STRING__BUILTIN "_builtin"
 #define IOTJS_MAGIC_STRING_BUS "bus"
 #define IOTJS_MAGIC_STRING_BYTELENGTH "byteLength"
+#define IOTJS_MAGIC_STRING_REJECTUNAUTHORIZED "rejectUnauthorized"
 #define IOTJS_MAGIC_STRING_BYTEPARSED "byteParsed"
 #define IOTJS_MAGIC_STRING_CA "ca"
 #define IOTJS_MAGIC_STRING_CERT "cert"

--- a/src/js/https_client.js
+++ b/src/js/https_client.js
@@ -38,6 +38,12 @@ function ClientRequest(options, cb) {
   this.cert = options.cert || '';
   this.key = options.key || '';
 
+  if (options.rejectUnauthorized == null) {
+    this.rejectUnauthorized = true;
+  } else {
+    this.rejectUnauthorized = options.rejectUnauthorized;
+  }
+
   var isMethodGood = false;
   for (var key in methods) {
     if (methods.hasOwnProperty(key)) {

--- a/src/modules/iotjs_module_https.h
+++ b/src/modules/iotjs_module_https.h
@@ -50,6 +50,7 @@ typedef struct {
   const char* ca;
   const char* cert;
   const char* key;
+  bool reject_unauthorized;
   // Content-Length for Post and Put
   long content_length;
 
@@ -86,7 +87,9 @@ typedef struct {
 
 iotjs_https_t* iotjs_https_create(const char* URL, const char* method,
                                   const char* ca, const char* cert,
-                                  const char* key, const iotjs_jval_t* jthis);
+                                  const char* key,
+                                  const bool reject_unauthorized,
+                                  const iotjs_jval_t* jthis);
 
 #define THIS iotjs_https_t* https_data
 // Some utility functions


### PR DESCRIPTION
**What this patch adds -**  This patch implements the option rejectUnauthorize from Node's HTTPS.request  - [https://nodejs.org/api/tls.html#tls_tls_connect_options_callback](https://nodejs.org/api/tls.html#tls_tls_connect_options_callback)

**Why -** This option is by default true, meaning certificates are verified and checked to 
make sure that the connection is to a correct server.

Setting this option to false will let an HTTPS connection proceed even if server's
certificate is incorrect or cannot be verified. Sometimes it may be desirable to let the
connection proceed even if the certificate is invalid, and this option allows that.

**Test Cases -** While this option was tested manually against a Node server, unlike
other tests, I was unable to find a web service which offered incorrect
certs. Hence no test case was added for this enhancement.

IoT.js-DCO-1.0-Signed-off-by: Akhil Kedia akhil.kedia@samsung.com