### PR TITLE
Fix invalid release of resources in ADC module

### DIFF
--- a/src/iotjs_binding.c
+++ b/src/iotjs_binding.c
@@ -381,7 +381,7 @@ iotjs_jval_t iotjs_jval_get_property(const iotjs_jval_t* jobj,
 
 void iotjs_jval_set_object_native_handle(const iotjs_jval_t* jobj,
                                          uintptr_t ptr,
-                                         JNativeInfoType native_info) {
+                                         JNativeInfoType* native_info) {
   const IOTJS_VALIDATED_STRUCT_METHOD(iotjs_jval_t, jobj);
   IOTJS_ASSERT(iotjs_jval_is_object(jobj));
 
@@ -394,14 +394,14 @@ uintptr_t iotjs_jval_get_object_native_handle(const iotjs_jval_t* jobj) {
   IOTJS_ASSERT(iotjs_jval_is_object(jobj));
 
   uintptr_t ptr = 0x0;
-  JNativeInfoType out_info;
+  JNativeInfoType* out_info;
   jerry_get_object_native_pointer(_this->value, (void**)&ptr, &out_info);
   return ptr;
 }
 
 
 uintptr_t iotjs_jval_get_object_from_jhandler(iotjs_jhandler_t* jhandler,
-                                              JNativeInfoType native_info) {
+                                              JNativeInfoType* native_info) {
   const iotjs_jval_t* jobj = JHANDLER_GET_THIS(object);
   const IOTJS_DECLARE_THIS(iotjs_jval_t, jobj);
 
@@ -410,7 +410,7 @@ uintptr_t iotjs_jval_get_object_from_jhandler(iotjs_jhandler_t* jhandler,
   }
 
   uintptr_t ptr = 0;
-  JNativeInfoType out_native_info;
+  JNativeInfoType* out_native_info;
 
   if (jerry_get_object_native_pointer(_this->value, (void**)&ptr,
                                       &out_native_info)) {
@@ -427,7 +427,7 @@ uintptr_t iotjs_jval_get_object_from_jhandler(iotjs_jhandler_t* jhandler,
 
 uintptr_t iotjs_jval_get_arg_obj_from_jhandler(iotjs_jhandler_t* jhandler,
                                                uint16_t index,
-                                               JNativeInfoType native_info) {
+                                               JNativeInfoType* native_info) {
   IOTJS_VALIDATED_STRUCT_METHOD(iotjs_jhandler_t, jhandler);
 
   if (index >= _this->jargc) {
@@ -441,7 +441,7 @@ uintptr_t iotjs_jval_get_arg_obj_from_jhandler(iotjs_jhandler_t* jhandler,
   }
 
   uintptr_t ptr = 0;
-  JNativeInfoType out_native_info;
+  JNativeInfoType* out_native_info;
 
   if (jerry_get_object_native_pointer(jobj.unsafe.value, (void**)&ptr,
                                       &out_native_info)) {
@@ -865,7 +865,7 @@ static jerry_value_t iotjs_native_dispatch_function(
     const jerry_value_t jfunc, const jerry_value_t jthis,
     const jerry_value_t jargv[], const JRawLengthType jargc) {
   uintptr_t target_function_ptr = 0x0;
-  JNativeInfoType out_info;
+  JNativeInfoType* out_info;
 
   if (!jerry_get_object_native_pointer(jfunc, (void**)&target_function_ptr,
                                        &out_info)) {

--- a/src/iotjs_binding.h
+++ b/src/iotjs_binding.h
@@ -23,7 +23,7 @@
 
 
 typedef jerry_external_handler_t JHandlerType;
-typedef const jerry_object_native_info_t* JNativeInfoType;
+typedef const jerry_object_native_info_t JNativeInfoType;
 typedef jerry_length_t JRawLengthType;
 
 
@@ -131,13 +131,13 @@ void iotjs_jval_set_property_string_raw(THIS_JVAL, const char* name,
 iotjs_jval_t iotjs_jval_get_property(THIS_JVAL, const char* name);
 
 void iotjs_jval_set_object_native_handle(THIS_JVAL, uintptr_t ptr,
-                                         JNativeInfoType native_info);
+                                         JNativeInfoType* native_info);
 uintptr_t iotjs_jval_get_object_native_handle(THIS_JVAL);
 uintptr_t iotjs_jval_get_object_from_jhandler(iotjs_jhandler_t* jhandler,
-                                              JNativeInfoType native_info);
+                                              JNativeInfoType* native_info);
 uintptr_t iotjs_jval_get_arg_obj_from_jhandler(iotjs_jhandler_t* jhandler,
                                                uint16_t index,
-                                               JNativeInfoType native_info);
+                                               JNativeInfoType* native_info);
 
 void iotjs_jval_set_property_by_index(THIS_JVAL, uint32_t idx,
                                       const iotjs_jval_t* value);

--- a/src/iotjs_handlewrap.c
+++ b/src/iotjs_handlewrap.c
@@ -20,7 +20,7 @@
 void iotjs_handlewrap_initialize(iotjs_handlewrap_t* handlewrap,
                                  const iotjs_jval_t* jobject,
                                  uv_handle_t* handle,
-                                 JNativeInfoType native_info) {
+                                 JNativeInfoType* native_info) {
   IOTJS_VALIDATED_STRUCT_CONSTRUCTOR(iotjs_handlewrap_t, handlewrap);
 
   // Increase ref count of Javascript object to guarantee it is alive until the

--- a/src/iotjs_handlewrap.h
+++ b/src/iotjs_handlewrap.h
@@ -53,7 +53,7 @@ typedef struct {
 void iotjs_handlewrap_initialize(iotjs_handlewrap_t* handlewrap,
                                  const iotjs_jval_t* jobject,
                                  uv_handle_t* handle,
-                                 JNativeInfoType native_info);
+                                 JNativeInfoType* native_info);
 
 void iotjs_handlewrap_destroy(iotjs_handlewrap_t* handlewrap);
 

--- a/src/iotjs_objectwrap.c
+++ b/src/iotjs_objectwrap.c
@@ -19,7 +19,7 @@
 
 void iotjs_jobjectwrap_initialize(iotjs_jobjectwrap_t* jobjectwrap,
                                   const iotjs_jval_t* jobject,
-                                  JNativeInfoType native_info) {
+                                  JNativeInfoType* native_info) {
   IOTJS_VALIDATED_STRUCT_CONSTRUCTOR(iotjs_jobjectwrap_t, jobjectwrap);
 
   IOTJS_ASSERT(iotjs_jval_is_object(jobject));

--- a/src/iotjs_objectwrap.h
+++ b/src/iotjs_objectwrap.h
@@ -28,7 +28,7 @@ typedef struct {
 
 void iotjs_jobjectwrap_initialize(iotjs_jobjectwrap_t* jobjectwrap,
                                   const iotjs_jval_t* jobject,
-                                  JNativeInfoType native_info);
+                                  JNativeInfoType* native_info);
 
 void iotjs_jobjectwrap_destroy(iotjs_jobjectwrap_t* jobjectwrap);
 


### PR DESCRIPTION
 -the native object should be alive until adc has closed.
 -change JNativeInfoType in order to make NULL callback of native info.
 -tested on stm32f4dis and artik053.

IoT.js-DCO-1.0-Signed-off-by: Hosung Kim hs852.kim@samsung.com