### PR TITLE
Apply Docker to Travis for linux and rpi2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,25 +4,31 @@ os: linux
 dist: trusty
 sudo: required
 
+services:
+  - docker
+
 before_install:
-  - if [[ "$INSTALL_ARM_DEPS" == "yes" ]]; then tools/apt-get-install-arm.sh; fi
   - if [[ "$INSTALL_NUTTX_DEPS" == "yes" ]]; then tools/apt-get-install-nuttx.sh; fi
   - if [[ "$INSTALL_TIZEN_DEPS" == "yes" ]]; then . tools/apt-get-install-tizen.sh; fi
   - if [[ "$INSTALL_TIZENRT_DEPS" == "yes" ]]; then . tools/apt-get-install-tizenrt.sh; fi
   - if [[ "$INSTALL_TRAVIS_I686_DEPS" == "yes" ]]; then tools/apt-get-install-travis-i686.sh; fi
-  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then tools/apt-get-install-deps.sh; fi
+  - if [[ "$RUN_DOCKER" == "yes" ]]; then docker pull iotjs/ubuntu:0.1; fi
+  - if [ -z "$RUN_DOCKER" ] && [ "$TRAVIS_OS_NAME" == "linux" ]; then tools/apt-get-install-deps.sh; fi
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then tools/brew-install-deps.sh; fi
 
 install:
 
-script: "tools/precommit.py $OPTS"
+script:
+  if [[ "$RUN_DOCKER" == "yes" ]]; then tools/travis_script.py;
+  else tools/precommit.py $OPTS;
+  fi
 
 env:
   global:
     - secure: "lUGzoKK/Yn4/OmpqLQALrIgfY9mQWE51deUawPrCO87UQ2GknfQ4BvwY3UT5QY0XnztPBP1+vRQ2qxbiAU7VWicp280sXDnh0FeuZD14FcE9l0FczraL12reoLu+gY5HWFfbkZncmcBsZkxDEYxhkM14FJU8fxyqGQW2ypJNz+gUGP+8r40Re5J3WjcddCQNe5IG8U+M9B4YeDHhN2QspLdN5pkgn56XtdGa3+qbecO2NpjJG5ltM9j1tTuo/Dg22DxrIFVfeFSFKUj4nfMrgPo5LevRsC/lfaBSCsj751eqrxRcQRh2hkpiIJ7mEBs2LL1EH9O6Mbj+eRh8BvIYqTB85VPNFc43sLWk14apcSVBrxJE5j3kP9sAsOD9Y5JynnkeuxYyISrkywwoX2uxsmCzIfGbwsv5VLToQzrqWlGYrHOAmVXNi8561dLfsWwxxFUjdqkZr1Kgc8UfnBEcBUtSiKCHS86/YUUbBJGkEkjDUS0GiqhFY4bXLQCR7EX4qDX3m6p7Mnh4NVUolpnSmyeYE/MjmqQ+7PJsPLL3EcIYmJ7dtW3mZ3yE2NyaFD0Pym9+TiuCCXRtrNVK1M3Kya64KNv+HbhjT/fTCgXLSeyDmJOKVAqugRlDo3b1KGR1LI0AfegzSA6mEC4e9JLjYiSnHPMUahzgLt8oU0hNFRY="
   matrix:
-    - OPTS="--test=host-linux"
-    - OPTS="--test=rpi2" INSTALL_ARM_DEPS=yes
+    - OPTS="host-linux" RUN_DOCKER=yes
+    - OPTS="rpi2" RUN_DOCKER=yes
     - OPTS="--test=nuttx" INSTALL_NUTTX_DEPS=yes
     - OPTS="--test=artik10" INSTALL_TIZEN_DEPS=yes
     - OPTS="--test=artik053" INSTALL_TIZENRT_DEPS=yes

--- a/tools/travis_script.py
+++ b/tools/travis_script.py
@@ -1,0 +1,68 @@
+#!/usr/bin/env python
+
+# Copyright 2017-present Samsung Electronics Co., Ltd. and other contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+import json
+
+from common_py.system.filesystem import FileSystem as fs
+from common_py.system.executor import Executor as ex
+
+
+DOCKER_ROOT_PATH = \
+    fs.abspath(fs.join(fs.dirname(__file__), fs.pardir, fs.pardir))
+IOTJS_PATH = fs.join(DOCKER_ROOT_PATH, 'iotjs')
+BUILD_MODULE_PATH = fs.join(IOTJS_PATH, 'build.module')
+
+DOCKER_NAME = 'iotjs_docker'
+BUILDTYPES=['debug', 'release']
+
+def get_config():
+    with open(BUILD_MODULE_PATH, 'r') as f:
+        config = json.loads(f.read().encode('ascii'))
+    return config
+
+def run_docker():
+    ex.check_run_cmd('docker', ['run', '-dit', '--name', DOCKER_NAME, '-v',
+                     '%s:%s' % (os.environ['TRAVIS_BUILD_DIR'], IOTJS_PATH),
+                     'iotjs/ubuntu:0.1'])
+
+def exec_docker(cwd, cmd):
+    exec_cmd = 'cd %s && ' % cwd + ' '.join(cmd)
+    ex.check_run_cmd('docker', ['exec', '-it', DOCKER_NAME,
+                                'bash', '-c', exec_cmd])
+
+if __name__ == '__main__':
+    config = get_config()
+    os_dependency_module = {}
+    extend_module = config['module']['supported']['extended']
+    for os_name in extend_module.keys():
+        os_dependency_module[os_name] = \
+            '--iotjs-include-module=' + ','.join(extend_module[os_name])
+
+    test = os.environ['OPTS']
+    if test == 'host-linux':
+        run_docker()
+        for buildtype in BUILDTYPES:
+            exec_docker(IOTJS_PATH, ['./tools/build.py',
+                                     '--buildtype=%s' % buildtype])
+    elif test == 'rpi2':
+        run_docker()
+        build_options = ['--clean', '--target-arch=arm', '--target-board=rpi2',
+                         os_dependency_module['linux']]
+        for buildtype in BUILDTYPES:
+            exec_docker(IOTJS_PATH, ['./tools/build.py',
+                                     '--buildtype=%s' % buildtype] +
+                                     build_options)


### PR DESCRIPTION
use the docker service to provide a common build environment and
simplify the testing phase.
This is the first commit to provide a docker service.

IoT.js-DCO-1.0-Signed-off-by: Hosung Kim hs852.kim@samsung.com