### PR TITLE
Fix jerry-debugger on IoT.js build

### DIFF
--- a/src/iotjs.c
+++ b/src/iotjs.c
@@ -51,13 +51,12 @@ static bool iotjs_jerry_initialize(iotjs_environment_t* env) {
     jerry_port_default_set_log_level(JERRY_LOG_LEVEL_DEBUG);
 #endif
   }
-
-  if (iotjs_environment_config(env)->debugger) {
-    jerry_flags |= JERRY_INIT_DEBUGGER;
-  }
-
   // Initialize jerry.
   jerry_init(jerry_flags);
+
+  if (iotjs_environment_config(env)->debugger) {
+    jerry_debugger_init(iotjs_environment_config(env)->debugger_port);
+  }
 
   if (iotjs_environment_config(env)->debugger) {
     jerry_debugger_continue();
@@ -92,7 +91,10 @@ static bool iotjs_jerry_initialize(iotjs_environment_t* env) {
 }
 
 
-static void iotjs_jerry_release() {
+static void iotjs_jerry_release(iotjs_environment_t* env) {
+  if (iotjs_environment_config(env)->debugger) {
+    jerry_debugger_cleanup();
+  }
   jerry_cleanup();
 }
 
@@ -224,7 +226,7 @@ int iotjs_entry(int argc, char** argv) {
   IOTJS_ASSERT(res == 0);
 
   // Release JerryScript engine.
-  iotjs_jerry_release();
+  iotjs_jerry_release(env);
 
 terminate:
   // Release environment.

--- a/src/iotjs_env.c
+++ b/src/iotjs_env.c
@@ -71,6 +71,7 @@ static void iotjs_environment_initialize(iotjs_environment_t* env) {
   _this->config.memstat = false;
   _this->config.show_opcode = false;
   _this->config.debugger = false;
+  _this->config.debugger_port = 5001;
 }
 
 
@@ -101,6 +102,7 @@ bool iotjs_environment_parse_command_line_arguments(iotjs_environment_t* env,
 
   // Parse IoT.js command line arguments.
   uint32_t i = 1;
+  uint8_t port_arg_len = strlen("--jerry-debugger-port=");
   while (i < argc && argv[i][0] == '-') {
     if (!strcmp(argv[i], "--memstat")) {
       _this->config.memstat = true;
@@ -108,6 +110,11 @@ bool iotjs_environment_parse_command_line_arguments(iotjs_environment_t* env,
       _this->config.show_opcode = true;
     } else if (!strcmp(argv[i], "--start-debug-server")) {
       _this->config.debugger = true;
+    } else if (!strncmp(argv[i], "--jerry-debugger-port=", port_arg_len)) {
+      size_t port_length = sizeof(strlen(argv[i] - port_arg_len - 1));
+      char port[port_length];
+      memcpy(&port, argv[i] + port_arg_len, port_length);
+      sscanf(port, "%d", &(_this->config.debugger_port));
     } else {
       fprintf(stderr, "unknown command line option: %s\n", argv[i]);
       return false;

--- a/src/iotjs_env.h
+++ b/src/iotjs_env.h
@@ -23,6 +23,7 @@ typedef struct {
   bool memstat;
   bool show_opcode;
   bool debugger;
+  int debugger_port;
 } Config;
 
 typedef enum {


### PR DESCRIPTION
On 18th, July the Jerry Debugger API has changed, therefore the debugger-server couldn't start, because the patch introduced runtime port configuration, making the current jerry debugger call broken.
This patch fixes it.
Passing the environment value is needed, since now Jerry won't do the cleanup itself, it needs to be manually called from IoT.js.

IoT.js-DCO-1.0-Signed-off-by: Daniel Balla dballa@inf.u-szeged.hu