### PR TITLE
Fix test_module_require.js err on TizenRT

### DIFF
--- a/src/js/module.js
+++ b/src/js/module.js
@@ -67,12 +67,13 @@ iotjs_module_t.resolveFilepath = function(id, directories) {
     var dir = directories[i];
     var modulePath = dir + id;
 
-    // START: Temprorary fix for TizenRT
-    // See: https://github.com/Samsung/TizenRT/issues/320
     if (modulePath[0] !== '/') {
       modulePath = process.cwd() + '/' + modulePath;
     }
-    // END: Temprorary fix for TizenRT
+
+    if (process.platform === 'tizenrt' && modulePath.indexOf("..") != -1) {
+      modulePath = iotjs_module_t.normalizePath(modulePath);
+    }
 
     // 1. 'id'
     var filepath = iotjs_module_t.tryPath(modulePath);

--- a/test/testsets.json
+++ b/test/testsets.json
@@ -52,7 +52,7 @@
     { "name": "test_i2c.js", "skip": ["all"], "reason": "need to setup test environment" },
     { "name": "test_iotjs_promise.js", "skip": ["all"], "reason": "es2015 is off by default" },
     { "name": "test_module_cache.js", "skip": ["nuttx", "tizenrt"], "reason": "not implemented for nuttx/TizenRT" },
-    { "name": "test_module_require.js", "skip": ["nuttx", "tizenrt"], "reason": "not implemented for nuttx/TizenRT" },
+    { "name": "test_module_require.js", "skip": ["nuttx"], "reason": "not implemented for nuttx" },
     { "name": "test_net_1.js" },
     { "name": "test_net_2.js" },
     { "name": "test_net_3.js", "skip": ["all"], "reason": "[linux]: flaky on Travis, [nuttx/tizenrt]: requires too many socket descriptors and too large buffers" },


### PR DESCRIPTION
  - to support relative path parameter in require('../add2')

IoT.js-DCO-1.0-Signed-off-by: Haesik, Jun haesik.jun@samsung.com