### PR TITLE
UDP.setBroadCast is enabled on TizenRT

### DIFF
--- a/src/modules/iotjs_module_udp.c
+++ b/src/modules/iotjs_module_udp.c
@@ -350,7 +350,7 @@ JHANDLER_FUNCTION(GetSockeName) {
 
 
 JHANDLER_FUNCTION(SetBroadcast) {
-#if !defined(__NUTTX__) && !defined(__TIZENRT__)
+#if !defined(__NUTTX__)
   IOTJS_UV_SET_SOCKOPT(uv_udp_set_broadcast);
 #else
   IOTJS_ASSERT(!"Not implemented");


### PR DESCRIPTION
TizenRT support udp broadcast, so it is enabled.

Enable SetBroadCast on TizenRT since TizenRT supports udp broadcast.

IoT.js-DCO-1.0-Signed-off-by: Sanggyu Lee sg5.lee@samsung.com