### PR TITLE
Fix closing resource issue

### DIFF
--- a/src/js/gpio.js
+++ b/src/js/gpio.js
@@ -179,9 +179,8 @@ function gpioPinOpen(configuration, callback) {
 
     _binding.close(function(err) {
       util.isFunction(callback) && callback.call(self, err);
+      _binding = null;
     });
-
-    _binding = null;
   };
 
   GpioPin.prototype.closeSync = function() {
@@ -190,7 +189,6 @@ function gpioPinOpen(configuration, callback) {
     }
 
     _binding.close();
-
     _binding = null;
   };
 

--- a/src/js/pwm.js
+++ b/src/js/pwm.js
@@ -221,8 +221,8 @@ function pwmPinOpen(configuration, callback) {
 
     _binding.close(function(err) {
       util.isFunction(callback) && callback.call(self, err);
+      _binding = null;
     });
-    _binding = null;
   };
 
   PwmPin.prototype.closeSync = function() {

--- a/src/js/spi.js
+++ b/src/js/spi.js
@@ -204,8 +204,8 @@ function spiBusOpen(configuration, callback) {
 
     _binding.close(function(err) {
       util.isFunction(callback) && callback.call(self, err);
+      _binding = null;
     });
-    _binding = null;
   };
 
   SpiBus.prototype.closeSync = function() {

--- a/src/js/uart.js
+++ b/src/js/uart.js
@@ -120,8 +120,8 @@ function uartPortOpen(configuration, callback) {
 
     _binding.close(function(err) {
       util.isFunction(callback) && callback.call(self, err);
+      _binding = null;
     });
-    _binding = null;
   };
 
   UartPort.prototype.closeSync = function() {

--- a/src/modules/iotjs_module_uart.h
+++ b/src/modules/iotjs_module_uart.h
@@ -18,7 +18,7 @@
 #define IOTJS_MODULE_UART_H
 
 #include "iotjs_def.h"
-#include "iotjs_objectwrap.h"
+#include "iotjs_handlewrap.h"
 #include "iotjs_reqwrap.h"
 
 
@@ -33,7 +33,7 @@ typedef enum {
 
 
 typedef struct {
-  iotjs_jobjectwrap_t jobjectwrap;
+  iotjs_handlewrap_t handlewrap;
   iotjs_jval_t jemitter_this;
   int device_fd;
   int baud_rate;

--- a/test/run_pass/issue/issue-1101.js
+++ b/test/run_pass/issue/issue-1101.js
@@ -1,0 +1,44 @@
+/* Copyright 2017-present Samsung Electronics Co., Ltd. and other contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+var UART = require('uart');
+var uart = new UART();
+var res = uart.open({
+  device: '/dev/ttyS1',
+  baudRate: 115200,
+  dataBits: 8
+}, function(err) {
+  if (err) {
+    console.error(err);
+  } else {
+    console.log('opened');
+    res.close(function(err) {
+      if (err) {
+      console.error(err);
+    } else {
+      console.log('closed');
+    }
+    });
+    var c = 0;
+    var p = function() {
+      c++;
+      console.log('this should still run');
+      if (c < 10) {
+        setTimeout(p, 250);
+      }
+    };
+    p();
+  }
+});

--- a/test/run_pass/test_uart.js
+++ b/test/run_pass/test_uart.js
@@ -25,10 +25,8 @@ var configuration = {
 
 if (process.platform === 'linux') {
   configuration.device = '/dev/ttyS0';
-} else if (process.platform === 'nuttx') {
+} else if (process.platform === 'nuttx' || process.platform === 'tizenrt') {
   configuration.device = '/dev/ttyS1';
-} else if (process.platform === 'tizenrt') {
-  configuration.device = '/dev/ttyDBG';
 } else {
   assert.fail();
 }
@@ -77,4 +75,3 @@ function writeReadTest() {
     });
   });
 }
-

--- a/test/testsets.json
+++ b/test/testsets.json
@@ -106,7 +106,8 @@
     { "name": "issue-323.js" },
     { "name": "issue-816.js" },
     { "name": "issue-1046.js" },
-    { "name": "issue-1077.js" }
+    { "name": "issue-1077.js" },
+    { "name": "issue-1101.js", "skip": ["all"], "reason": "need to setup test environment" }    
   ],
   "run_fail":  [
     { "name": "test_assert_equal.js", "expected-failure": true },


### PR DESCRIPTION
 - must use handlewrap to release native resource after closing is finished
 - must release the native binding resource after user callback is finished
 - related issue #1101
 - tested on artik053, stm32f4dis

IoT.js-DCO-1.0-Signed-off-by: Hosung Kim hs852.kim@samsung.com