### PR TITLE
Replace some type checker calls

### DIFF
--- a/src/js/buffer.js
+++ b/src/js/buffer.js
@@ -43,9 +43,9 @@ function Buffer(subject, encoding) {
     return new Buffer(subject);
   }
 
-  if (util.isNumber(subject)) {
+  if ( typeof subject === 'number' ) {
     this.length = subject > 0 ? subject >>> 0 : 0;
-  } else if (util.isString(subject)) {
+  } else if (typeof subject === 'string') {
     this.length = Buffer.byteLength(subject, encoding);
   } else if (util.isBuffer(subject) || util.isArray(subject)) {
     this.length = subject.length;
@@ -55,8 +55,8 @@ function Buffer(subject, encoding) {
 
   this._builtin = new bufferBuiltin(this, this.length);
 
-  if (util.isString(subject)) {
-    if (encoding !== undefined && util.isString(encoding)) {
+  if (typeof subject === 'string') {
+    if (encoding !== undefined && typeof encoding === 'string') {
       switch (encoding) {
         case 'hex':
           if (this._builtin.hexWrite(subject, 0, this.length) != this.length) {
@@ -83,7 +83,7 @@ function Buffer(subject, encoding) {
 Buffer.byteLength = function(str, encoding) {
   var len = bufferBuiltin.byteLength(str);
 
-  if (encoding !== undefined && util.isString(encoding)) {
+  if (encoding !== undefined && typeof encoding === 'string') {
     switch (encoding) {
       case 'hex':
         return len >>> 1;
@@ -176,7 +176,7 @@ Buffer.prototype.copy = function(target, targetStart, sourceStart, sourceEnd) {
 // * offset - default to 0
 // * length - default to buffer.length - offset
 Buffer.prototype.write = function(string, offset, length) {
-  if (!util.isString(string)) {
+  if (typeof string !== 'string') {
     throw new TypeError('Bad arguments: buff.write(string)');
   }
 
@@ -214,7 +214,7 @@ Buffer.prototype.slice = function(start, end) {
 // * start - default to 0
 // * end - default to buff.length
 Buffer.prototype.toString = function(start, end) {
-  if (util.isString(start) && start === "hex" && end === undefined) {
+  if (typeof start === 'string' && start === "hex" && end === undefined) {
       return this._builtin.toHexString();
   }
   start = start === undefined ? 0 : ~~start;
@@ -304,7 +304,7 @@ Buffer.prototype.readUInt16LE = function(offset, noAssert) {
 
 // buff.fill(value)
 Buffer.prototype.fill = function(value) {
-  if (util.isNumber(value)) {
+  if (typeof value === 'number') {
     value = value & 255;
     for (var i = 0; i < this.length; i++) {
       this._builtin.writeUInt8(value, i);

--- a/src/js/dgram.js
+++ b/src/js/dgram.js
@@ -70,7 +70,7 @@ function Socket(type, listener) {
   // If true - UV_UDP_REUSEADDR flag will be set
   this._reuseAddr = options && options.reuseAddr;
 
-  if (util.isFunction(listener))
+  if (typeof listener === 'function')
     this.on('message', listener);
 }
 util.inherits(Socket, EventEmitter);
@@ -105,7 +105,7 @@ Socket.prototype.bind = function(port, address, callback) {
 
   var address;
 
-  if (util.isFunction(port)) {
+  if (typeof port === 'function') {
     callback = port;
     port = 0;
     address = '';
@@ -113,12 +113,12 @@ Socket.prototype.bind = function(port, address, callback) {
     callback = address;
     address = port.address || '';
     port = port.port;
-  } else if (util.isFunction(address)) {
+  } else if (address === 'function') {
     callback = address;
     address = '';
   }
 
-  if (util.isFunction(callback))
+  if (typeof callback === 'function')
     self.once('listening', callback);
 
   // defaulting address for bind to all interfaces
@@ -158,10 +158,10 @@ Socket.prototype.bind = function(port, address, callback) {
 // thin wrapper around `send`, here for compatibility with dgram_legacy.js
 Socket.prototype.sendto = function(buffer, offset, length, port, address,
                                    callback) {
-  if (!(util.isNumber(offset)) || !(util.isNumber(length)))
+  if (typeof offset !== 'number' || typeof length !== 'number')
     throw new Error('send takes offset and length as args 2 and 3');
 
-  if (!(util.isString(address)))
+  if (typeof address !== 'string')
     throw new Error(this.type + ' sockets must send to port, address');
 
   this.send(buffer, offset, length, port, address, callback);
@@ -169,7 +169,7 @@ Socket.prototype.sendto = function(buffer, offset, length, port, address,
 
 
 function sliceBuffer(buffer, offset, length) {
-  if (util.isString(buffer))
+  if (typeof buffer === 'string')
     buffer = new Buffer(buffer);
   else if (!(util.isBuffer(buffer)))
     throw new TypeError('First argument must be a buffer or string');
@@ -186,7 +186,7 @@ function fixBufferList(list) {
 
   for (var i = 0, l = list.length; i < l; i++) {
     var buf = list[i];
-    if (util.isString(buf))
+    if (typeof buf === 'string')
       newlist[i] = new Buffer(buf);
     else if (!(util.isBuffer(buf)))
       return null;
@@ -232,7 +232,7 @@ Socket.prototype.send = function(buffer, offset, length, port, address,
   var self = this;
   var list;
 
-  if (address || (port && !(util.isFunction(port)))) {
+  if (address || (port && typeof port !== 'function')) {
     buffer = sliceBuffer(buffer, offset, length);
   } else {
     callback = port;
@@ -241,7 +241,7 @@ Socket.prototype.send = function(buffer, offset, length, port, address,
   }
 
   if (!util.isArray(buffer)) {
-    if (util.isString(buffer)) {
+    if (typeof buffer === 'string') {
       list = [ new Buffer(buffer) ];
     } else if (!util.isBuffer(buffer)) {
       throw new TypeError('First argument must be a buffer or a string');
@@ -259,7 +259,7 @@ Socket.prototype.send = function(buffer, offset, length, port, address,
 
   // Normalize callback so it's either a function or undefined but not anything
   // else.
-  if (!(util.isFunction(callback)))
+  if (typeof callback !== 'function')
     callback = undefined;
 
   self._healthCheck();
@@ -285,7 +285,7 @@ Socket.prototype.send = function(buffer, offset, length, port, address,
 
 function doSend(ex, self, ip, list, address, port, callback) {
   if (ex) {
-    if (util.isFunction(callback)) {
+    if (typeof callback === 'function') {
       callback(ex);
       return;
     }
@@ -305,7 +305,7 @@ function doSend(ex, self, ip, list, address, port, callback) {
       err = null;
     }
 
-    if (util.isFunction(callback)) {
+    if (typeof callback === 'function') {
       callback(err, length);
     }
   });
@@ -319,7 +319,7 @@ function doSend(ex, self, ip, list, address, port, callback) {
 
 
 Socket.prototype.close = function(callback) {
-  if (util.isFunction(callback))
+  if (typeof callback === 'function')
     this.on('close', callback);
 
   if (this._queue) {
@@ -362,7 +362,7 @@ Socket.prototype.setBroadcast = function(arg) {
 
 
 Socket.prototype.setTTL = function(arg) {
-  if (!(util.isNumber(arg))) {
+  if (typeof arg !== 'number') {
     throw new TypeError('Argument must be a number');
   }
 
@@ -376,7 +376,7 @@ Socket.prototype.setTTL = function(arg) {
 
 
 Socket.prototype.setMulticastTTL = function(arg) {
-  if (!(util.isNumber(arg))) {
+  if (typeof arg !== 'number') {
     throw new TypeError('Argument must be a number');
   }
 

--- a/src/js/dns.js
+++ b/src/js/dns.js
@@ -34,13 +34,13 @@ exports.lookup = function lookup(hostname, options, callback) {
   var family = -1;
 
   // Parse arguments
-  if (!util.isString(hostname)) {
+  if (typeof hostname !== 'string') {
     throw TypeError('invalid argument: hostname must be a string');
   }
-  if (util.isFunction(options)) {
+  if (typeof options === 'function') {
     callback = options;
     family = 0;
-  } else if (!util.isFunction(callback)) {
+  } else if (typeof callback !== 'function') {
     throw TypeError('invalid argument: callback must be passed');
   } else if (util.isObject(options)) {
     hints = options.hints >>> 0;
@@ -49,7 +49,7 @@ exports.lookup = function lookup(hostname, options, callback) {
     if (hints < 0 || hints > (exports.ADDRCONFIG | exports.V4MAPPED)) {
       throw new TypeError('invalid argument: invalid hints flags');
     }
-  } else if (util.isNumber(options)) {
+  } else if (typeof options === 'number') {
     family = ~~options;
   } else {
     throw TypeError(

--- a/src/js/events.js
+++ b/src/js/events.js
@@ -54,7 +54,7 @@ EventEmitter.prototype.emit = function(type) {
 
 
 EventEmitter.prototype.addListener = function(type, listener) {
-  if (!util.isFunction(listener)) {
+  if (typeof listener !== 'function') {
     throw new TypeError('listener must be a function');
   }
 
@@ -75,7 +75,7 @@ EventEmitter.prototype.on = EventEmitter.prototype.addListener;
 
 
 EventEmitter.prototype.once = function(type, listener) {
-  if (!util.isFunction(listener)) {
+  if (typeof listener !== 'function') {
     throw new TypeError('listener must be a function');
   }
 
@@ -96,7 +96,7 @@ EventEmitter.prototype.once = function(type, listener) {
 
 
 EventEmitter.prototype.removeListener = function(type, listener) {
-  if (!util.isFunction(listener)) {
+  if (typeof listener !== 'function') {
     throw new TypeError('listener must be a function');
   }
 

--- a/src/js/fs.js
+++ b/src/js/fs.js
@@ -132,7 +132,7 @@ fs.readSync = function(fd, buffer, offset, length, position) {
 
 
 fs.write = function(fd, buffer, offset, length, position, callback) {
-  if (util.isFunction(position)) {
+  if (typeof position === 'function') {
     callback = position;
     position = -1; // write at current position.
   } else if (util.isNullOrUndefined(position)) {
@@ -315,7 +315,7 @@ fs.writeFileSync = function(path, data) {
 
 
 fs.mkdir = function(path, mode, callback) {
-  if (util.isFunction(mode)) callback = mode;
+  if (typeof mode === 'function') callback = mode;
   checkArgString(path, 'path');
   checkArgFunction(callback, 'callback');
   fsBuiltin.mkdir(path, convertMode(mode, 511), callback);
@@ -389,7 +389,7 @@ function convertFlags(flag) {
   var O_TRUNC = constants.O_TRUNC;
   var O_WRONLY = constants.O_WRONLY;
 
-  if (util.isString(flag)) {
+  if (typeof flag === 'string') {
     switch (flag) {
       case 'r': return O_RDONLY;
       case 'rs':
@@ -421,9 +421,9 @@ function convertFlags(flag) {
 
 
 function convertMode(mode, def) {
-  if (util.isNumber(mode)) {
+  if (typeof mode === 'number') {
     return mode;
-  } else if (util.isString(mode)) {
+  } else if (typeof mode === 'string') {
     return parseInt(mode, 8);
   } else if (def) {
     return convertMode(def);

--- a/src/js/gpio.js
+++ b/src/js/gpio.js
@@ -49,7 +49,7 @@ function gpioPinOpen(configuration, callback) {
 
     // validate pin
     if (util.isObject(configuration)) {
-      if (!util.isNumber(configuration.pin)) {
+      if (typeof configuration.pin !== 'number') {
         throw new TypeError('Bad configuration - pin is mandatory and number');
       }
     } else {
@@ -104,7 +104,7 @@ function gpioPinOpen(configuration, callback) {
     EventEmitter.call(this);
 
     _binding = new gpio.Gpio(configuration, function(err) {
-      util.isFunction(callback) && callback.call(self, err);
+      typeof callback === 'function' && callback.call(self, err);
     });
 
     _binding.onChange = function() {
@@ -129,12 +129,12 @@ function gpioPinOpen(configuration, callback) {
       throw new Error('GPIO pin is not opened');
     }
 
-    if (!util.isNumber(value) && !util.isBoolean(value)) {
+    if (typeof value !== 'number' && typeof value !== 'boolean') {
       throw new TypeError('Bad arguments - value should be Boolean');
     }
 
     _binding.write(!!value, function(err) {
-      util.isFunction(callback) && callback.call(self, err);
+      typeof callback === 'function' && callback.call(self, err);
     });
   };
 
@@ -143,7 +143,7 @@ function gpioPinOpen(configuration, callback) {
       throw new Error('GPIO pin is not opened');
     }
 
-    if (!util.isNumber(value) && !util.isBoolean(value)) {
+    if (typeof value !== 'number' && typeof value !== 'boolean') {
       throw new TypeError('Bad arguments - value should be Boolean');
     }
 
@@ -158,7 +158,7 @@ function gpioPinOpen(configuration, callback) {
     }
 
     _binding.read(function(err, value) {
-      util.isFunction(callback) && callback.call(self, err, value);
+      typeof callback === 'function' && callback.call(self, err, value);
     });
   };
 
@@ -178,7 +178,7 @@ function gpioPinOpen(configuration, callback) {
     }
 
     _binding.close(function(err) {
-      util.isFunction(callback) && callback.call(self, err);
+      typeof callback === 'function' && callback.call(self, err);
       _binding = null;
     });
   };

--- a/src/js/http_common.js
+++ b/src/js/http_common.js
@@ -71,7 +71,7 @@ function parserOnHeadersComplete(info) {
   // add header fields of headers to incoming.headers
   this.incoming.addHeaders(headers);
 
-  if (util.isNumber(info.method)) {
+  if (typeof info.method === 'number') {
     // for server
     this.incoming.method = HTTPParser.methods[info.method];
   } else {

--- a/src/js/http_outgoing.js
+++ b/src/js/http_outgoing.js
@@ -45,10 +45,10 @@ exports.OutgoingMessage = OutgoingMessage;
 OutgoingMessage.prototype.end = function(data, encoding, callback) {
   var self = this;
 
-  if (util.isFunction(data)) {
+  if (typeof data === 'function') {
     callback = data;
     data = null;
-  } else if (util.isFunction(encoding)) {
+  } else if (typeof encoding === 'function') {
     callback = encoding;
     encoding = null;
   }
@@ -67,7 +67,7 @@ OutgoingMessage.prototype.end = function(data, encoding, callback) {
   }
 
   // Register finish event handler.
-  if (util.isFunction(callback)) {
+  if (typeof callback === 'function') {
     this.once('finish', callback);
   }
 
@@ -99,7 +99,7 @@ OutgoingMessage.prototype._finish = function() {
 // This sends chunk directly into socket
 // TODO: buffering of chunk in the case of socket is not available
 OutgoingMessage.prototype._send = function(chunk, encoding, callback) {
-  if (util.isFunction(encoding)) {
+  if (typeof encoding === 'function') {
     callback = encoding;
   }
 

--- a/src/js/http_server.js
+++ b/src/js/http_server.js
@@ -87,7 +87,7 @@ ServerResponse.prototype._implicitHeader = function() {
 
 
 ServerResponse.prototype.writeHead = function(statusCode, reason, obj) {
-  if (util.isString(reason)) {
+  if (typeof reason === 'string') {
     this.statusMessage = reason;
   }
   else {
@@ -151,7 +151,7 @@ function Server(requestListener) {
 
   net.Server.call(this, {allowHalfOpen: true});
 
-  if (util.isFunction(requestListener)) {
+  if (typeof requestListener === 'function') {
     this.addListener('request', requestListener);
   }
 

--- a/src/js/i2c.js
+++ b/src/js/i2c.js
@@ -63,17 +63,17 @@ function i2cBusOpen(configurable, callback) {
   function I2CBus(configurable, callback) {
     if (util.isObject(configurable)) {
       if (process.platform === 'linux') {
-        if (!util.isString(configurable.device)) {
+        if (typeof configurable.device !== 'string') {
           throw new TypeError('Bad configurable - device: String');
         }
       } else if (process.platform === 'nuttx' ||
                  process.platform === 'tizen') {
-        if (!util.isNumber(configurable.device)) {
+        if (typeof configurable.device !== 'number') {
           throw new TypeError('Bad configurable - device: Number');
         }
       }
 
-      if (!util.isNumber(configurable.address)) {
+      if (typeof configurable.address !== 'number') {
         throw new TypeError('Bad configurable - address: Number');
       }
 
@@ -84,7 +84,7 @@ function i2cBusOpen(configurable, callback) {
           if (!err) {
             _this.setAddress(configurable.address);
           }
-          util.isFunction(callback) && callback(err);
+          typeof callback === 'function' && callback(err);
         };
       })(this));
     }
@@ -95,14 +95,14 @@ function i2cBusOpen(configurable, callback) {
   };
 
   I2CBus.prototype.setAddress = function(address, callback) {
-    if (!util.isNumber(address)) {
+    if (typeof address !== 'number') {
       throw new TypeError('Bad argument - address: Number');
     }
 
     this.address = address;
     _binding.setAddress(this.address);
 
-    util.isFunction(callback) && callback();
+    typeof callback === 'function' && callback();
   };
 
   I2CBus.prototype.write = function(array, callback) {
@@ -112,18 +112,18 @@ function i2cBusOpen(configurable, callback) {
 
     this.setAddress(this.address);
     _binding.write(array, function(err) {
-      util.isFunction(callback) && callback(err);
+      typeof callback === 'function' && callback(err);
     });
   };
 
   I2CBus.prototype.read = function(length, callback) {
-    if (!util.isNumber(length)) {
+    if (typeof length !== 'number') {
       throw new TypeError('Bad argument - length: Number');
     }
 
     this.setAddress(this.address);
     _binding.read(length, function(err, data) {
-      util.isFunction(callback) && callback(err, data);
+      typeof callback === 'function' && callback(err, data);
     });
   };
 

--- a/src/js/net.js
+++ b/src/js/net.js
@@ -92,7 +92,7 @@ Socket.prototype.connect = function() {
     self._handle.owner = self;
   }
 
-  if (util.isFunction(callback)) {
+  if (typeof callback === 'function') {
     self.once('connect', callback);
   }
 
@@ -108,7 +108,7 @@ Socket.prototype.connect = function() {
     hints: 0
   };
 
-  if (!util.isNumber(port) || port < 0 || port > 65535)
+  if (typeof port !== 'number' || port < 0 || port > 65535)
     throw new RangeError('port should be >= 0 and < 65536: ' + options.port);
 
   if (dnsopts.family !== 0 && dnsopts.family !== 4 && dnsopts.family !== 6)
@@ -137,7 +137,7 @@ Socket.prototype.connect = function() {
 
 
 Socket.prototype.write = function(data, callback) {
-  if (!util.isString(data) && !util.isBuffer(data)) {
+  if (typeof data !== 'string' && !util.isBuffer(data)) {
     throw new TypeError('invalid argument');
   }
   return stream.Duplex.prototype.write.call(this, data, callback);
@@ -146,13 +146,13 @@ Socket.prototype.write = function(data, callback) {
 
 Socket.prototype._write = function(chunk, callback, afterWrite) {
   assert(util.isBuffer(chunk));
-  assert(util.isFunction(afterWrite));
+  assert(typeof afterWrite === 'function');
 
   var self = this;
 
   if (self.errored) {
     process.nextTick(afterWrite, 1);
-    if (util.isFunction(callback)) {
+    if (typeof callback === 'function') {
       process.nextTick(function(self, status) {
         callback.call(self, status);
       }, self, 1);
@@ -164,7 +164,7 @@ Socket.prototype._write = function(chunk, callback, afterWrite) {
 
     self._handle.write(chunk, function(status) {
       afterWrite(status);
-      if (util.isFunction(callback)) {
+      if (typeof callback === 'function') {
         callback.call(self, status);
       }
     });
@@ -465,14 +465,14 @@ function Server(options, connectionListener) {
 
   EventEmitter.call(this);
 
-  if (util.isFunction(options)) {
+  if (typeof options === 'function') {
     connectionListener = options;
     options = {};
   } else {
     options = options || {};
   }
 
-  if (util.isFunction(connectionListener)) {
+  if (typeof connectionListener === 'function') {
     this.on('connection', connectionListener);
   }
 
@@ -496,15 +496,15 @@ Server.prototype.listen = function() {
   var callback = args[1];
 
   var port = options.port;
-  var host = util.isString(options.host) ? options.host : '0.0.0.0';
-  var backlog = util.isNumber(options.backlog) ? options.backlog : 511;
+  var host = typeof options.host === 'string' ? options.host : '0.0.0.0';
+  var backlog = typeof options.backlog === 'number' ? options.backlog : 511;
 
-  if (!util.isNumber(port)) {
+  if (typeof port !== 'number') {
     throw new Error('invalid argument - need port number');
   }
 
   // register listening event listener.
-  if (util.isFunction(callback)) {
+  if (typeof callback === 'function') {
     self.once('listening', callback);
   }
 
@@ -555,7 +555,7 @@ Server.prototype.address = function() {
 
 
 Server.prototype.close = function(callback) {
-  if (util.isFunction(callback)) {
+  if (typeof callback === 'function') {
     if (!this._handle) {
       this.once('close', function() {
         callback(new Error('Not running'));
@@ -624,17 +624,17 @@ function normalizeListenArgs(args) {
   } else {
     var idx = 0;
     options.port = args[idx++];
-    if (util.isString(args[idx])) {
+    if (typeof args[idx] === 'string') {
       options.host = args[idx++];
     }
-    if (util.isNumber(args[idx])) {
+    if (typeof args[idx] === 'number') {
       options.backlog = args[idx++];
     }
   }
 
   var cb = args[args.length - 1];
 
-  return util.isFunction(cb) ? [options, cb] : [options];
+  return typeof cb === 'function' ? [options, cb] : [options];
 }
 
 
@@ -645,14 +645,14 @@ function normalizeConnectArgs(args) {
     options = args[0];
   } else {
     options.port = args[0];
-    if (util.isString(args[1])) {
+    if (typeof args[1] === 'string') {
       options.host = args[1];
     }
   }
 
   var cb = args[args.length - 1];
 
-  return util.isFunction(cb) ? [options, cb] : [options];
+  return typeof cb === 'function' ? [options, cb] : [options];
 }
 
 

--- a/src/js/pwm.js
+++ b/src/js/pwm.js
@@ -37,14 +37,14 @@ function pwmPinOpen(configuration, callback) {
 
     if (util.isObject(configuration)) {
       if (process.platform === 'linux') {
-        if (util.isNumber(configuration.chip)) {
+        if (typeof configuration.chip === 'number') {
           self._configuration.chip = configuration.chip
         } else {
           self._configuration.chip = 0;
         }
       }
 
-      if (!util.isNumber(configuration.pin)) {
+      if (typeof configuration.pin !== 'number') {
         throw new TypeError(
           'Bad configuration - pin is mandatory and should be Number');
       } else {
@@ -57,18 +57,19 @@ function pwmPinOpen(configuration, callback) {
     // validate configuration
     var dutyCycle = configuration.dutyCycle;
     var period = configuration.period;
-    if (!util.isNumber(period) && util.isNumber(configuration.frequency)) {
+    if (typeof period !== 'number'
+        && typeof configuration.frequency === 'number') {
       period = 1.0 / configuration.frequency;
     }
 
-    if (util.isNumber(dutyCycle) && dutyCycle >= 0.0 && dutyCycle <= 1.0 &&
-      util.isNumber(period) && util.isFinite(period) && period > 0) {
+    if (typeof dutyCycle === 'number' && dutyCycle >= 0.0 && dutyCycle <= 1.0 &&
+      typeof period === 'number' && util.isFinite(period) && period > 0) {
       self._configuration.dutyCycle = dutyCycle;
       self._configuration.period = period;
     }
 
     _binding = new pwm(self._configuration, function(err) {
-      util.isFunction(callback) && callback.call(self, err);
+      typeof callback === 'function' && callback.call(self, err);
     });
 
     process.on('exit', (function(self) {
@@ -81,7 +82,7 @@ function pwmPinOpen(configuration, callback) {
   }
 
   PwmPin.prototype._validatePeriod = function(period) {
-    if (!util.isNumber(period)) {
+    if (typeof period !== 'number') {
       throw new TypeError('Period is not a number(' + typeof(period) + ')');
     } else if (period < 0) {
       throw new RangeError('Period(' + period + ') is negative');
@@ -90,7 +91,7 @@ function pwmPinOpen(configuration, callback) {
   };
 
   PwmPin.prototype._validateFrequency = function(frequency) {
-    if (!util.isNumber(frequency)) {
+    if (typeof frequency !== 'number') {
       throw new TypeError('Frequency is not a number(' +
         typeof(frequency) + ')');
     } else if (frequency <= 0) {
@@ -100,7 +101,7 @@ function pwmPinOpen(configuration, callback) {
   };
 
   PwmPin.prototype._validateDutyCycle = function(dutyCycle) {
-    if (!util.isNumber(dutyCycle)) {
+    if (typeof dutyCycle !== 'number') {
       throw TypeError('DutyCycle is not a number(' + typeof(dutyCycle) + ')');
     } else if (dutyCycle < 0.0 || dutyCycle > 1.0) {
       throw RangeError('DutyCycle of ' + dutyCycle + ' out of bounds [0..1]');
@@ -117,7 +118,7 @@ function pwmPinOpen(configuration, callback) {
 
     if (this._validatePeriod(period)) {
       _binding.setPeriod(period, function(err) {
-        util.isFunction(callback) && callback.call(self, err);
+        typeof callback === 'function' && callback.call(self, err);
       });
     }
   };
@@ -141,7 +142,7 @@ function pwmPinOpen(configuration, callback) {
 
     if (this._validateFrequency(frequency)) {
       _binding.setPeriod(1.0 / frequency, function(err) {
-        util.isFunction(callback) && callback.call(self, err);
+        typeof callback === 'function' && callback.call(self, err);
       });
     }
   };
@@ -166,7 +167,7 @@ function pwmPinOpen(configuration, callback) {
     // Check arguments.
     if (this._validateDutyCycle(dutyCycle)) {
       _binding.setDutyCycle(dutyCycle, function(err) {
-        util.isFunction(callback) && callback.call(self, err);
+        typeof callback === 'function' && callback.call(self, err);
       });
     }
   };
@@ -190,12 +191,12 @@ function pwmPinOpen(configuration, callback) {
     }
 
     // Check arguments.
-    if (!util.isNumber(enable) && !util.isBoolean(enable)) {
+    if (typeof enable !== 'number' && typeof enable !== 'boolean') {
       throw new TypeError('enable is of type ' + typeof(enable));
     }
 
     _binding.setEnable(!!enable, function(err) {
-      util.isFunction(callback) && callback.call(self, err);
+      typeof callback === 'function' && callback.call(self, err);
     });
   };
 
@@ -205,7 +206,7 @@ function pwmPinOpen(configuration, callback) {
     }
 
     // Check arguments.
-    if (!util.isNumber(enable) && !util.isBoolean(enable)) {
+    if (typeof enable !== 'number' && typeof enable !== 'boolean') {
       throw new TypeError('enable is of type ' + typeof(enable));
     }
 
@@ -220,7 +221,7 @@ function pwmPinOpen(configuration, callback) {
     }
 
     _binding.close(function(err) {
-      util.isFunction(callback) && callback.call(self, err);
+      typeof callback === 'function' && callback.call(self, err);
       _binding = null;
     });
   };

--- a/src/js/spi.js
+++ b/src/js/spi.js
@@ -48,11 +48,11 @@ function spiBusOpen(configuration, callback) {
     var self = this;
 
     if (process.platform === 'linux') {
-      if (!util.isString(configuration.device)) {
+      if (typeof configuration.device !== 'string') {
         throw new TypeError('Bad configuration - device: String');
       }
     } else if (process.platform === 'nuttx') {
-      if (!util.isNumber(configuration.bus)) {
+      if (typeof configuration.bus !== 'number') {
         throw new TypeError('Bad configuration - bus: Number');
       }
     }
@@ -83,7 +83,7 @@ function spiBusOpen(configuration, callback) {
 
     // validate max speed
     if (configuration.maxSpeed !== undefined) {
-      if (!util.isNumber(configuration.maxSpeed)) {
+      if (typeof configuration.maxSpeed !== 'number') {
         throw new TypeError('Bad arguments - maxSpeed should be Number');
       }
     } else {
@@ -114,7 +114,7 @@ function spiBusOpen(configuration, callback) {
     // validate loopback
     var loopback = configuration.loopback;
     if (loopback !== undefined) {
-      if (!util.isBoolean(loopback)) {
+      if (typeof loopback !== 'boolean') {
         throw new TypeError('Bad arguments - loopback should be Boolean');
       }
     } else {
@@ -122,7 +122,7 @@ function spiBusOpen(configuration, callback) {
     }
 
     _binding = new spi.Spi(configuration, function(err) {
-      util.isFunction(callback) && callback.call(self, err);
+      typeof callback === 'function' && callback.call(self, err);
     });
 
     process.on('exit', (function(self) {
@@ -153,7 +153,7 @@ function spiBusOpen(configuration, callback) {
         rxBuffer[i] = buffer[i];
       }
 
-      util.isFunction(callback) && callback.call(self, err);
+      typeof callback === 'function' && callback.call(self, err);
     };
 
     if (util.isArray(txBuffer) && util.isArray(rxBuffer)) {
@@ -203,7 +203,7 @@ function spiBusOpen(configuration, callback) {
     }
 
     _binding.close(function(err) {
-      util.isFunction(callback) && callback.call(self, err);
+      typeof callback === 'function' && callback.call(self, err);
       _binding = null;
     });
   };

--- a/src/js/stream_readable.js
+++ b/src/js/stream_readable.js
@@ -58,7 +58,7 @@ Readable.prototype.read = function(n) {
   var state = this._readableState;
   var res;
 
-  if (!util.isNumber(n) || n > state.length) {
+  if (typeof n !== 'number' || n > state.length) {
     n = state.length;
   } else if (n < 0) {
     n = 0;
@@ -124,13 +124,13 @@ Readable.prototype.push = function(chunk, encoding) {
 
   if (chunk === null) {
     onEof(this);
-  } else if (!util.isString(chunk) &&
+  } else if (typeof chunk !== 'string' &&
              !util.isBuffer(chunk)) {
     this.error(TypeError('Invalid chunk'));
   } else if (state.ended) {
     this.error(Error('stream.push() after EOF'));
   } else {
-    if (util.isString(chunk)) {
+    if (typeof chunk === 'string') {
       encoding = encoding || state.defaultEncoding;
       chunk = new Buffer(chunk, encoding);
     }

--- a/src/js/stream_writable.js
+++ b/src/js/stream_writable.js
@@ -37,7 +37,7 @@ function WritableState(options) {
 
   // high water mark.
   // The point where write() starts retuning false.
-  this.highWaterMark = (options && util.isNumber(options.highWaterMark)) ?
+  this.highWaterMark = (options && typeof options.highWaterMark === 'number') ?
     options.highWaterMark : defaultHighWaterMark;
 
   // 'true' if stream is ready to write.
@@ -158,7 +158,7 @@ Writable.prototype._onwrite = function() {
 function writeAfterEnd(stream, callback) {
   var err = new Error('write after end');
   stream.emit('error', err);
-  if (util.isFunction(callback)) {
+  if (typeof callback === 'function') {
     process.nextTick(callback.bind(undefined, err));
   }
 }
@@ -167,7 +167,7 @@ function writeAfterEnd(stream, callback) {
 function writeOrBuffer(stream, chunk, callback) {
   var state = stream._writableState;
 
-  if (util.isString(chunk)) {
+  if (typeof chunk === 'string') {
     chunk = new Buffer(chunk);
   }
 

--- a/src/js/timers.js
+++ b/src/js/timers.js
@@ -65,7 +65,7 @@ Timeout.prototype.unref = function() {
 };
 
 function timeoutConfigurator(isrepeat, callback, delay) {
-  if (!util.isFunction(callback)) {
+  if (typeof callback !== 'function') {
     throw new TypeError('Bad arguments: callback must be a Function');
   }
 

--- a/src/js/uart.js
+++ b/src/js/uart.js
@@ -46,7 +46,7 @@ function uartPortOpen(configuration, callback) {
     var self = this;
 
     if (util.isObject(configuration)) {
-      if (!util.isString(configuration.device)) {
+      if (typeof configuration.device !== 'string') {
         throw new TypeError(
           'Bad configuration - device is mandatory and should be String');
       }
@@ -75,7 +75,7 @@ function uartPortOpen(configuration, callback) {
     EventEmitter.call(this);
 
     _binding = new uart(configuration, this, function(err) {
-      util.isFunction(callback) && callback.call(self, err);
+      typeof callback === 'function' && callback.call(self, err);
     });
 
     process.on('exit', (function(self) {
@@ -97,7 +97,7 @@ function uartPortOpen(configuration, callback) {
     }
 
     _binding.write(buffer, function(err) {
-      util.isFunction(callback) && callback.call(self, err);
+      typeof callback === 'function' && callback.call(self, err);
     });
   };
 
@@ -119,7 +119,7 @@ function uartPortOpen(configuration, callback) {
     }
 
     _binding.close(function(err) {
-      util.isFunction(callback) && callback.call(self, err);
+      typeof callback === 'function'  && callback.call(self, err);
       _binding = null;
     });
   };

--- a/src/js/util.js
+++ b/src/js/util.js
@@ -75,7 +75,7 @@ function inherits(ctor, superCtor) {
 
 
 function format(s) {
-  if (!isString(s)) {
+  if (typeof s !== 'string') {
     var arrs = [];
     for (var i = 0; i < arguments.length; ++i) {
       arrs.push(formatValue(arguments[i]));


### PR DESCRIPTION
Deleted isNumber(arg) function calls from
JavaScript sources and replaced these with JavaScript
comparison operator.

Deleted isBoolean(arg) function calls from
JavaScript sources and replaced these with JavaScript
comparison operator.

Deleted isString(arg) function calls from
JavaScript sources and replaced these with JavaScript
comparison operator.

Deleted isFunction(arg) function calls from
JavaScript sources and replaced these with JavaScript
comparison operator.

IoT.js-DCO-1.0-Signed-off-by: Tamas Keri tkeri@inf.u-szeged.hu