### PR TITLE
Enable setTTL on TizenRT and refine setTTL test case

### DIFF
--- a/src/modules/iotjs_module_udp.c
+++ b/src/modules/iotjs_module_udp.c
@@ -361,7 +361,7 @@ JHANDLER_FUNCTION(SetBroadcast) {
 
 
 JHANDLER_FUNCTION(SetTTL) {
-#if !defined(__NUTTX__) && !defined(__TIZENRT__)
+#if !defined(__NUTTX__)
   IOTJS_UV_SET_SOCKOPT(uv_udp_set_ttl);
 #else
   IOTJS_ASSERT(!"Not implemented");

--- a/test/run_pass/test_dgram_setttl_client.js
+++ b/test/run_pass/test_dgram_setttl_client.js
@@ -18,6 +18,7 @@ var dgram = require('dgram');
 
 var port = 41234;
 var msg = 'Hello IoT.js';
+var msg2 = 'Bye IoT.js';
 var addr = '192.168.0.1'; // Change to your ip address
 var server = dgram.createSocket('udp4');
 
@@ -33,7 +34,7 @@ client.on('error', function(err) {
 });
 
 client.on('listening', function(err) {
-  client.setTTL(1);
+  client.setTTL(2);
 });
 
 client.on('message', function(data, rinfo) {
@@ -43,6 +44,16 @@ client.on('message', function(data, rinfo) {
   console.log('server family : ' + rinfo.family);
   assert.equal(port, rinfo.port);
   assert.equal(data, msg);
-  client.close();
+  /* send with TTL=1 */
+  client.setTTL(1);
+  client.send(msg2, port, addr, function(err, len) {
+    assert.equal(err, null);
+    assert.equal(len, msg2.length);
+    client.close();
+  });
+});
+
+process.on('exit', function(code) {
+  assert.equal(code, 0);
 });
 

--- a/test/run_pass/test_dgram_setttl_server.js
+++ b/test/run_pass/test_dgram_setttl_server.js
@@ -19,6 +19,8 @@ var dgram = require('dgram');
 var port = 41234;
 var msg = 'Hello IoT.js';
 var server = dgram.createSocket('udp4');
+var recvMsg = "";
+var recvCnt = 0;
 
 server.on('error', function(err) {
   assert.fail();
@@ -30,21 +32,24 @@ server.on('message', function(data, rinfo) {
   console.log('client address : ' + rinfo.address);
   console.log('client port : ' + rinfo.port);
   console.log('client family : ' + rinfo.family);
-  assert.equal(data, msg);
+  recvMsg = data;
+  recvCnt++;
   server.send(msg, rinfo.port, rinfo.address, function (err, len) {
     assert.equal(err, null);
     assert.equal(len, msg.length);
   });
+  setTimeout(function() { server.close() }, 4000);
 });
+
 
 server.on('listening', function() {
   console.log('listening');
 });
 
-server.bind(port, function() {
-  server.setTTL(1);
-});
+server.bind(port);
 
 process.on('exit', function(code) {
   assert.equal(code, 0);
+  assert.equal(recvCnt, 1);
+  assert.equal(recvMsg, msg);
 });


### PR DESCRIPTION
- Enable setTTL on TizenRT
- Previously, we have to adjust setTTL, and run the test case again.
Now, it is done by one execution.

IoT.js-DCO-1.0-Signed-off-by: Sanggyu Lee sg5.lee@samsung.com