### PR TITLE
Fix coverage tool to easily run on the board

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,12 @@ vgcore.*
 cscope.*
 *.pyc
 
+# Dependency directories
+node_modules/
+
+# Coverage directory used by tools like istanbul
+coverage
+
 # ctags and ID database
 tags
 ID

--- a/tools/measure_coverage.sh
+++ b/tools/measure_coverage.sh
@@ -70,8 +70,8 @@ print_usage()
     exit 0
 }
 
-# Use JS based testrunner by default.
-test_driver="jsdriver"
+# Use Python based testrunner by default.
+test_driver="pydriver"
 
 # Parse the given arguments.
 while [[ $# -gt 0 ]]
@@ -113,7 +113,12 @@ fi
 . ~/.profile
 
 # Istanbul and babel require node version > 4.0.
-nvm install 4.0
+nvm ls 4.0.0 >> /dev/null 2>&1
+if [ "$?" -ne "0" ]; then
+    nvm install 4.0
+else
+    nvm use 4.0
+fi
 
 dpkg -l lcov >> /dev/null 2>&1 && \
 dpkg -l gcc-multilib >> /dev/null 2>&1


### PR DESCRIPTION
This patch makes the below works.

a) Set `pydriver` as default since #1197 issue still occurs with `jsdriver`.
b) Any network connection isn't needed on the board once the appropriate node version is installed.
    `nvm install 4.0` requires network access.
c) The directories related are ignored by git.

IoT.js-DCO-1.0-Signed-off-by: Daeyeon Jeong daeyeon.jeong@samsung.com