### PR TITLE
Fix module.require error throwing on Linux

### DIFF
--- a/src/js/module.js
+++ b/src/js/module.js
@@ -69,7 +69,7 @@ iotjs_module_t.resolveFilepath = function(id, directories) {
 
     // START: Temprorary fix for TizenRT
     // See: https://github.com/Samsung/TizenRT/issues/320
-    if (process.platform === 'tizenrt' && modulePath[0] !== '/') {
+    if (modulePath[0] !== '/') {
       modulePath = process.cwd() + '/' + modulePath;
     }
     // END: Temprorary fix for TizenRT


### PR DESCRIPTION
Currently module loading throw error below root when it should not.

$ iotjs ../some.js

uncaughtException: Error: Requested path is below root:

IoT.js-DCO-1.0-Signed-off-by: Sanggyu Lee sg5.lee@samsung.com