### PR TITLE
Fix path handling when loading modules on TizenRT

### DIFF
--- a/src/js/module.js
+++ b/src/js/module.js
@@ -71,7 +71,8 @@ iotjs_module_t.resolveFilepath = function(id, directories) {
       modulePath = process.cwd() + '/' + modulePath;
     }
 
-    if (process.platform === 'tizenrt' && modulePath.indexOf("..") != -1) {
+    if (process.platform === 'tizenrt' &&
+        (modulePath.indexOf("../") != -1 || modulePath.indexOf("./") != -1)) {
       modulePath = iotjs_module_t.normalizePath(modulePath);
     }
 

--- a/test/testsets.json
+++ b/test/testsets.json
@@ -51,7 +51,7 @@
     { "name": "test_https_timeout.js", "timeout": 40, "skip": ["all"], "reason": "Implemented only for Tizen" },
     { "name": "test_i2c.js", "skip": ["all"], "reason": "need to setup test environment" },
     { "name": "test_iotjs_promise.js", "skip": ["all"], "reason": "es2015 is off by default" },
-    { "name": "test_module_cache.js", "skip": ["nuttx", "tizenrt"], "reason": "not implemented for nuttx/TizenRT" },
+    { "name": "test_module_cache.js", "skip": ["nuttx"], "reason": "not implemented for nuttx" },
     { "name": "test_module_require.js", "skip": ["nuttx"], "reason": "not implemented for nuttx" },
     { "name": "test_net_1.js" },
     { "name": "test_net_2.js" },


### PR DESCRIPTION
Handling for single dot was missing and the current implementation did not consider files with two or single dots in names, so we need to check delimiter also

IoT.js-DCO-1.0-Signed-off-by: Krzysztof Antoszek k.antoszek@samsung.com