### PR TITLE
Update Jerry Submodule and fix build

### DIFF
--- a/src/iotjs.c
+++ b/src/iotjs.c
@@ -92,9 +92,6 @@ static bool iotjs_jerry_initialize(iotjs_environment_t* env) {
 
 
 static void iotjs_jerry_release(iotjs_environment_t* env) {
-  if (iotjs_environment_config(env)->debugger) {
-    jerry_debugger_cleanup();
-  }
   jerry_cleanup();
 }
 


### PR DESCRIPTION
Updating the jerry submodule plus fixing the IoT.js build, since there was an update that removed the `debugger_cleanup` function, which is now done automatically within `jerry_cleanup()`

IoT.js-DCO-1.0-Signed-off-by: Daniel Balla dballa@inf.u-szeged.hu