### PR TITLE
Fix #1165 Buffer constructor is not passing encoding

### DIFF
--- a/src/js/buffer.js
+++ b/src/js/buffer.js
@@ -40,7 +40,7 @@ function checkOffset(offset, ext, length) {
 // [5] new Buffer(array)
 function Buffer(subject, encoding) {
   if (!util.isBuffer(this)) {
-    return new Buffer(subject);
+    return new Buffer(subject, encoding);
   }
 
   if (util.isNumber(subject)) {

--- a/test/run_pass/issue/issue-1165.js
+++ b/test/run_pass/issue/issue-1165.js
@@ -1,0 +1,18 @@
+/* Copyright 2017-present Samsung Electronics Co., Ltd. and other contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+var assert = require('assert');
+var s1 = Buffer('737263', 'hex').toString();
+var s2 = new Buffer('737263', 'hex').toString()
+assert(s1 === s2);


### PR DESCRIPTION
IoT.js-DCO-1.0-Signed-off-by: Sanggyu Lee sg5.lee@samsung.com