### PR TITLE
Change 'iotjs_jval_t*' function parameters to 'iotjs_jval_t' under modules directory

### DIFF
--- a/src/iotjs_binding.h
+++ b/src/iotjs_binding.h
@@ -292,9 +292,9 @@ static inline bool ge(uint16_t a, uint16_t b) {
 #define JHANDLER_GET_ARG_IF_EXIST(index, type)                          \
   ((iotjs_jhandler_get_arg_length(jhandler) > index)                    \
        ? (iotjs_jval_is_##type(iotjs_jhandler_get_arg(jhandler, index)) \
-              ? iotjs_jhandler_get_arg(jhandler, index)                 \
-              : NULL)                                                   \
-       : NULL)
+              ? *iotjs_jhandler_get_arg(jhandler, index)                \
+              : *iotjs_jval_get_null())                                 \
+       : *iotjs_jval_get_null())
 
 #define JHANDLER_GET_THIS(type) \
   iotjs_jval_as_##type(iotjs_jhandler_get_this(jhandler))

--- a/src/modules/iotjs_module_adc.c
+++ b/src/modules/iotjs_module_adc.c
@@ -211,17 +211,17 @@ JHANDLER_FUNCTION(AdcConstructor) {
   IOTJS_ASSERT(adc == iotjs_adc_instance_from_jval(jadc));
   IOTJS_VALIDATED_STRUCT_METHOD(iotjs_adc_t, adc);
 
-  const iotjs_jval_t* jconfiguration = JHANDLER_GET_ARG_IF_EXIST(0, object);
-  if (jconfiguration == NULL) {
+  const iotjs_jval_t jconfiguration = JHANDLER_GET_ARG_IF_EXIST(0, object);
+  if (jerry_value_is_null(jconfiguration)) {
     JHANDLER_THROW(TYPE, "Bad arguments - configuration should be Object");
     return;
   }
 
 #if defined(__linux__)
-  DJHANDLER_GET_REQUIRED_CONF_VALUE(jconfiguration, _this->device,
+  DJHANDLER_GET_REQUIRED_CONF_VALUE(&jconfiguration, _this->device,
                                     IOTJS_MAGIC_STRING_DEVICE, string);
 #elif defined(__NUTTX__) || defined(__TIZENRT__)
-  DJHANDLER_GET_REQUIRED_CONF_VALUE(jconfiguration, _this->pin,
+  DJHANDLER_GET_REQUIRED_CONF_VALUE(&jconfiguration, _this->pin,
                                     IOTJS_MAGIC_STRING_PIN, number);
 #endif
 
@@ -246,12 +246,12 @@ JHANDLER_FUNCTION(Read) {
   JHANDLER_DECLARE_THIS_PTR(adc, adc);
   DJHANDLER_CHECK_ARG_IF_EXIST(0, function);
 
-  const iotjs_jval_t* jcallback = JHANDLER_GET_ARG_IF_EXIST(0, function);
+  const iotjs_jval_t jcallback = JHANDLER_GET_ARG_IF_EXIST(0, function);
 
-  if (jcallback == NULL) {
+  if (jerry_value_is_null(jcallback)) {
     JHANDLER_THROW(TYPE, "Bad arguments - callback required");
   } else {
-    ADC_ASYNC(read, adc, jcallback, kAdcOpRead);
+    ADC_ASYNC(read, adc, &jcallback, kAdcOpRead);
   }
 }
 
@@ -270,16 +270,15 @@ JHANDLER_FUNCTION(Close) {
   JHANDLER_DECLARE_THIS_PTR(adc, adc);
   DJHANDLER_CHECK_ARG_IF_EXIST(0, function);
 
-  const iotjs_jval_t* jcallback =
-      (iotjs_jval_t*)JHANDLER_GET_ARG_IF_EXIST(0, function);
+  iotjs_jval_t jcallback = JHANDLER_GET_ARG_IF_EXIST(0, function);
 
-  if (jcallback == NULL) {
+  if (jerry_value_is_null(jcallback)) {
     iotjs_jval_t jdummycallback =
         iotjs_jval_create_function(&iotjs_jval_dummy_function);
     ADC_ASYNC(close, adc, &jdummycallback, kAdcOpClose);
     iotjs_jval_destroy(&jdummycallback);
   } else {
-    ADC_ASYNC(close, adc, jcallback, kAdcOpClose);
+    ADC_ASYNC(close, adc, &jcallback, kAdcOpClose);
   }
 
   iotjs_jhandler_return_null(jhandler);

--- a/src/modules/iotjs_module_blehcisocket.c
+++ b/src/modules/iotjs_module_blehcisocket.c
@@ -144,7 +144,7 @@ JHANDLER_FUNCTION(SetFilter) {
   DJHANDLER_CHECK_ARGS(1, object);
 
   iotjs_bufferwrap_t* buffer =
-      iotjs_bufferwrap_from_jbuffer(JHANDLER_GET_ARG(0, object));
+      iotjs_bufferwrap_from_jbuffer(*JHANDLER_GET_ARG(0, object));
 
   iotjs_blehcisocket_setFilter(blehcisocket, iotjs_bufferwrap_buffer(buffer),
                                iotjs_bufferwrap_length(buffer));
@@ -168,7 +168,7 @@ JHANDLER_FUNCTION(Write) {
   DJHANDLER_CHECK_ARGS(1, object);
 
   iotjs_bufferwrap_t* buffer =
-      iotjs_bufferwrap_from_jbuffer(JHANDLER_GET_ARG(0, object));
+      iotjs_bufferwrap_from_jbuffer(*JHANDLER_GET_ARG(0, object));
 
   iotjs_blehcisocket_write(blehcisocket, iotjs_bufferwrap_buffer(buffer),
                            iotjs_bufferwrap_length(buffer));

--- a/src/modules/iotjs_module_buffer.c
+++ b/src/modules/iotjs_module_buffer.c
@@ -24,12 +24,12 @@
 IOTJS_DEFINE_NATIVE_HANDLE_INFO_THIS_MODULE(bufferwrap);
 
 
-iotjs_bufferwrap_t* iotjs_bufferwrap_create(const iotjs_jval_t* jbuiltin,
+iotjs_bufferwrap_t* iotjs_bufferwrap_create(const iotjs_jval_t jbuiltin,
                                             size_t length) {
   iotjs_bufferwrap_t* bufferwrap = IOTJS_ALLOC(iotjs_bufferwrap_t);
   IOTJS_VALIDATED_STRUCT_CONSTRUCTOR(iotjs_bufferwrap_t, bufferwrap);
 
-  iotjs_jobjectwrap_initialize(&_this->jobjectwrap, jbuiltin,
+  iotjs_jobjectwrap_initialize(&_this->jobjectwrap, &jbuiltin,
                                &this_module_native_info);
   if (length > 0) {
     _this->length = length;
@@ -42,7 +42,7 @@ iotjs_bufferwrap_t* iotjs_bufferwrap_create(const iotjs_jval_t* jbuiltin,
 
   IOTJS_ASSERT(
       bufferwrap ==
-      (iotjs_bufferwrap_t*)(iotjs_jval_get_object_native_handle(jbuiltin)));
+      (iotjs_bufferwrap_t*)(iotjs_jval_get_object_native_handle(&jbuiltin)));
 
   return bufferwrap;
 }
@@ -59,35 +59,35 @@ static void iotjs_bufferwrap_destroy(iotjs_bufferwrap_t* bufferwrap) {
 
 
 iotjs_bufferwrap_t* iotjs_bufferwrap_from_jbuiltin(
-    const iotjs_jval_t* jbuiltin) {
-  IOTJS_ASSERT(iotjs_jval_is_object(jbuiltin));
+    const iotjs_jval_t jbuiltin) {
+  IOTJS_ASSERT(iotjs_jval_is_object(&jbuiltin));
   iotjs_bufferwrap_t* buffer =
-      (iotjs_bufferwrap_t*)iotjs_jval_get_object_native_handle(jbuiltin);
+      (iotjs_bufferwrap_t*)iotjs_jval_get_object_native_handle(&jbuiltin);
   IOTJS_ASSERT(buffer != NULL);
   return buffer;
 }
 
 
-iotjs_bufferwrap_t* iotjs_bufferwrap_from_jbuffer(const iotjs_jval_t* jbuffer) {
-  IOTJS_ASSERT(iotjs_jval_is_object(jbuffer));
+iotjs_bufferwrap_t* iotjs_bufferwrap_from_jbuffer(const iotjs_jval_t jbuffer) {
+  IOTJS_ASSERT(iotjs_jval_is_object(&jbuffer));
   iotjs_jval_t jbuiltin =
-      iotjs_jval_get_property(jbuffer, IOTJS_MAGIC_STRING__BUILTIN);
-  iotjs_bufferwrap_t* buffer = iotjs_bufferwrap_from_jbuiltin(&jbuiltin);
+      iotjs_jval_get_property(&jbuffer, IOTJS_MAGIC_STRING__BUILTIN);
+  iotjs_bufferwrap_t* buffer = iotjs_bufferwrap_from_jbuiltin(jbuiltin);
   iotjs_jval_destroy(&jbuiltin);
   return buffer;
 }
 
 
-iotjs_jval_t* iotjs_bufferwrap_jbuiltin(iotjs_bufferwrap_t* bufferwrap) {
+iotjs_jval_t iotjs_bufferwrap_jbuiltin(iotjs_bufferwrap_t* bufferwrap) {
   IOTJS_VALIDATED_STRUCT_METHOD(iotjs_bufferwrap_t, bufferwrap);
-  return iotjs_jobjectwrap_jobject(&_this->jobjectwrap);
+  return *iotjs_jobjectwrap_jobject(&_this->jobjectwrap);
 }
 
 
 iotjs_jval_t iotjs_bufferwrap_jbuffer(iotjs_bufferwrap_t* bufferwrap) {
   IOTJS_VALIDATABLE_STRUCT_METHOD_VALIDATE(iotjs_bufferwrap_t, bufferwrap);
-  iotjs_jval_t* jbuiltin = iotjs_bufferwrap_jbuiltin(bufferwrap);
-  return iotjs_jval_get_property(jbuiltin, IOTJS_MAGIC_STRING__BUFFER);
+  iotjs_jval_t jbuiltin = iotjs_bufferwrap_jbuiltin(bufferwrap);
+  return iotjs_jval_get_property(&jbuiltin, IOTJS_MAGIC_STRING__BUFFER);
 }
 
 
@@ -213,10 +213,10 @@ size_t iotjs_bufferwrap_copy(iotjs_bufferwrap_t* bufferwrap, const char* src,
 
 
 iotjs_jval_t iotjs_bufferwrap_create_buffer(size_t len) {
-  iotjs_jval_t* jglobal = iotjs_jval_get_global_object();
+  iotjs_jval_t jglobal = *iotjs_jval_get_global_object();
 
   iotjs_jval_t jbuffer =
-      iotjs_jval_get_property(jglobal, IOTJS_MAGIC_STRING_BUFFER);
+      iotjs_jval_get_property(&jglobal, IOTJS_MAGIC_STRING_BUFFER);
   IOTJS_ASSERT(iotjs_jval_is_function(&jbuffer));
 
   iotjs_jargs_t jargs = iotjs_jargs_create(1);
@@ -237,11 +237,11 @@ JHANDLER_FUNCTION(Buffer) {
   DJHANDLER_CHECK_THIS(object);
   DJHANDLER_CHECK_ARGS(2, object, number);
 
-  const iotjs_jval_t* jbuiltin = JHANDLER_GET_THIS(object);
-  const iotjs_jval_t* jbuffer = JHANDLER_GET_ARG(0, object);
+  const iotjs_jval_t jbuiltin = *JHANDLER_GET_THIS(object);
+  const iotjs_jval_t jbuffer = *JHANDLER_GET_ARG(0, object);
   size_t length = JHANDLER_GET_ARG(1, number);
 
-  iotjs_jval_set_property_jval(jbuiltin, IOTJS_MAGIC_STRING__BUFFER, jbuffer);
+  iotjs_jval_set_property_jval(&jbuiltin, IOTJS_MAGIC_STRING__BUFFER, &jbuffer);
 
   iotjs_bufferwrap_t* buffer_wrap = iotjs_bufferwrap_create(jbuiltin, length);
   IOTJS_UNUSED(buffer_wrap);
@@ -261,7 +261,7 @@ JHANDLER_FUNCTION(Copy) {
   JHANDLER_DECLARE_THIS_PTR(bufferwrap, src_buffer_wrap);
   DJHANDLER_CHECK_ARGS(4, object, number, number, number);
 
-  const iotjs_jval_t* jdst_buffer = JHANDLER_GET_ARG(0, object);
+  const iotjs_jval_t jdst_buffer = *JHANDLER_GET_ARG(0, object);
   iotjs_bufferwrap_t* dst_buffer_wrap =
       iotjs_bufferwrap_from_jbuffer(jdst_buffer);
 
@@ -421,7 +421,7 @@ JHANDLER_FUNCTION(Slice) {
 
   iotjs_jval_t jnew_buffer = iotjs_bufferwrap_create_buffer(length);
   iotjs_bufferwrap_t* new_buffer_wrap =
-      iotjs_bufferwrap_from_jbuffer(&jnew_buffer);
+      iotjs_bufferwrap_from_jbuffer(jnew_buffer);
   iotjs_bufferwrap_copy_internal(new_buffer_wrap,
                                  iotjs_bufferwrap_buffer(buffer_wrap),
                                  start_idx, end_idx, 0);

--- a/src/modules/iotjs_module_buffer.h
+++ b/src/modules/iotjs_module_buffer.h
@@ -27,14 +27,13 @@ typedef struct {
 } IOTJS_VALIDATED_STRUCT(iotjs_bufferwrap_t);
 
 
-iotjs_bufferwrap_t* iotjs_bufferwrap_create(const iotjs_jval_t* jbuiltin,
+iotjs_bufferwrap_t* iotjs_bufferwrap_create(const iotjs_jval_t jbuiltin,
                                             size_t length);
 
-iotjs_bufferwrap_t* iotjs_bufferwrap_from_jbuiltin(
-    const iotjs_jval_t* jbuiltin);
-iotjs_bufferwrap_t* iotjs_bufferwrap_from_jbuffer(const iotjs_jval_t* jbuffer);
+iotjs_bufferwrap_t* iotjs_bufferwrap_from_jbuiltin(const iotjs_jval_t jbuiltin);
+iotjs_bufferwrap_t* iotjs_bufferwrap_from_jbuffer(const iotjs_jval_t jbuffer);
 
-iotjs_jval_t* iotjs_bufferwrap_jbuiltin(iotjs_bufferwrap_t* bufferwrap);
+iotjs_jval_t iotjs_bufferwrap_jbuiltin(iotjs_bufferwrap_t* bufferwrap);
 iotjs_jval_t iotjs_bufferwrap_jbuffer(iotjs_bufferwrap_t* bufferwrap);
 
 char* iotjs_bufferwrap_buffer(iotjs_bufferwrap_t* bufferwrap);

--- a/src/modules/iotjs_module_dns.h
+++ b/src/modules/iotjs_module_dns.h
@@ -30,12 +30,12 @@ typedef struct {
 #define THIS iotjs_getaddrinfo_reqwrap_t* getaddrinfo_reqwrap
 
 iotjs_getaddrinfo_reqwrap_t* iotjs_getaddrinfo_reqwrap_create(
-    const iotjs_jval_t* jcallback);
+    const iotjs_jval_t jcallback);
 
 void iotjs_getaddrinfo_reqwrap_dispatched(THIS);
 
 uv_getaddrinfo_t* iotjs_getaddrinfo_reqwrap_req(THIS);
-const iotjs_jval_t* iotjs_getaddrinfo_reqwrap_jcallback(THIS);
+iotjs_jval_t iotjs_getaddrinfo_reqwrap_jcallback(THIS);
 
 #undef THIS
 

--- a/src/modules/iotjs_module_fs.c
+++ b/src/modules/iotjs_module_fs.c
@@ -27,9 +27,9 @@ typedef struct {
 } iotjs_fs_reqwrap_t;
 
 
-iotjs_fs_reqwrap_t* iotjs_fs_reqwrap_create(const iotjs_jval_t* jcallback) {
+iotjs_fs_reqwrap_t* iotjs_fs_reqwrap_create(const iotjs_jval_t jcallback) {
   iotjs_fs_reqwrap_t* fs_reqwrap = IOTJS_ALLOC(iotjs_fs_reqwrap_t);
-  iotjs_reqwrap_initialize(&fs_reqwrap->reqwrap, jcallback,
+  iotjs_reqwrap_initialize(&fs_reqwrap->reqwrap, &jcallback,
                            (uv_req_t*)&fs_reqwrap->req);
   return fs_reqwrap;
 }
@@ -197,9 +197,9 @@ JHANDLER_FUNCTION(Close) {
   const iotjs_environment_t* env = iotjs_environment_get();
 
   int fd = JHANDLER_GET_ARG(0, number);
-  const iotjs_jval_t* jcallback = JHANDLER_GET_ARG_IF_EXIST(1, function);
+  const iotjs_jval_t jcallback = JHANDLER_GET_ARG_IF_EXIST(1, function);
 
-  if (jcallback) {
+  if (!jerry_value_is_null(jcallback)) {
     FS_ASYNC(env, close, jcallback, fd);
   } else {
     FS_SYNC(env, close, fd);
@@ -217,9 +217,9 @@ JHANDLER_FUNCTION(Open) {
   iotjs_string_t path = JHANDLER_GET_ARG(0, string);
   int flags = JHANDLER_GET_ARG(1, number);
   int mode = JHANDLER_GET_ARG(2, number);
-  const iotjs_jval_t* jcallback = JHANDLER_GET_ARG_IF_EXIST(3, function);
+  const iotjs_jval_t jcallback = JHANDLER_GET_ARG_IF_EXIST(3, function);
 
-  if (jcallback) {
+  if (!jerry_value_is_null(jcallback)) {
     FS_ASYNC(env, open, jcallback, iotjs_string_data(&path), flags, mode);
   } else {
     FS_SYNC(env, open, iotjs_string_data(&path), flags, mode);
@@ -237,11 +237,11 @@ JHANDLER_FUNCTION(Read) {
   const iotjs_environment_t* env = iotjs_environment_get();
 
   int fd = JHANDLER_GET_ARG(0, number);
-  const iotjs_jval_t* jbuffer = JHANDLER_GET_ARG(1, object);
+  const iotjs_jval_t jbuffer = *JHANDLER_GET_ARG(1, object);
   size_t offset = JHANDLER_GET_ARG(2, number);
   size_t length = JHANDLER_GET_ARG(3, number);
   int position = JHANDLER_GET_ARG(4, number);
-  const iotjs_jval_t* jcallback = JHANDLER_GET_ARG_IF_EXIST(5, function);
+  const iotjs_jval_t jcallback = JHANDLER_GET_ARG_IF_EXIST(5, function);
 
   iotjs_bufferwrap_t* buffer_wrap = iotjs_bufferwrap_from_jbuffer(jbuffer);
   char* data = iotjs_bufferwrap_buffer(buffer_wrap);
@@ -260,7 +260,7 @@ JHANDLER_FUNCTION(Read) {
 
   uv_buf_t uvbuf = uv_buf_init(data + offset, length);
 
-  if (jcallback) {
+  if (!jerry_value_is_null(jcallback)) {
     FS_ASYNC(env, read, jcallback, fd, &uvbuf, 1, position);
   } else {
     FS_SYNC(env, read, fd, &uvbuf, 1, position);
@@ -276,11 +276,11 @@ JHANDLER_FUNCTION(Write) {
   const iotjs_environment_t* env = iotjs_environment_get();
 
   int fd = JHANDLER_GET_ARG(0, number);
-  const iotjs_jval_t* jbuffer = JHANDLER_GET_ARG(1, object);
+  const iotjs_jval_t jbuffer = *JHANDLER_GET_ARG(1, object);
   size_t offset = JHANDLER_GET_ARG(2, number);
   size_t length = JHANDLER_GET_ARG(3, number);
   int position = JHANDLER_GET_ARG(4, number);
-  const iotjs_jval_t* jcallback = JHANDLER_GET_ARG_IF_EXIST(5, function);
+  const iotjs_jval_t jcallback = JHANDLER_GET_ARG_IF_EXIST(5, function);
 
   iotjs_bufferwrap_t* buffer_wrap = iotjs_bufferwrap_from_jbuffer(jbuffer);
   char* data = iotjs_bufferwrap_buffer(buffer_wrap);
@@ -299,7 +299,7 @@ JHANDLER_FUNCTION(Write) {
 
   uv_buf_t uvbuf = uv_buf_init(data + offset, length);
 
-  if (jcallback) {
+  if (!jerry_value_is_null(jcallback)) {
     FS_ASYNC(env, write, jcallback, fd, &uvbuf, 1, position);
   } else {
     FS_SYNC(env, write, fd, &uvbuf, 1, position);
@@ -348,9 +348,9 @@ JHANDLER_FUNCTION(Stat) {
   const iotjs_environment_t* env = iotjs_environment_get();
 
   iotjs_string_t path = JHANDLER_GET_ARG(0, string);
-  const iotjs_jval_t* jcallback = JHANDLER_GET_ARG_IF_EXIST(1, function);
+  const iotjs_jval_t jcallback = JHANDLER_GET_ARG_IF_EXIST(1, function);
 
-  if (jcallback) {
+  if (!jerry_value_is_null(jcallback)) {
     FS_ASYNC(env, stat, jcallback, iotjs_string_data(&path));
   } else {
     FS_SYNC(env, stat, iotjs_string_data(&path));
@@ -368,9 +368,9 @@ JHANDLER_FUNCTION(Fstat) {
   const iotjs_environment_t* env = iotjs_environment_get();
 
   int fd = JHANDLER_GET_ARG(0, number);
-  const iotjs_jval_t* jcallback = JHANDLER_GET_ARG_IF_EXIST(1, function);
+  const iotjs_jval_t jcallback = JHANDLER_GET_ARG_IF_EXIST(1, function);
 
-  if (jcallback) {
+  if (!jerry_value_is_null(jcallback)) {
     FS_ASYNC(env, fstat, jcallback, fd);
   } else {
     FS_SYNC(env, fstat, fd);
@@ -387,9 +387,9 @@ JHANDLER_FUNCTION(MkDir) {
 
   iotjs_string_t path = JHANDLER_GET_ARG(0, string);
   int mode = JHANDLER_GET_ARG(1, number);
-  const iotjs_jval_t* jcallback = JHANDLER_GET_ARG_IF_EXIST(2, function);
+  const iotjs_jval_t jcallback = JHANDLER_GET_ARG_IF_EXIST(2, function);
 
-  if (jcallback) {
+  if (!jerry_value_is_null(jcallback)) {
     FS_ASYNC(env, mkdir, jcallback, iotjs_string_data(&path), mode);
   } else {
     FS_SYNC(env, mkdir, iotjs_string_data(&path), mode);
@@ -407,9 +407,9 @@ JHANDLER_FUNCTION(RmDir) {
   const iotjs_environment_t* env = iotjs_environment_get();
 
   iotjs_string_t path = JHANDLER_GET_ARG(0, string);
-  const iotjs_jval_t* jcallback = JHANDLER_GET_ARG_IF_EXIST(1, function);
+  const iotjs_jval_t jcallback = JHANDLER_GET_ARG_IF_EXIST(1, function);
 
-  if (jcallback) {
+  if (!jerry_value_is_null(jcallback)) {
     FS_ASYNC(env, rmdir, jcallback, iotjs_string_data(&path));
   } else {
     FS_SYNC(env, rmdir, iotjs_string_data(&path));
@@ -427,9 +427,9 @@ JHANDLER_FUNCTION(Unlink) {
   const iotjs_environment_t* env = iotjs_environment_get();
 
   iotjs_string_t path = JHANDLER_GET_ARG(0, string);
-  const iotjs_jval_t* jcallback = JHANDLER_GET_ARG_IF_EXIST(1, function);
+  const iotjs_jval_t jcallback = JHANDLER_GET_ARG_IF_EXIST(1, function);
 
-  if (jcallback) {
+  if (!jerry_value_is_null(jcallback)) {
     FS_ASYNC(env, unlink, jcallback, iotjs_string_data(&path));
   } else {
     FS_SYNC(env, unlink, iotjs_string_data(&path));
@@ -448,9 +448,9 @@ JHANDLER_FUNCTION(Rename) {
 
   iotjs_string_t oldPath = JHANDLER_GET_ARG(0, string);
   iotjs_string_t newPath = JHANDLER_GET_ARG(1, string);
-  const iotjs_jval_t* jcallback = JHANDLER_GET_ARG_IF_EXIST(2, function);
+  const iotjs_jval_t jcallback = JHANDLER_GET_ARG_IF_EXIST(2, function);
 
-  if (jcallback) {
+  if (!jerry_value_is_null(jcallback)) {
     FS_ASYNC(env, rename, jcallback, iotjs_string_data(&oldPath),
              iotjs_string_data(&newPath));
   } else {
@@ -470,9 +470,9 @@ JHANDLER_FUNCTION(ReadDir) {
 
   const iotjs_environment_t* env = iotjs_environment_get();
   iotjs_string_t path = JHANDLER_GET_ARG(0, string);
-  const iotjs_jval_t* jcallback = JHANDLER_GET_ARG_IF_EXIST(1, function);
+  const iotjs_jval_t jcallback = JHANDLER_GET_ARG_IF_EXIST(1, function);
 
-  if (jcallback) {
+  if (!jerry_value_is_null(jcallback)) {
     FS_ASYNC(env, scandir, jcallback, iotjs_string_data(&path), 0);
   } else {
     FS_SYNC(env, scandir, iotjs_string_data(&path), 0);

--- a/src/modules/iotjs_module_gpio.c
+++ b/src/modules/iotjs_module_gpio.c
@@ -273,12 +273,12 @@ JHANDLER_FUNCTION(Write) {
   DJHANDLER_CHECK_ARGS(1, boolean);
   DJHANDLER_CHECK_ARG_IF_EXIST(1, function);
 
-  const iotjs_jval_t* jcallback = JHANDLER_GET_ARG_IF_EXIST(1, function);
+  const iotjs_jval_t jcallback = JHANDLER_GET_ARG_IF_EXIST(1, function);
 
   bool value = JHANDLER_GET_ARG(0, boolean);
 
-  if (jcallback) {
-    GPIO_ASYNC_WITH_VALUE(write, gpio, jcallback, kGpioOpWrite, value);
+  if (!jerry_value_is_null(jcallback)) {
+    GPIO_ASYNC_WITH_VALUE(write, gpio, &jcallback, kGpioOpWrite, value);
   } else {
     if (!iotjs_gpio_write(gpio, value)) {
       JHANDLER_THROW(COMMON, "GPIO WriteSync Error");
@@ -294,10 +294,10 @@ JHANDLER_FUNCTION(Read) {
   DJHANDLER_CHECK_ARGS(0);
   DJHANDLER_CHECK_ARG_IF_EXIST(0, function);
 
-  const iotjs_jval_t* jcallback = JHANDLER_GET_ARG_IF_EXIST(0, function);
+  const iotjs_jval_t jcallback = JHANDLER_GET_ARG_IF_EXIST(0, function);
 
-  if (jcallback) {
-    GPIO_ASYNC(read, gpio, jcallback, kGpioOpRead);
+  if (!jerry_value_is_null(jcallback)) {
+    GPIO_ASYNC(read, gpio, &jcallback, kGpioOpRead);
     iotjs_jhandler_return_null(jhandler);
   } else {
     int value = iotjs_gpio_read(gpio);
@@ -313,10 +313,10 @@ JHANDLER_FUNCTION(Close) {
   JHANDLER_DECLARE_THIS_PTR(gpio, gpio)
   DJHANDLER_CHECK_ARG_IF_EXIST(0, function);
 
-  const iotjs_jval_t* jcallback = JHANDLER_GET_ARG_IF_EXIST(0, function);
+  const iotjs_jval_t jcallback = JHANDLER_GET_ARG_IF_EXIST(0, function);
 
-  if (jcallback) {
-    GPIO_ASYNC(close, gpio, jcallback, kGpioOpClose);
+  if (!jerry_value_is_null(jcallback)) {
+    GPIO_ASYNC(close, gpio, &jcallback, kGpioOpClose);
   } else {
     if (!iotjs_gpio_close(gpio)) {
       JHANDLER_THROW(COMMON, "GPIO CloseSync Error");

--- a/src/modules/iotjs_module_httpparser.c
+++ b/src/modules/iotjs_module_httpparser.c
@@ -46,7 +46,7 @@ typedef struct {
   size_t n_fields;
   size_t n_values;
 
-  iotjs_jval_t* cur_jbuf;
+  iotjs_jval_t cur_jbuf;
   char* cur_buf;
   size_t cur_buf_len;
 
@@ -66,7 +66,7 @@ static void iotjs_httpparserwrap_initialize(
   _this->n_fields = 0;
   _this->n_values = 0;
   _this->flushed = false;
-  _this->cur_jbuf = NULL;
+  _this->cur_jbuf = *iotjs_jval_get_null();
   _this->cur_buf = NULL;
   _this->cur_buf_len = 0;
 }
@@ -75,11 +75,11 @@ static void iotjs_httpparserwrap_initialize(
 IOTJS_DEFINE_NATIVE_HANDLE_INFO_THIS_MODULE(httpparserwrap);
 
 
-static void iotjs_httpparserwrap_create(const iotjs_jval_t* jparser,
+static void iotjs_httpparserwrap_create(const iotjs_jval_t jparser,
                                         http_parser_type type) {
   iotjs_httpparserwrap_t* httpparserwrap = IOTJS_ALLOC(iotjs_httpparserwrap_t);
   IOTJS_VALIDATED_STRUCT_CONSTRUCTOR(iotjs_httpparserwrap_t, httpparserwrap);
-  iotjs_jobjectwrap_initialize(&_this->jobjectwrap, jparser,
+  iotjs_jobjectwrap_initialize(&_this->jobjectwrap, &jparser,
                                &this_module_native_info);
 
   _this->url = iotjs_string_create();
@@ -131,9 +131,9 @@ static iotjs_jval_t iotjs_httpparserwrap_make_header(
 
 static void iotjs_httpparserwrap_flush(iotjs_httpparserwrap_t* httpparserwrap) {
   IOTJS_VALIDATED_STRUCT_METHOD(iotjs_httpparserwrap_t, httpparserwrap);
-  const iotjs_jval_t* jobj = iotjs_jobjectwrap_jobject(&_this->jobjectwrap);
+  const iotjs_jval_t jobj = *iotjs_jobjectwrap_jobject(&_this->jobjectwrap);
   iotjs_jval_t func =
-      iotjs_jval_get_property(jobj, IOTJS_MAGIC_STRING_ONHEADERS);
+      iotjs_jval_get_property(&jobj, IOTJS_MAGIC_STRING_ONHEADERS);
   IOTJS_ASSERT(iotjs_jval_is_function(&func));
 
   iotjs_jargs_t argv = iotjs_jargs_create(2);
@@ -145,7 +145,7 @@ static void iotjs_httpparserwrap_flush(iotjs_httpparserwrap_t* httpparserwrap) {
     iotjs_jargs_append_string(&argv, &_this->url);
   }
 
-  iotjs_make_callback(&func, jobj, &argv);
+  iotjs_make_callback(&func, &jobj, &argv);
 
   iotjs_string_make_empty(&_this->url);
   iotjs_jargs_destroy(&argv);
@@ -155,7 +155,7 @@ static void iotjs_httpparserwrap_flush(iotjs_httpparserwrap_t* httpparserwrap) {
 
 
 static void iotjs_httpparserwrap_set_buf(iotjs_httpparserwrap_t* httpparserwrap,
-                                         iotjs_jval_t* jbuf, char* buf,
+                                         iotjs_jval_t jbuf, char* buf,
                                          size_t sz) {
   IOTJS_VALIDATED_STRUCT_METHOD(iotjs_httpparserwrap_t, httpparserwrap);
   _this->cur_jbuf = jbuf;
@@ -240,9 +240,9 @@ static int iotjs_httpparserwrap_on_headers_complete(http_parser* parser) {
   iotjs_httpparserwrap_t* httpparserwrap =
       (iotjs_httpparserwrap_t*)(parser->data);
   IOTJS_VALIDATED_STRUCT_METHOD(iotjs_httpparserwrap_t, httpparserwrap);
-  const iotjs_jval_t* jobj = iotjs_jobjectwrap_jobject(&_this->jobjectwrap);
+  const iotjs_jval_t jobj = *iotjs_jobjectwrap_jobject(&_this->jobjectwrap);
   iotjs_jval_t func =
-      iotjs_jval_get_property(jobj, IOTJS_MAGIC_STRING_ONHEADERSCOMPLETE);
+      iotjs_jval_get_property(&jobj, IOTJS_MAGIC_STRING_ONHEADERSCOMPLETE);
   IOTJS_ASSERT(iotjs_jval_is_function(&func));
 
   // URL
@@ -294,7 +294,7 @@ static int iotjs_httpparserwrap_on_headers_complete(http_parser* parser) {
 
   iotjs_jargs_append_jval(&argv, &info);
 
-  iotjs_jval_t res = iotjs_make_callback_with_result(&func, jobj, &argv);
+  iotjs_jval_t res = iotjs_make_callback_with_result(&func, &jobj, &argv);
 
   int ret = 1;
   if (iotjs_jval_is_boolean(&res)) {
@@ -319,17 +319,17 @@ static int iotjs_httpparserwrap_on_body(http_parser* parser, const char* at,
   iotjs_httpparserwrap_t* httpparserwrap =
       (iotjs_httpparserwrap_t*)(parser->data);
   IOTJS_VALIDATED_STRUCT_METHOD(iotjs_httpparserwrap_t, httpparserwrap);
-  const iotjs_jval_t* jobj = iotjs_jobjectwrap_jobject(&_this->jobjectwrap);
-  iotjs_jval_t func = iotjs_jval_get_property(jobj, IOTJS_MAGIC_STRING_ONBODY);
+  const iotjs_jval_t jobj = *iotjs_jobjectwrap_jobject(&_this->jobjectwrap);
+  iotjs_jval_t func = iotjs_jval_get_property(&jobj, IOTJS_MAGIC_STRING_ONBODY);
   IOTJS_ASSERT(iotjs_jval_is_function(&func));
 
   iotjs_jargs_t argv = iotjs_jargs_create(3);
-  iotjs_jargs_append_jval(&argv, _this->cur_jbuf);
+  iotjs_jargs_append_jval(&argv, &_this->cur_jbuf);
   iotjs_jargs_append_number(&argv, at - _this->cur_buf);
   iotjs_jargs_append_number(&argv, length);
 
 
-  iotjs_make_callback(&func, jobj, &argv);
+  iotjs_make_callback(&func, &jobj, &argv);
 
   iotjs_jargs_destroy(&argv);
   iotjs_jval_destroy(&func);
@@ -342,12 +342,12 @@ static int iotjs_httpparserwrap_on_message_complete(http_parser* parser) {
   iotjs_httpparserwrap_t* httpparserwrap =
       (iotjs_httpparserwrap_t*)(parser->data);
   IOTJS_VALIDATED_STRUCT_METHOD(iotjs_httpparserwrap_t, httpparserwrap);
-  const iotjs_jval_t* jobj = iotjs_jobjectwrap_jobject(&_this->jobjectwrap);
+  const iotjs_jval_t jobj = *iotjs_jobjectwrap_jobject(&_this->jobjectwrap);
   iotjs_jval_t func =
-      iotjs_jval_get_property(jobj, IOTJS_MAGIC_STRING_ONMESSAGECOMPLETE);
+      iotjs_jval_get_property(&jobj, IOTJS_MAGIC_STRING_ONMESSAGECOMPLETE);
   IOTJS_ASSERT(iotjs_jval_is_function(&func));
 
-  iotjs_make_callback(&func, jobj, iotjs_jargs_get_empty());
+  iotjs_make_callback(&func, &jobj, iotjs_jargs_get_empty());
 
   iotjs_jval_destroy(&func);
 
@@ -413,22 +413,21 @@ JHANDLER_FUNCTION(Execute) {
   JHANDLER_DECLARE_THIS_PTR(httpparserwrap, parser);
   DJHANDLER_CHECK_ARGS(1, object);
 
-  const iotjs_jval_t* jbuffer = JHANDLER_GET_ARG(0, object);
+  iotjs_jval_t jbuffer = *JHANDLER_GET_ARG(0, object);
   iotjs_bufferwrap_t* buffer_wrap = iotjs_bufferwrap_from_jbuffer(jbuffer);
   char* buf_data = iotjs_bufferwrap_buffer(buffer_wrap);
   size_t buf_len = iotjs_bufferwrap_length(buffer_wrap);
   JHANDLER_CHECK(buf_data != NULL);
   JHANDLER_CHECK(buf_len > 0);
 
-  iotjs_httpparserwrap_set_buf(parser, (iotjs_jval_t*)jbuffer, buf_data,
-                               buf_len);
+  iotjs_httpparserwrap_set_buf(parser, jbuffer, buf_data, buf_len);
 
   IOTJS_VALIDATED_STRUCT_METHOD(iotjs_httpparserwrap_t, parser);
   http_parser* nativeparser = &_this->parser;
   size_t nparsed =
       http_parser_execute(nativeparser, &settings, buf_data, buf_len);
 
-  iotjs_httpparserwrap_set_buf(parser, NULL, NULL, 0);
+  iotjs_httpparserwrap_set_buf(parser, *iotjs_jval_get_null(), NULL, 0);
 
 
   if (!nativeparser->upgrade && nparsed != buf_len) {
@@ -462,7 +461,7 @@ JHANDLER_FUNCTION(HTTPParserCons) {
   DJHANDLER_CHECK_THIS(object);
   DJHANDLER_CHECK_ARGS(1, number);
 
-  const iotjs_jval_t* jparser = JHANDLER_GET_THIS(object);
+  const iotjs_jval_t jparser = *JHANDLER_GET_THIS(object);
 
   http_parser_type httpparser_type =
       (http_parser_type)(JHANDLER_GET_ARG(0, number));

--- a/src/modules/iotjs_module_pwm.c
+++ b/src/modules/iotjs_module_pwm.c
@@ -271,13 +271,13 @@ JHANDLER_FUNCTION(SetPeriod) {
   DJHANDLER_CHECK_ARGS(1, number);
   DJHANDLER_CHECK_ARG_IF_EXIST(1, function);
 
-  const iotjs_jval_t* jcallback = JHANDLER_GET_ARG_IF_EXIST(1, function);
+  const iotjs_jval_t jcallback = JHANDLER_GET_ARG_IF_EXIST(1, function);
 
   IOTJS_VALIDATED_STRUCT_METHOD(iotjs_pwm_t, pwm);
   _this->period = JHANDLER_GET_ARG(0, number);
 
-  if (jcallback) {
-    PWM_ASYNC_COMMON_WORKER(iotjs_pwm_set_period, pwm, jcallback,
+  if (!jerry_value_is_null(jcallback)) {
+    PWM_ASYNC_COMMON_WORKER(iotjs_pwm_set_period, pwm, &jcallback,
                             kPwmOpSetPeriod);
   } else {
     if (!iotjs_pwm_set_period(pwm)) {
@@ -295,13 +295,13 @@ JHANDLER_FUNCTION(SetDutyCycle) {
   DJHANDLER_CHECK_ARGS(1, number);
   DJHANDLER_CHECK_ARG_IF_EXIST(1, function);
 
-  const iotjs_jval_t* jcallback = JHANDLER_GET_ARG_IF_EXIST(1, function);
+  const iotjs_jval_t jcallback = JHANDLER_GET_ARG_IF_EXIST(1, function);
 
   IOTJS_VALIDATED_STRUCT_METHOD(iotjs_pwm_t, pwm);
   _this->duty_cycle = JHANDLER_GET_ARG(0, number);
 
-  if (jcallback) {
-    PWM_ASYNC_COMMON_WORKER(iotjs_pwm_set_dutycycle, pwm, jcallback,
+  if (!jerry_value_is_null(jcallback)) {
+    PWM_ASYNC_COMMON_WORKER(iotjs_pwm_set_dutycycle, pwm, &jcallback,
                             kPwmOpSetDutyCycle);
   } else {
     if (!iotjs_pwm_set_dutycycle(pwm)) {
@@ -319,13 +319,13 @@ JHANDLER_FUNCTION(SetEnable) {
   DJHANDLER_CHECK_ARGS(1, boolean);
   DJHANDLER_CHECK_ARG_IF_EXIST(1, function);
 
-  const iotjs_jval_t* jcallback = JHANDLER_GET_ARG_IF_EXIST(1, function);
+  const iotjs_jval_t jcallback = JHANDLER_GET_ARG_IF_EXIST(1, function);
 
   IOTJS_VALIDATED_STRUCT_METHOD(iotjs_pwm_t, pwm);
   _this->enable = JHANDLER_GET_ARG(0, boolean);
 
-  if (jcallback) {
-    PWM_ASYNC_COMMON_WORKER(iotjs_pwm_set_enable, pwm, jcallback,
+  if (!jerry_value_is_null(jcallback)) {
+    PWM_ASYNC_COMMON_WORKER(iotjs_pwm_set_enable, pwm, &jcallback,
                             kPwmOpSetEnable);
   } else {
     if (!iotjs_pwm_set_enable(pwm)) {
@@ -341,10 +341,10 @@ JHANDLER_FUNCTION(Close) {
   JHANDLER_DECLARE_THIS_PTR(pwm, pwm);
   DJHANDLER_CHECK_ARG_IF_EXIST(0, function);
 
-  const iotjs_jval_t* jcallback = JHANDLER_GET_ARG_IF_EXIST(0, function);
+  const iotjs_jval_t jcallback = JHANDLER_GET_ARG_IF_EXIST(0, function);
 
-  if (jcallback) {
-    PWM_ASYNC_COMMON_WORKER(iotjs_pwm_close, pwm, jcallback, kPwmOpClose);
+  if (!jerry_value_is_null(jcallback)) {
+    PWM_ASYNC_COMMON_WORKER(iotjs_pwm_close, pwm, &jcallback, kPwmOpClose);
   } else {
     if (!iotjs_pwm_close(pwm)) {
       JHANDLER_THROW(COMMON, "PWM Close Error");

--- a/src/modules/iotjs_module_spi.c
+++ b/src/modules/iotjs_module_spi.c
@@ -150,8 +150,8 @@ static void iotjs_spi_set_buffer(iotjs_spi_t* spi, const iotjs_jval_t* jtx_buf,
                                  const iotjs_jval_t* jrx_buf) {
   IOTJS_VALIDATED_STRUCT_METHOD(iotjs_spi_t, spi);
 
-  iotjs_bufferwrap_t* tx_buf = iotjs_bufferwrap_from_jbuffer(jtx_buf);
-  iotjs_bufferwrap_t* rx_buf = iotjs_bufferwrap_from_jbuffer(jrx_buf);
+  iotjs_bufferwrap_t* tx_buf = iotjs_bufferwrap_from_jbuffer(*jtx_buf);
+  iotjs_bufferwrap_t* rx_buf = iotjs_bufferwrap_from_jbuffer(*jrx_buf);
 
   _this->tx_buf_data = iotjs_bufferwrap_buffer(tx_buf);
   uint8_t tx_buf_len = iotjs_bufferwrap_length(tx_buf);
@@ -350,13 +350,13 @@ JHANDLER_FUNCTION(TransferArray) {
   DJHANDLER_CHECK_ARGS(2, array, array);
   DJHANDLER_CHECK_ARG_IF_EXIST(2, function);
 
-  const iotjs_jval_t* jcallback = JHANDLER_GET_ARG_IF_EXIST(2, function);
+  const iotjs_jval_t jcallback = JHANDLER_GET_ARG_IF_EXIST(2, function);
 
   iotjs_spi_set_array_buffer(spi, JHANDLER_GET_ARG(0, array),
                              JHANDLER_GET_ARG(1, array));
 
-  if (jcallback) {
-    SPI_ASYNC(transfer, spi, jcallback, kSpiOpTransferArray);
+  if (!jerry_value_is_null(jcallback)) {
+    SPI_ASYNC(transfer, spi, &jcallback, kSpiOpTransferArray);
   } else {
     if (!iotjs_spi_transfer(spi)) {
       JHANDLER_THROW(COMMON, "SPI Transfer Error");
@@ -380,13 +380,13 @@ JHANDLER_FUNCTION(TransferBuffer) {
   DJHANDLER_CHECK_ARGS(2, object, object);
   DJHANDLER_CHECK_ARG_IF_EXIST(2, function);
 
-  const iotjs_jval_t* jcallback = JHANDLER_GET_ARG_IF_EXIST(2, function);
+  const iotjs_jval_t jcallback = JHANDLER_GET_ARG_IF_EXIST(2, function);
 
   iotjs_spi_set_buffer(spi, JHANDLER_GET_ARG(0, object),
                        JHANDLER_GET_ARG(1, object));
 
-  if (jcallback) {
-    SPI_ASYNC(transfer, spi, jcallback, kSpiOpTransferBuffer);
+  if (!jerry_value_is_null(jcallback)) {
+    SPI_ASYNC(transfer, spi, &jcallback, kSpiOpTransferBuffer);
   } else {
     if (!iotjs_spi_transfer(spi)) {
       JHANDLER_THROW(COMMON, "SPI Transfer Error");
@@ -407,10 +407,10 @@ JHANDLER_FUNCTION(Close) {
 
   DJHANDLER_CHECK_ARG_IF_EXIST(0, function);
 
-  const iotjs_jval_t* jcallback = JHANDLER_GET_ARG_IF_EXIST(0, function);
+  const iotjs_jval_t jcallback = JHANDLER_GET_ARG_IF_EXIST(0, function);
 
-  if (jcallback) {
-    SPI_ASYNC(close, spi, jcallback, kSpiOpClose);
+  if (!jerry_value_is_null(jcallback)) {
+    SPI_ASYNC(close, spi, &jcallback, kSpiOpClose);
   } else {
     if (!iotjs_spi_close(spi)) {
       JHANDLER_THROW(COMMON, "SPI Close Error");

--- a/src/modules/iotjs_module_tcp.c
+++ b/src/modules/iotjs_module_tcp.c
@@ -433,7 +433,7 @@ JHANDLER_FUNCTION(Write) {
   JHANDLER_DECLARE_THIS_PTR(tcpwrap, tcp_wrap);
   DJHANDLER_CHECK_ARGS(2, object, function);
 
-  const iotjs_jval_t* jbuffer = JHANDLER_GET_ARG(0, object);
+  const iotjs_jval_t jbuffer = *JHANDLER_GET_ARG(0, object);
   iotjs_bufferwrap_t* buffer_wrap = iotjs_bufferwrap_from_jbuffer(jbuffer);
   char* buffer = iotjs_bufferwrap_buffer(buffer_wrap);
   size_t len = iotjs_bufferwrap_length(buffer_wrap);
@@ -501,7 +501,7 @@ void OnRead(uv_stream_t* handle, ssize_t nread, const uv_buf_t* buf) {
     }
   } else {
     iotjs_jval_t jbuffer = iotjs_bufferwrap_create_buffer((size_t)nread);
-    iotjs_bufferwrap_t* buffer_wrap = iotjs_bufferwrap_from_jbuffer(&jbuffer);
+    iotjs_bufferwrap_t* buffer_wrap = iotjs_bufferwrap_from_jbuffer(jbuffer);
 
     iotjs_bufferwrap_copy(buffer_wrap, buf->base, (size_t)nread);
 

--- a/src/modules/iotjs_module_uart.c
+++ b/src/modules/iotjs_module_uart.c
@@ -297,15 +297,15 @@ JHANDLER_FUNCTION(Write) {
   DJHANDLER_CHECK_ARGS(1, string);
   DJHANDLER_CHECK_ARG_IF_EXIST(1, function);
 
-  const iotjs_jval_t* jcallback = JHANDLER_GET_ARG_IF_EXIST(1, function);
+  const iotjs_jval_t jcallback = JHANDLER_GET_ARG_IF_EXIST(1, function);
 
   IOTJS_VALIDATED_STRUCT_METHOD(iotjs_uart_t, uart);
 
   _this->buf_data = JHANDLER_GET_ARG(0, string);
   _this->buf_len = iotjs_string_size(&_this->buf_data);
 
-  if (jcallback) {
-    UART_ASYNC(write, uart, jcallback, kUartOpWrite);
+  if (!jerry_value_is_null(jcallback)) {
+    UART_ASYNC(write, uart, &jcallback, kUartOpWrite);
   } else {
     bool result = iotjs_uart_write(uart);
     iotjs_string_destroy(&_this->buf_data);
@@ -324,13 +324,13 @@ JHANDLER_FUNCTION(Close) {
   JHANDLER_DECLARE_THIS_PTR(uart, uart);
   DJHANDLER_CHECK_ARG_IF_EXIST(0, function);
 
-  const iotjs_jval_t* jcallback = JHANDLER_GET_ARG_IF_EXIST(0, function);
+  const iotjs_jval_t jcallback = JHANDLER_GET_ARG_IF_EXIST(0, function);
 
   IOTJS_VALIDATED_STRUCT_METHOD(iotjs_uart_t, uart);
   iotjs_jval_destroy(&_this->jemitter_this);
 
-  if (jcallback) {
-    UART_ASYNC(close, uart, jcallback, kUartOpClose);
+  if (!jerry_value_is_null(jcallback)) {
+    UART_ASYNC(close, uart, &jcallback, kUartOpClose);
   } else {
     if (!iotjs_uart_close(uart)) {
       JHANDLER_THROW(COMMON, "UART Close Error");

--- a/src/modules/iotjs_module_udp.c
+++ b/src/modules/iotjs_module_udp.c
@@ -209,7 +209,7 @@ static void OnRecv(uv_udp_t* handle, ssize_t nread, const uv_buf_t* buf,
   }
 
   iotjs_jval_t jbuffer = iotjs_bufferwrap_create_buffer((size_t)nread);
-  iotjs_bufferwrap_t* buffer_wrap = iotjs_bufferwrap_from_jbuffer(&jbuffer);
+  iotjs_bufferwrap_t* buffer_wrap = iotjs_bufferwrap_from_jbuffer(jbuffer);
 
   iotjs_bufferwrap_copy(buffer_wrap, buf->base, (size_t)nread);
 
@@ -287,7 +287,7 @@ JHANDLER_FUNCTION(Send) {
   IOTJS_ASSERT(iotjs_jval_is_function(iotjs_jhandler_get_arg(jhandler, 3)) ||
                iotjs_jval_is_undefined(iotjs_jhandler_get_arg(jhandler, 3)));
 
-  const iotjs_jval_t* jbuffer = JHANDLER_GET_ARG(0, object);
+  const iotjs_jval_t jbuffer = *JHANDLER_GET_ARG(0, object);
   const unsigned short port = JHANDLER_GET_ARG(1, number);
   iotjs_string_t address = JHANDLER_GET_ARG(2, string);
   const iotjs_jval_t* jcallback = JHANDLER_GET_ARG(3, object);

--- a/src/platform/linux/iotjs_module_blehcisocket-linux.c
+++ b/src/platform/linux/iotjs_module_blehcisocket-linux.c
@@ -305,7 +305,7 @@ void iotjs_blehcisocket_poll(THIS) {
     iotjs_jval_t str = iotjs_jval_create_string_raw("data");
     IOTJS_ASSERT(length >= 0);
     iotjs_jval_t jbuf = iotjs_bufferwrap_create_buffer((size_t)length);
-    iotjs_bufferwrap_t* buf_wrap = iotjs_bufferwrap_from_jbuffer(&jbuf);
+    iotjs_bufferwrap_t* buf_wrap = iotjs_bufferwrap_from_jbuffer(jbuf);
     iotjs_bufferwrap_copy(buf_wrap, data, (size_t)length);
     iotjs_jargs_append_jval(&jargs, &str);
     iotjs_jargs_append_jval(&jargs, &jbuf);


### PR DESCRIPTION
First part of the change `iotjs_jval_t` (step 2 of #1201). I did not want to make too big patch to make it easier to review. I changed a bunch of function parameters under the modules directory (buffer, dns, fs, httpparser and their call sites in other modules). @glistening could you try the hardware related tests (gpio, uart, adc, etc.)?