### PR TITLE
Fix config and app copying for tizenrt

### DIFF
--- a/tools/precommit.py
+++ b/tools/precommit.py
@@ -115,18 +115,17 @@ def setup_tizen_root(tizen_root):
 
 def copy_tiznert_stuff(tizenrt_root, iotjs_dir):
     tizenrt_iotjsapp_dir = fs.join(tizenrt_root, 'apps/system/iotjs')
-    if not fs.exists(tizenrt_iotjsapp_dir):
-        iotjs_tizenrt_appdir = fs.join(iotjs_dir,
-                                       'config/tizenrt/artik05x/app')
-        ex.check_run_cmd('cp',
-                         ['-r', iotjs_tizenrt_appdir, tizenrt_iotjsapp_dir])
-
     tizenrt_config_dir = fs.join(tizenrt_root, 'build/configs/artik053/iotjs')
-    if not fs.exists(tizenrt_config_dir):
-        iotjs_config_dir = \
-            fs.join(iotjs_dir, 'config/tizenrt/artik05x/configs')
-        ex.check_run_cmd('cp',
-                         ['-r', iotjs_config_dir, tizenrt_config_dir])
+    iotjs_tizenrt_appdir = fs.join(iotjs_dir,
+                                  'config/tizenrt/artik05x/app')
+    iotjs_config_dir = \
+        fs.join(iotjs_dir, 'config/tizenrt/artik05x/configs')
+
+    ex.check_run_cmd('cp',
+                    ['-rfu', iotjs_tizenrt_appdir, tizenrt_iotjsapp_dir])
+
+    ex.check_run_cmd('cp',
+                    ['-rfu', iotjs_config_dir, tizenrt_config_dir])
 
 def setup_tizenrt_repo(tizenrt_root):
     if fs.exists(tizenrt_root):


### PR DESCRIPTION
The config and app folders should always be copied if files are newer on the iotjs repo folder. When changing options for tizenrt whe changes are not made in deps/tizenrt as the `precommit.py` made those only when the folder did not exist. This creates confusion.

This fix resolves that with least impact (only newer files are copied)

IoT.js-DCO-1.0-Signed-off-by: Krzysztof Antoszek k.antoszek@samsung.com