### PR TITLE
jerry: Propagate ENABLE_STATIC_LINK cmake flags

### DIFF
--- a/cmake/jerry.cmake
+++ b/cmake/jerry.cmake
@@ -29,6 +29,7 @@ ExternalProject_Add(hostjerry
     -DJERRY_CMDLINE_MINIMAL=OFF
     -DFEATURE_SNAPSHOT_SAVE=${ENABLE_SNAPSHOT}
     -DFEATURE_PROFILE=es5.1
+    -DENABLE_STATIC_LINK=${ENABLE_STATIC_LINK}
 )
 add_executable(jerry IMPORTED)
 add_dependencies(jerry hostjerry)


### PR DESCRIPTION
This can be helful for packagers,
who prefer to turn this variable off to use use system's libc.

Currently it will only be used for iotjs code,
but kept static in jerryscript module, this is not wanted.

IoT.js-DCO-1.0-Signed-off-by: Philippe Coval philippe.coval@osg.samsung.com