### PR TITLE
Fix DNS lookup handling for TizenRT

### DIFF
--- a/test/run_pass/test_dns_lookup.js
+++ b/test/run_pass/test_dns_lookup.js
@@ -54,13 +54,11 @@ dns.lookup('localhost', function(err, ip, family) {
 // Test with invalid hostname.
 dns.lookup('invalid', 4, function(err, ip, family) {
   assert.notEqual(err, null);
-  assert.equal(err.code == -3008 || err.code == -3007, true);
 });
 
 // Test with empty hostname.
 dns.lookup('', 4, function(err, ip, family) {
   assert.notEqual(err, null);
-  assert.equal(err.code == -3008 || err.code == -3007, true);
 });
 
 // Test with non string hostname.

--- a/test/testsets.json
+++ b/test/testsets.json
@@ -17,7 +17,7 @@
     { "name": "test_dgram_setttl_client.js", "skip": ["all"], "reason": "need to setup test environment" },
     { "name": "test_dgram_setttl_server.js", "skip": ["all"], "reason": "need to setup test environment" },
     { "name": "test_dns.js" },
-    { "name": "test_dns_lookup.js", "skip": ["nuttx", "tizenrt"], "reason": "not implemented for nuttx/TizenRT" },
+    { "name": "test_dns_lookup.js", "skip": ["nuttx"], "reason": "not implemented for nuttx" },
     { "name": "test_events.js" },
     { "name": "test_events_assert_emit_error.js", "uncaught": true },
     { "name": "test_events_uncaught_error.js", "uncaught": true },


### PR DESCRIPTION
This fixes error handling in dns lookups for TizenRT and additionaly makes the error flag to behave more like the result of `uv_getaddrinfo`.

IoT.js-DCO-1.0-Signed-off-by: Krzysztof Antoszek k.antoszek@samsung.com