### PR TITLE
Continue the 'iotjs_jval_t*' elimination.

### DIFF
--- a/src/iotjs_binding_helper.c
+++ b/src/iotjs_binding_helper.c
@@ -26,7 +26,7 @@ void iotjs_uncaught_exception(const iotjs_jval_t* jexception) {
   iotjs_jval_t jonuncaughtexception =
       iotjs_jval_get_property(&process,
                               IOTJS_MAGIC_STRING__ONUNCAUGHTEXCEPTION);
-  IOTJS_ASSERT(iotjs_jval_is_function(&jonuncaughtexception));
+  IOTJS_ASSERT(iotjs_jval_is_function(jonuncaughtexception));
 
   iotjs_jargs_t args = iotjs_jargs_create(1);
   iotjs_jargs_append_jval(&args, jexception);
@@ -55,7 +55,7 @@ void iotjs_process_emit_exit(int code) {
 
   iotjs_jval_t jexit =
       iotjs_jval_get_property(&process, IOTJS_MAGIC_STRING_EMITEXIT);
-  IOTJS_ASSERT(iotjs_jval_is_function(&jexit));
+  IOTJS_ASSERT(iotjs_jval_is_function(jexit));
 
   iotjs_jargs_t jargs = iotjs_jargs_create(1);
   iotjs_jargs_append_number(&jargs, code);
@@ -85,15 +85,15 @@ bool iotjs_process_next_tick() {
 
   iotjs_jval_t jon_next_tick =
       iotjs_jval_get_property(&process, IOTJS_MAGIC_STRING__ONNEXTTICK);
-  IOTJS_ASSERT(iotjs_jval_is_function(&jon_next_tick));
+  IOTJS_ASSERT(iotjs_jval_is_function(jon_next_tick));
 
   iotjs_jval_t jres =
       iotjs_jhelper_call_ok(&jon_next_tick, iotjs_jval_get_undefined(),
                             iotjs_jargs_get_empty());
 
-  IOTJS_ASSERT(iotjs_jval_is_boolean(&jres));
+  IOTJS_ASSERT(iotjs_jval_is_boolean(jres));
 
-  bool ret = iotjs_jval_as_boolean(&jres);
+  bool ret = iotjs_jval_as_boolean(jres);
   iotjs_jval_destroy(&jres);
   iotjs_jval_destroy(&jon_next_tick);
 
@@ -136,9 +136,9 @@ int iotjs_process_exitcode() {
 
   iotjs_jval_t jexitcode =
       iotjs_jval_get_property(&process, IOTJS_MAGIC_STRING_EXITCODE);
-  IOTJS_ASSERT(iotjs_jval_is_number(&jexitcode));
+  IOTJS_ASSERT(iotjs_jval_is_number(jexitcode));
 
-  const int exitcode = (int)iotjs_jval_as_number(&jexitcode);
+  const int exitcode = (int)iotjs_jval_as_number(jexitcode);
   iotjs_jval_destroy(&jexitcode);
 
   return exitcode;

--- a/src/iotjs_handlewrap.c
+++ b/src/iotjs_handlewrap.c
@@ -56,7 +56,7 @@ iotjs_handlewrap_t* iotjs_handlewrap_from_handle(uv_handle_t* handle) {
 
 iotjs_handlewrap_t* iotjs_handlewrap_from_jobject(const iotjs_jval_t* jobject) {
   iotjs_handlewrap_t* handlewrap =
-      (iotjs_handlewrap_t*)(iotjs_jval_get_object_native_handle(jobject));
+      (iotjs_handlewrap_t*)(iotjs_jval_get_object_native_handle(*jobject));
   iotjs_handlewrap_validate(handlewrap);
   return handlewrap;
 }
@@ -69,7 +69,7 @@ uv_handle_t* iotjs_handlewrap_get_uv_handle(iotjs_handlewrap_t* handlewrap) {
 }
 
 
-iotjs_jval_t* iotjs_handlewrap_jobject(iotjs_handlewrap_t* handlewrap) {
+iotjs_jval_t iotjs_handlewrap_jobject(iotjs_handlewrap_t* handlewrap) {
   IOTJS_VALIDATED_STRUCT_METHOD(iotjs_handlewrap_t, handlewrap);
   iotjs_handlewrap_validate(handlewrap);
   return iotjs_jobjectwrap_jobject(&_this->jobjectwrap);
@@ -90,7 +90,8 @@ static void iotjs_handlewrap_on_close(iotjs_handlewrap_t* handlewrap) {
 
   // Decrease ref count of Javascript object. From now the object can be
   // reclaimed.
-  iotjs_jval_destroy(iotjs_jobjectwrap_jobject(&_this->jobjectwrap));
+  iotjs_jval_t jval = iotjs_jobjectwrap_jobject(&_this->jobjectwrap);
+  iotjs_jval_destroy(&jval);
 }
 
 

--- a/src/iotjs_handlewrap.h
+++ b/src/iotjs_handlewrap.h
@@ -64,7 +64,7 @@ iotjs_handlewrap_t* iotjs_handlewrap_from_handle(uv_handle_t* handle);
 iotjs_handlewrap_t* iotjs_handlewrap_from_jobject(const iotjs_jval_t* jobject);
 
 uv_handle_t* iotjs_handlewrap_get_uv_handle(iotjs_handlewrap_t* handlewrap);
-iotjs_jval_t* iotjs_handlewrap_jobject(iotjs_handlewrap_t* handlewrap);
+iotjs_jval_t iotjs_handlewrap_jobject(iotjs_handlewrap_t* handlewrap);
 
 void iotjs_handlewrap_validate(iotjs_handlewrap_t* handlewrap);
 

--- a/src/iotjs_module.c
+++ b/src/iotjs_module.c
@@ -48,8 +48,8 @@ void iotjs_module_list_init() {
 #undef INIT_MODULE_LIST
 
 
-#define CLENUP_MODULE_LIST(upper, Camel, lower)                   \
-  if (!iotjs_jval_is_undefined(&modules[MODULE_##upper].jmodule)) \
+#define CLENUP_MODULE_LIST(upper, Camel, lower)                  \
+  if (!iotjs_jval_is_undefined(modules[MODULE_##upper].jmodule)) \
     iotjs_jval_destroy(&modules[MODULE_##upper].jmodule);
 
 void iotjs_module_list_cleanup() {
@@ -63,7 +63,7 @@ const iotjs_jval_t* iotjs_module_initialize_if_necessary(ModuleKind kind) {
   IOTJS_ASSERT(kind < MODULE_COUNT);
   IOTJS_ASSERT(&modules[kind].fn_register != NULL);
 
-  if (iotjs_jval_is_undefined(&modules[kind].jmodule)) {
+  if (iotjs_jval_is_undefined(modules[kind].jmodule)) {
     modules[kind].jmodule = modules[kind].fn_register();
   }
 
@@ -73,6 +73,6 @@ const iotjs_jval_t* iotjs_module_initialize_if_necessary(ModuleKind kind) {
 
 const iotjs_jval_t* iotjs_module_get(ModuleKind kind) {
   IOTJS_ASSERT(kind < MODULE_COUNT);
-  IOTJS_ASSERT(!iotjs_jval_is_undefined(&modules[kind].jmodule));
+  IOTJS_ASSERT(!iotjs_jval_is_undefined(modules[kind].jmodule));
   return &modules[kind].jmodule;
 }

--- a/src/iotjs_objectwrap.c
+++ b/src/iotjs_objectwrap.c
@@ -22,7 +22,7 @@ void iotjs_jobjectwrap_initialize(iotjs_jobjectwrap_t* jobjectwrap,
                                   JNativeInfoType* native_info) {
   IOTJS_VALIDATED_STRUCT_CONSTRUCTOR(iotjs_jobjectwrap_t, jobjectwrap);
 
-  IOTJS_ASSERT(iotjs_jval_is_object(jobject));
+  IOTJS_ASSERT(iotjs_jval_is_object(*jobject));
 
   // This wrapper holds pointer to the javascript object but never increases
   // reference count.
@@ -42,9 +42,9 @@ void iotjs_jobjectwrap_destroy(iotjs_jobjectwrap_t* jobjectwrap) {
 }
 
 
-iotjs_jval_t* iotjs_jobjectwrap_jobject(iotjs_jobjectwrap_t* jobjectwrap) {
+iotjs_jval_t iotjs_jobjectwrap_jobject(iotjs_jobjectwrap_t* jobjectwrap) {
   IOTJS_VALIDATED_STRUCT_METHOD(iotjs_jobjectwrap_t, jobjectwrap);
-  iotjs_jval_t* jobject = &_this->jobject;
+  iotjs_jval_t jobject = _this->jobject;
   IOTJS_ASSERT((uintptr_t)jobjectwrap ==
                iotjs_jval_get_object_native_handle(jobject));
   IOTJS_ASSERT(iotjs_jval_is_object(jobject));
@@ -55,7 +55,7 @@ iotjs_jval_t* iotjs_jobjectwrap_jobject(iotjs_jobjectwrap_t* jobjectwrap) {
 iotjs_jobjectwrap_t* iotjs_jobjectwrap_from_jobject(
     const iotjs_jval_t* jobject) {
   iotjs_jobjectwrap_t* wrap =
-      (iotjs_jobjectwrap_t*)(iotjs_jval_get_object_native_handle(jobject));
+      (iotjs_jobjectwrap_t*)(iotjs_jval_get_object_native_handle(*jobject));
   IOTJS_ASSERT(iotjs_jval_is_object(iotjs_jobjectwrap_jobject(wrap)));
   return wrap;
 }

--- a/src/iotjs_objectwrap.h
+++ b/src/iotjs_objectwrap.h
@@ -32,7 +32,7 @@ void iotjs_jobjectwrap_initialize(iotjs_jobjectwrap_t* jobjectwrap,
 
 void iotjs_jobjectwrap_destroy(iotjs_jobjectwrap_t* jobjectwrap);
 
-iotjs_jval_t* iotjs_jobjectwrap_jobject(iotjs_jobjectwrap_t* jobjectwrap);
+iotjs_jval_t iotjs_jobjectwrap_jobject(iotjs_jobjectwrap_t* jobjectwrap);
 iotjs_jobjectwrap_t* iotjs_jobjectwrap_from_jobject(
     const iotjs_jval_t* jobject);
 

--- a/src/iotjs_reqwrap.c
+++ b/src/iotjs_reqwrap.c
@@ -21,7 +21,7 @@ void iotjs_reqwrap_initialize(iotjs_reqwrap_t* reqwrap,
                               const iotjs_jval_t* jcallback,
                               uv_req_t* request) {
   IOTJS_VALIDATED_STRUCT_CONSTRUCTOR(iotjs_reqwrap_t, reqwrap);
-  IOTJS_ASSERT(iotjs_jval_is_function(jcallback));
+  IOTJS_ASSERT(iotjs_jval_is_function(*jcallback));
   _this->jcallback = iotjs_jval_create_copied(jcallback);
   _this->request = request;
   _this->request->data = reqwrap;

--- a/src/modules/iotjs_module_adc.c
+++ b/src/modules/iotjs_module_adc.c
@@ -85,7 +85,7 @@ static iotjs_jval_t iotjs_adc_reqwrap_jcallback(THIS) {
 
 
 static iotjs_adc_t* iotjs_adc_instance_from_jval(const iotjs_jval_t jadc) {
-  uintptr_t handle = iotjs_jval_get_object_native_handle(&jadc);
+  uintptr_t handle = iotjs_jval_get_object_native_handle(jadc);
   return (iotjs_adc_t*)handle;
 }
 
@@ -206,7 +206,7 @@ JHANDLER_FUNCTION(AdcConstructor) {
   DJHANDLER_CHECK_THIS(object);
 
   // Create ADC object
-  const iotjs_jval_t jadc = *JHANDLER_GET_THIS(object);
+  const iotjs_jval_t jadc = JHANDLER_GET_THIS(object);
   iotjs_adc_t* adc = iotjs_adc_create(jadc);
   IOTJS_ASSERT(adc == iotjs_adc_instance_from_jval(jadc));
   IOTJS_VALIDATED_STRUCT_METHOD(iotjs_adc_t, adc);
@@ -226,8 +226,8 @@ JHANDLER_FUNCTION(AdcConstructor) {
 #endif
 
   if (iotjs_jhandler_get_arg_length(jhandler) > 1) {
-    const iotjs_jval_t jcallback = *iotjs_jhandler_get_arg(jhandler, 1);
-    if (iotjs_jval_is_function(&jcallback)) {
+    const iotjs_jval_t jcallback = iotjs_jhandler_get_arg(jhandler, 1);
+    if (iotjs_jval_is_function(jcallback)) {
       ADC_ASYNC(open, adc, jcallback, kAdcOpOpen);
     } else {
       JHANDLER_THROW(TYPE, "Bad arguments - callback should be Function");

--- a/src/modules/iotjs_module_blehcisocket.c
+++ b/src/modules/iotjs_module_blehcisocket.c
@@ -93,9 +93,9 @@ JHANDLER_FUNCTION(BindRaw) {
   int devId = 0;
   int* pDevId = NULL;
 
-  iotjs_jval_t raw = *iotjs_jhandler_get_arg(jhandler, 0);
-  if (iotjs_jval_is_number(&raw)) {
-    devId = iotjs_jval_as_number(&raw);
+  iotjs_jval_t raw = iotjs_jhandler_get_arg(jhandler, 0);
+  if (iotjs_jval_is_number(raw)) {
+    devId = iotjs_jval_as_number(raw);
     pDevId = &devId;
   }
 
@@ -143,7 +143,7 @@ JHANDLER_FUNCTION(SetFilter) {
   DJHANDLER_CHECK_ARGS(1, object);
 
   iotjs_bufferwrap_t* buffer =
-      iotjs_bufferwrap_from_jbuffer(*JHANDLER_GET_ARG(0, object));
+      iotjs_bufferwrap_from_jbuffer(JHANDLER_GET_ARG(0, object));
 
   iotjs_blehcisocket_setFilter(blehcisocket, iotjs_bufferwrap_buffer(buffer),
                                iotjs_bufferwrap_length(buffer));
@@ -167,7 +167,7 @@ JHANDLER_FUNCTION(Write) {
   DJHANDLER_CHECK_ARGS(1, object);
 
   iotjs_bufferwrap_t* buffer =
-      iotjs_bufferwrap_from_jbuffer(*JHANDLER_GET_ARG(0, object));
+      iotjs_bufferwrap_from_jbuffer(JHANDLER_GET_ARG(0, object));
 
   iotjs_blehcisocket_write(blehcisocket, iotjs_bufferwrap_buffer(buffer),
                            iotjs_bufferwrap_length(buffer));
@@ -181,11 +181,11 @@ JHANDLER_FUNCTION(BleHciSocketCons) {
   DJHANDLER_CHECK_ARGS(0);
 
   // Create object
-  iotjs_jval_t jblehcisocket = *JHANDLER_GET_THIS(object);
+  iotjs_jval_t jblehcisocket = JHANDLER_GET_THIS(object);
   iotjs_blehcisocket_t* blehcisocket = iotjs_blehcisocket_create(jblehcisocket);
   IOTJS_ASSERT(blehcisocket ==
                (iotjs_blehcisocket_t*)(iotjs_jval_get_object_native_handle(
-                   &jblehcisocket)));
+                   jblehcisocket)));
 }
 
 

--- a/src/modules/iotjs_module_buffer.c
+++ b/src/modules/iotjs_module_buffer.c
@@ -42,7 +42,7 @@ iotjs_bufferwrap_t* iotjs_bufferwrap_create(const iotjs_jval_t jbuiltin,
 
   IOTJS_ASSERT(
       bufferwrap ==
-      (iotjs_bufferwrap_t*)(iotjs_jval_get_object_native_handle(&jbuiltin)));
+      (iotjs_bufferwrap_t*)(iotjs_jval_get_object_native_handle(jbuiltin)));
 
   return bufferwrap;
 }
@@ -60,16 +60,16 @@ static void iotjs_bufferwrap_destroy(iotjs_bufferwrap_t* bufferwrap) {
 
 iotjs_bufferwrap_t* iotjs_bufferwrap_from_jbuiltin(
     const iotjs_jval_t jbuiltin) {
-  IOTJS_ASSERT(iotjs_jval_is_object(&jbuiltin));
+  IOTJS_ASSERT(iotjs_jval_is_object(jbuiltin));
   iotjs_bufferwrap_t* buffer =
-      (iotjs_bufferwrap_t*)iotjs_jval_get_object_native_handle(&jbuiltin);
+      (iotjs_bufferwrap_t*)iotjs_jval_get_object_native_handle(jbuiltin);
   IOTJS_ASSERT(buffer != NULL);
   return buffer;
 }
 
 
 iotjs_bufferwrap_t* iotjs_bufferwrap_from_jbuffer(const iotjs_jval_t jbuffer) {
-  IOTJS_ASSERT(iotjs_jval_is_object(&jbuffer));
+  IOTJS_ASSERT(iotjs_jval_is_object(jbuffer));
   iotjs_jval_t jbuiltin =
       iotjs_jval_get_property(&jbuffer, IOTJS_MAGIC_STRING__BUILTIN);
   iotjs_bufferwrap_t* buffer = iotjs_bufferwrap_from_jbuiltin(jbuiltin);
@@ -80,7 +80,7 @@ iotjs_bufferwrap_t* iotjs_bufferwrap_from_jbuffer(const iotjs_jval_t jbuffer) {
 
 iotjs_jval_t iotjs_bufferwrap_jbuiltin(iotjs_bufferwrap_t* bufferwrap) {
   IOTJS_VALIDATED_STRUCT_METHOD(iotjs_bufferwrap_t, bufferwrap);
-  return *iotjs_jobjectwrap_jobject(&_this->jobjectwrap);
+  return iotjs_jobjectwrap_jobject(&_this->jobjectwrap);
 }
 
 
@@ -103,7 +103,7 @@ size_t iotjs_bufferwrap_length(iotjs_bufferwrap_t* bufferwrap) {
   iotjs_jval_t jbuf = iotjs_bufferwrap_jbuffer(bufferwrap);
   iotjs_jval_t jlength =
       iotjs_jval_get_property(&jbuf, IOTJS_MAGIC_STRING_LENGTH);
-  size_t length = iotjs_jval_as_number(&jlength);
+  size_t length = iotjs_jval_as_number(jlength);
   IOTJS_ASSERT(length == _this->length);
   iotjs_jval_destroy(&jbuf);
   iotjs_jval_destroy(&jlength);
@@ -217,14 +217,14 @@ iotjs_jval_t iotjs_bufferwrap_create_buffer(size_t len) {
 
   iotjs_jval_t jbuffer =
       iotjs_jval_get_property(&jglobal, IOTJS_MAGIC_STRING_BUFFER);
-  IOTJS_ASSERT(iotjs_jval_is_function(&jbuffer));
+  IOTJS_ASSERT(iotjs_jval_is_function(jbuffer));
 
   iotjs_jargs_t jargs = iotjs_jargs_create(1);
   iotjs_jargs_append_number(&jargs, len);
 
   iotjs_jval_t jres =
       iotjs_jhelper_call_ok(&jbuffer, iotjs_jval_get_undefined(), &jargs);
-  IOTJS_ASSERT(iotjs_jval_is_object(&jres));
+  IOTJS_ASSERT(iotjs_jval_is_object(jres));
 
   iotjs_jargs_destroy(&jargs);
   iotjs_jval_destroy(&jbuffer);
@@ -237,8 +237,8 @@ JHANDLER_FUNCTION(Buffer) {
   DJHANDLER_CHECK_THIS(object);
   DJHANDLER_CHECK_ARGS(2, object, number);
 
-  const iotjs_jval_t jbuiltin = *JHANDLER_GET_THIS(object);
-  const iotjs_jval_t jbuffer = *JHANDLER_GET_ARG(0, object);
+  const iotjs_jval_t jbuiltin = JHANDLER_GET_THIS(object);
+  const iotjs_jval_t jbuffer = JHANDLER_GET_ARG(0, object);
   size_t length = JHANDLER_GET_ARG(1, number);
 
   iotjs_jval_set_property_jval(&jbuiltin, IOTJS_MAGIC_STRING__BUFFER, &jbuffer);
@@ -261,7 +261,7 @@ JHANDLER_FUNCTION(Copy) {
   JHANDLER_DECLARE_THIS_PTR(bufferwrap, src_buffer_wrap);
   DJHANDLER_CHECK_ARGS(4, object, number, number, number);
 
-  const iotjs_jval_t jdst_buffer = *JHANDLER_GET_ARG(0, object);
+  const iotjs_jval_t jdst_buffer = JHANDLER_GET_ARG(0, object);
   iotjs_bufferwrap_t* dst_buffer_wrap =
       iotjs_bufferwrap_from_jbuffer(jdst_buffer);
 

--- a/src/modules/iotjs_module_dns.c
+++ b/src/modules/iotjs_module_dns.c
@@ -172,7 +172,7 @@ JHANDLER_FUNCTION(GetAddrInfo) {
   int option = JHANDLER_GET_ARG(1, number);
   int flags = JHANDLER_GET_ARG(2, number);
   int error = 0;
-  const iotjs_jval_t jcallback = *JHANDLER_GET_ARG(3, function);
+  const iotjs_jval_t jcallback = JHANDLER_GET_ARG(3, function);
 
   int family;
   if (option == 0) {

--- a/src/modules/iotjs_module_fs.c
+++ b/src/modules/iotjs_module_fs.c
@@ -50,7 +50,7 @@ static void AfterAsync(uv_fs_t* req) {
   IOTJS_ASSERT(&req_wrap->req == req);
 
   const iotjs_jval_t cb = *iotjs_reqwrap_jcallback(&req_wrap->reqwrap);
-  IOTJS_ASSERT(iotjs_jval_is_function(&cb));
+  IOTJS_ASSERT(iotjs_jval_is_function(cb));
 
   iotjs_jargs_t jarg = iotjs_jargs_create(2);
   if (req->result < 0) {
@@ -237,7 +237,7 @@ JHANDLER_FUNCTION(Read) {
   const iotjs_environment_t* env = iotjs_environment_get();
 
   int fd = JHANDLER_GET_ARG(0, number);
-  const iotjs_jval_t jbuffer = *JHANDLER_GET_ARG(1, object);
+  const iotjs_jval_t jbuffer = JHANDLER_GET_ARG(1, object);
   size_t offset = JHANDLER_GET_ARG(2, number);
   size_t length = JHANDLER_GET_ARG(3, number);
   int position = JHANDLER_GET_ARG(4, number);
@@ -276,7 +276,7 @@ JHANDLER_FUNCTION(Write) {
   const iotjs_environment_t* env = iotjs_environment_get();
 
   int fd = JHANDLER_GET_ARG(0, number);
-  const iotjs_jval_t jbuffer = *JHANDLER_GET_ARG(1, object);
+  const iotjs_jval_t jbuffer = JHANDLER_GET_ARG(1, object);
   size_t offset = JHANDLER_GET_ARG(2, number);
   size_t length = JHANDLER_GET_ARG(3, number);
   int position = JHANDLER_GET_ARG(4, number);
@@ -312,7 +312,7 @@ iotjs_jval_t MakeStatObject(uv_stat_t* statbuf) {
 
   iotjs_jval_t stat_prototype =
       iotjs_jval_get_property(&fs, IOTJS_MAGIC_STRING_STATS);
-  IOTJS_ASSERT(iotjs_jval_is_object(&stat_prototype));
+  IOTJS_ASSERT(iotjs_jval_is_object(stat_prototype));
 
   iotjs_jval_t jstat = iotjs_jval_create_object();
   iotjs_jval_set_prototype(&jstat, &stat_prototype);
@@ -482,10 +482,10 @@ JHANDLER_FUNCTION(ReadDir) {
 
 static void StatsIsTypeOf(iotjs_jhandler_t* jhandler, int type) {
   DJHANDLER_CHECK_THIS(object);
-  const iotjs_jval_t stats = *JHANDLER_GET_THIS(object);
+  const iotjs_jval_t stats = JHANDLER_GET_THIS(object);
   iotjs_jval_t mode = iotjs_jval_get_property(&stats, IOTJS_MAGIC_STRING_MODE);
 
-  int mode_number = (int)iotjs_jval_as_number(&mode);
+  int mode_number = (int)iotjs_jval_as_number(mode);
 
   iotjs_jval_destroy(&mode);
 

--- a/src/modules/iotjs_module_gpio.c
+++ b/src/modules/iotjs_module_gpio.c
@@ -87,7 +87,7 @@ static iotjs_jval_t iotjs_gpio_reqwrap_jcallback(THIS) {
 
 
 static iotjs_gpio_t* iotjs_gpio_instance_from_jval(const iotjs_jval_t jgpio) {
-  uintptr_t handle = iotjs_jval_get_object_native_handle(&jgpio);
+  uintptr_t handle = iotjs_jval_get_object_native_handle(jgpio);
   return (iotjs_gpio_t*)handle;
 }
 
@@ -209,22 +209,22 @@ static void gpio_set_configurable(iotjs_gpio_t* gpio,
 
   iotjs_jval_t jpin =
       iotjs_jval_get_property(&jconfigurable, IOTJS_MAGIC_STRING_PIN);
-  _this->pin = iotjs_jval_as_number(&jpin);
+  _this->pin = iotjs_jval_as_number(jpin);
   iotjs_jval_destroy(&jpin);
 
   iotjs_jval_t jdirection =
       iotjs_jval_get_property(&jconfigurable, IOTJS_MAGIC_STRING_DIRECTION);
-  _this->direction = (GpioDirection)iotjs_jval_as_number(&jdirection);
+  _this->direction = (GpioDirection)iotjs_jval_as_number(jdirection);
   iotjs_jval_destroy(&jdirection);
 
   iotjs_jval_t jmode =
       iotjs_jval_get_property(&jconfigurable, IOTJS_MAGIC_STRING_MODE);
-  _this->mode = (GpioMode)iotjs_jval_as_number(&jmode);
+  _this->mode = (GpioMode)iotjs_jval_as_number(jmode);
   iotjs_jval_destroy(&jmode);
 
   iotjs_jval_t jedge =
       iotjs_jval_get_property(&jconfigurable, IOTJS_MAGIC_STRING_EDGE);
-  _this->edge = (GpioMode)iotjs_jval_as_number(&jedge);
+  _this->edge = (GpioMode)iotjs_jval_as_number(jedge);
   iotjs_jval_destroy(&jedge);
 }
 
@@ -258,13 +258,13 @@ JHANDLER_FUNCTION(GpioConstructor) {
   DJHANDLER_CHECK_ARGS(2, object, function);
 
   // Create GPIO object
-  const iotjs_jval_t jgpio = *JHANDLER_GET_THIS(object);
+  const iotjs_jval_t jgpio = JHANDLER_GET_THIS(object);
   iotjs_gpio_t* gpio = iotjs_gpio_create(jgpio);
   IOTJS_ASSERT(gpio == iotjs_gpio_instance_from_jval(jgpio));
 
-  gpio_set_configurable(gpio, *JHANDLER_GET_ARG(0, object));
+  gpio_set_configurable(gpio, JHANDLER_GET_ARG(0, object));
 
-  const iotjs_jval_t jcallback = *JHANDLER_GET_ARG(1, function);
+  const iotjs_jval_t jcallback = JHANDLER_GET_ARG(1, function);
   GPIO_ASYNC(open, gpio, jcallback, kGpioOpOpen);
 }
 

--- a/src/modules/iotjs_module_httpparser.c
+++ b/src/modules/iotjs_module_httpparser.c
@@ -131,10 +131,10 @@ static iotjs_jval_t iotjs_httpparserwrap_make_header(
 
 static void iotjs_httpparserwrap_flush(iotjs_httpparserwrap_t* httpparserwrap) {
   IOTJS_VALIDATED_STRUCT_METHOD(iotjs_httpparserwrap_t, httpparserwrap);
-  const iotjs_jval_t jobj = *iotjs_jobjectwrap_jobject(&_this->jobjectwrap);
+  const iotjs_jval_t jobj = iotjs_jobjectwrap_jobject(&_this->jobjectwrap);
   iotjs_jval_t func =
       iotjs_jval_get_property(&jobj, IOTJS_MAGIC_STRING_ONHEADERS);
-  IOTJS_ASSERT(iotjs_jval_is_function(&func));
+  IOTJS_ASSERT(iotjs_jval_is_function(func));
 
   iotjs_jargs_t argv = iotjs_jargs_create(2);
   iotjs_jval_t jheader = iotjs_httpparserwrap_make_header(httpparserwrap);
@@ -240,10 +240,10 @@ static int iotjs_httpparserwrap_on_headers_complete(http_parser* parser) {
   iotjs_httpparserwrap_t* httpparserwrap =
       (iotjs_httpparserwrap_t*)(parser->data);
   IOTJS_VALIDATED_STRUCT_METHOD(iotjs_httpparserwrap_t, httpparserwrap);
-  const iotjs_jval_t jobj = *iotjs_jobjectwrap_jobject(&_this->jobjectwrap);
+  const iotjs_jval_t jobj = iotjs_jobjectwrap_jobject(&_this->jobjectwrap);
   iotjs_jval_t func =
       iotjs_jval_get_property(&jobj, IOTJS_MAGIC_STRING_ONHEADERSCOMPLETE);
-  IOTJS_ASSERT(iotjs_jval_is_function(&func));
+  IOTJS_ASSERT(iotjs_jval_is_function(func));
 
   // URL
   iotjs_jargs_t argv = iotjs_jargs_create(1);
@@ -297,9 +297,9 @@ static int iotjs_httpparserwrap_on_headers_complete(http_parser* parser) {
   iotjs_jval_t res = iotjs_make_callback_with_result(&func, &jobj, &argv);
 
   int ret = 1;
-  if (iotjs_jval_is_boolean(&res)) {
-    ret = iotjs_jval_as_boolean(&res);
-  } else if (iotjs_jval_is_object(&res)) {
+  if (iotjs_jval_is_boolean(res)) {
+    ret = iotjs_jval_as_boolean(res);
+  } else if (iotjs_jval_is_object(res)) {
     // if exception throw occurs in iotjs_make_callback_with_result, then the
     // result can be an object.
     ret = 0;
@@ -319,9 +319,9 @@ static int iotjs_httpparserwrap_on_body(http_parser* parser, const char* at,
   iotjs_httpparserwrap_t* httpparserwrap =
       (iotjs_httpparserwrap_t*)(parser->data);
   IOTJS_VALIDATED_STRUCT_METHOD(iotjs_httpparserwrap_t, httpparserwrap);
-  const iotjs_jval_t jobj = *iotjs_jobjectwrap_jobject(&_this->jobjectwrap);
+  const iotjs_jval_t jobj = iotjs_jobjectwrap_jobject(&_this->jobjectwrap);
   iotjs_jval_t func = iotjs_jval_get_property(&jobj, IOTJS_MAGIC_STRING_ONBODY);
-  IOTJS_ASSERT(iotjs_jval_is_function(&func));
+  IOTJS_ASSERT(iotjs_jval_is_function(func));
 
   iotjs_jargs_t argv = iotjs_jargs_create(3);
   iotjs_jargs_append_jval(&argv, &_this->cur_jbuf);
@@ -342,10 +342,10 @@ static int iotjs_httpparserwrap_on_message_complete(http_parser* parser) {
   iotjs_httpparserwrap_t* httpparserwrap =
       (iotjs_httpparserwrap_t*)(parser->data);
   IOTJS_VALIDATED_STRUCT_METHOD(iotjs_httpparserwrap_t, httpparserwrap);
-  const iotjs_jval_t jobj = *iotjs_jobjectwrap_jobject(&_this->jobjectwrap);
+  const iotjs_jval_t jobj = iotjs_jobjectwrap_jobject(&_this->jobjectwrap);
   iotjs_jval_t func =
       iotjs_jval_get_property(&jobj, IOTJS_MAGIC_STRING_ONMESSAGECOMPLETE);
-  IOTJS_ASSERT(iotjs_jval_is_function(&func));
+  IOTJS_ASSERT(iotjs_jval_is_function(func));
 
   iotjs_make_callback(&func, &jobj, iotjs_jargs_get_empty());
 
@@ -413,7 +413,7 @@ JHANDLER_FUNCTION(Execute) {
   JHANDLER_DECLARE_THIS_PTR(httpparserwrap, parser);
   DJHANDLER_CHECK_ARGS(1, object);
 
-  iotjs_jval_t jbuffer = *JHANDLER_GET_ARG(0, object);
+  iotjs_jval_t jbuffer = JHANDLER_GET_ARG(0, object);
   iotjs_bufferwrap_t* buffer_wrap = iotjs_bufferwrap_from_jbuffer(jbuffer);
   char* buf_data = iotjs_bufferwrap_buffer(buffer_wrap);
   size_t buf_len = iotjs_bufferwrap_length(buffer_wrap);
@@ -461,7 +461,7 @@ JHANDLER_FUNCTION(HTTPParserCons) {
   DJHANDLER_CHECK_THIS(object);
   DJHANDLER_CHECK_ARGS(1, number);
 
-  const iotjs_jval_t jparser = *JHANDLER_GET_THIS(object);
+  const iotjs_jval_t jparser = JHANDLER_GET_THIS(object);
 
   http_parser_type httpparser_type =
       (http_parser_type)(JHANDLER_GET_ARG(0, number));

--- a/src/modules/iotjs_module_https.c
+++ b/src/modules/iotjs_module_https.c
@@ -182,9 +182,9 @@ void iotjs_https_cleanup(iotjs_https_t* https_data) {
   if (_this->to_destroy_read_onwrite) {
     const iotjs_jargs_t* jarg = iotjs_jargs_get_empty();
     iotjs_jval_t jthis = &(_this->jthis_native);
-    IOTJS_ASSERT(iotjs_jval_is_function(&(_this->read_onwrite)));
+    IOTJS_ASSERT(iotjs_jval_is_function((_this->read_onwrite)));
 
-    if (!iotjs_jval_is_undefined(&(_this->read_callback)))
+    if (!iotjs_jval_is_undefined((_this->read_callback)))
       iotjs_make_callback(&(_this->read_callback), &jthis, jarg);
 
     iotjs_make_callback(&(_this->read_onwrite), &jthis, jarg);
@@ -301,20 +301,20 @@ bool iotjs_https_jcallback(iotjs_https_t* https_data, const char* property,
                            const iotjs_jargs_t* jarg, bool resultvalue) {
   iotjs_jval_t jthis = iotjs_https_jthis_from_https(https_data);
   bool retval = true;
-  if (iotjs_jval_is_null(&jthis))
+  if (iotjs_jval_is_null(jthis))
     return retval;
 
   iotjs_jval_t jincoming =
       iotjs_jval_get_property(&jthis, IOTJS_MAGIC_STRING__INCOMING);
   iotjs_jval_t cb = iotjs_jval_get_property(&jincoming, property);
 
-  IOTJS_ASSERT(iotjs_jval_is_function(&cb));
+  IOTJS_ASSERT(iotjs_jval_is_function(cb));
   if (!resultvalue) {
     iotjs_make_callback(&cb, &jincoming, jarg);
   } else {
     iotjs_jval_t result =
         iotjs_make_callback_with_result(&cb, &jincoming, jarg);
-    retval = iotjs_jval_as_boolean(&result);
+    retval = iotjs_jval_as_boolean(result);
     iotjs_jval_destroy(&result);
   }
 
@@ -329,13 +329,13 @@ void iotjs_https_call_read_onwrite(uv_timer_t* timer) {
   IOTJS_VALIDATED_STRUCT_METHOD(iotjs_https_t, https_data);
 
   uv_timer_stop(&(_this->async_read_onwrite));
-  if (iotjs_jval_is_null(&_this->jthis_native))
+  if (iotjs_jval_is_null(_this->jthis_native))
     return;
   const iotjs_jargs_t* jarg = iotjs_jargs_get_empty();
   iotjs_jval_t jthis = _this->jthis_native;
-  IOTJS_ASSERT(iotjs_jval_is_function(&(_this->read_onwrite)));
+  IOTJS_ASSERT(iotjs_jval_is_function((_this->read_onwrite)));
 
-  if (!iotjs_jval_is_undefined(&(_this->read_callback)))
+  if (!iotjs_jval_is_undefined((_this->read_callback)))
     iotjs_make_callback(&(_this->read_callback), &jthis, jarg);
 
   iotjs_make_callback(&(_this->read_onwrite), &jthis, jarg);
@@ -553,7 +553,7 @@ size_t iotjs_https_curl_write_callback(void* contents, size_t size,
   iotjs_https_t* https_data = (iotjs_https_t*)userp;
   IOTJS_VALIDATED_STRUCT_METHOD(iotjs_https_t, https_data);
   size_t real_size = size * nmemb;
-  if (iotjs_jval_is_null(&_this->jthis_native))
+  if (iotjs_jval_is_null(_this->jthis_native))
     return real_size - 1;
   iotjs_jargs_t jarg = iotjs_jargs_create(1);
   iotjs_jval_t jresult_arr = iotjs_jval_create_byte_array(real_size, contents);
@@ -718,32 +718,32 @@ JHANDLER_FUNCTION(createRequest) {
   DJHANDLER_CHECK_THIS(object);
   DJHANDLER_CHECK_ARGS(1, object);
 
-  const iotjs_jval_t jthis = *JHANDLER_GET_ARG(0, object);
+  const iotjs_jval_t jthis = JHANDLER_GET_ARG(0, object);
 
   iotjs_jval_t jhost = iotjs_jval_get_property(&jthis, IOTJS_MAGIC_STRING_HOST);
-  iotjs_string_t host = iotjs_jval_as_string(&jhost);
+  iotjs_string_t host = iotjs_jval_as_string(jhost);
   iotjs_jval_destroy(&jhost);
 
   iotjs_jval_t jmethod =
       iotjs_jval_get_property(&jthis, IOTJS_MAGIC_STRING_METHOD);
-  iotjs_string_t method = iotjs_jval_as_string(&jmethod);
+  iotjs_string_t method = iotjs_jval_as_string(jmethod);
   iotjs_jval_destroy(&jmethod);
 
   iotjs_jval_t jca = iotjs_jval_get_property(&jthis, IOTJS_MAGIC_STRING_CA);
-  iotjs_string_t ca = iotjs_jval_as_string(&jca);
+  iotjs_string_t ca = iotjs_jval_as_string(jca);
   iotjs_jval_destroy(&jca);
 
   iotjs_jval_t jcert = iotjs_jval_get_property(&jthis, IOTJS_MAGIC_STRING_CERT);
-  iotjs_string_t cert = iotjs_jval_as_string(&jcert);
+  iotjs_string_t cert = iotjs_jval_as_string(jcert);
   iotjs_jval_destroy(&jcert);
 
   iotjs_jval_t jkey = iotjs_jval_get_property(&jthis, IOTJS_MAGIC_STRING_KEY);
-  iotjs_string_t key = iotjs_jval_as_string(&jkey);
+  iotjs_string_t key = iotjs_jval_as_string(jkey);
   iotjs_jval_destroy(&jkey);
 
   iotjs_jval_t jreject_unauthorized =
       iotjs_jval_get_property(&jthis, IOTJS_MAGIC_STRING_REJECTUNAUTHORIZED);
-  const bool reject_unauthorized = iotjs_jval_as_boolean(&jreject_unauthorized);
+  const bool reject_unauthorized = iotjs_jval_as_boolean(jreject_unauthorized);
 
   if (curl_global_init(CURL_GLOBAL_SSL)) {
     return;
@@ -770,9 +770,9 @@ JHANDLER_FUNCTION(addHeader) {
   iotjs_string_t header = JHANDLER_GET_ARG(0, string);
   const char* char_header = iotjs_string_data(&header);
 
-  iotjs_jval_t jthis = *JHANDLER_GET_ARG(1, object);
+  iotjs_jval_t jthis = JHANDLER_GET_ARG(1, object);
   iotjs_https_t* https_data =
-      (iotjs_https_t*)iotjs_jval_get_object_native_handle(&jthis);
+      (iotjs_https_t*)iotjs_jval_get_object_native_handle(jthis);
   iotjs_https_add_header(https_data, char_header);
 
   iotjs_string_destroy(&header);
@@ -783,9 +783,9 @@ JHANDLER_FUNCTION(sendRequest) {
   DJHANDLER_CHECK_THIS(object);
 
   DJHANDLER_CHECK_ARG(0, object);
-  iotjs_jval_t jthis = *JHANDLER_GET_ARG(0, object);
+  iotjs_jval_t jthis = JHANDLER_GET_ARG(0, object);
   iotjs_https_t* https_data =
-      (iotjs_https_t*)iotjs_jval_get_object_native_handle(&jthis);
+      (iotjs_https_t*)iotjs_jval_get_object_native_handle(jthis);
   iotjs_https_send_request(https_data);
   iotjs_jhandler_return_null(jhandler);
 }
@@ -795,10 +795,10 @@ JHANDLER_FUNCTION(setTimeout) {
   DJHANDLER_CHECK_ARGS(2, number, object);
 
   double ms = JHANDLER_GET_ARG(0, number);
-  iotjs_jval_t jthis = *JHANDLER_GET_ARG(1, object);
+  iotjs_jval_t jthis = JHANDLER_GET_ARG(1, object);
 
   iotjs_https_t* https_data =
-      (iotjs_https_t*)iotjs_jval_get_object_native_handle(&jthis);
+      (iotjs_https_t*)iotjs_jval_get_object_native_handle(jthis);
   iotjs_https_set_timeout((long)ms, https_data);
 
   iotjs_jhandler_return_null(jhandler);
@@ -810,14 +810,14 @@ JHANDLER_FUNCTION(_write) {
   // Argument 3 can be null, so not checked directly, checked later
   DJHANDLER_CHECK_ARG(3, function);
 
-  iotjs_jval_t jthis = *JHANDLER_GET_ARG(0, object);
+  iotjs_jval_t jthis = JHANDLER_GET_ARG(0, object);
   iotjs_string_t read_chunk = JHANDLER_GET_ARG(1, string);
 
-  iotjs_jval_t callback = *iotjs_jhandler_get_arg(jhandler, 2);
-  iotjs_jval_t onwrite = *JHANDLER_GET_ARG(3, function);
+  iotjs_jval_t callback = iotjs_jhandler_get_arg(jhandler, 2);
+  iotjs_jval_t onwrite = JHANDLER_GET_ARG(3, function);
 
   iotjs_https_t* https_data =
-      (iotjs_https_t*)iotjs_jval_get_object_native_handle(&jthis);
+      (iotjs_https_t*)iotjs_jval_get_object_native_handle(jthis);
   iotjs_https_data_to_write(https_data, read_chunk, callback, onwrite);
 
   // readchunk was copied to https_data, hence not destroyed.
@@ -828,9 +828,9 @@ JHANDLER_FUNCTION(finishRequest) {
   DJHANDLER_CHECK_THIS(object);
   DJHANDLER_CHECK_ARG(0, object);
 
-  iotjs_jval_t jthis = *JHANDLER_GET_ARG(0, object);
+  iotjs_jval_t jthis = JHANDLER_GET_ARG(0, object);
   iotjs_https_t* https_data =
-      (iotjs_https_t*)iotjs_jval_get_object_native_handle(&jthis);
+      (iotjs_https_t*)iotjs_jval_get_object_native_handle(jthis);
   iotjs_https_finish_request(https_data);
 
   iotjs_jhandler_return_null(jhandler);
@@ -840,9 +840,9 @@ JHANDLER_FUNCTION(Abort) {
   DJHANDLER_CHECK_THIS(object);
   DJHANDLER_CHECK_ARG(0, object);
 
-  iotjs_jval_t jthis = *JHANDLER_GET_ARG(0, object);
+  iotjs_jval_t jthis = JHANDLER_GET_ARG(0, object);
   iotjs_https_t* https_data =
-      (iotjs_https_t*)iotjs_jval_get_object_native_handle(&jthis);
+      (iotjs_https_t*)iotjs_jval_get_object_native_handle(jthis);
   iotjs_https_cleanup(https_data);
 
   iotjs_jhandler_return_null(jhandler);

--- a/src/modules/iotjs_module_i2c.c
+++ b/src/modules/iotjs_module_i2c.c
@@ -177,14 +177,14 @@ static void GetI2cArray(const iotjs_jval_t jarray,
   // Need to implement a function to get array info from iotjs_jval_t Array.
   iotjs_jval_t jlength =
       iotjs_jval_get_property(&jarray, IOTJS_MAGIC_STRING_LENGTH);
-  IOTJS_ASSERT(!iotjs_jval_is_undefined(&jlength));
+  IOTJS_ASSERT(!iotjs_jval_is_undefined(jlength));
 
-  req_data->buf_len = iotjs_jval_as_number(&jlength);
+  req_data->buf_len = iotjs_jval_as_number(jlength);
   req_data->buf_data = iotjs_buffer_allocate(req_data->buf_len);
 
   for (uint8_t i = 0; i < req_data->buf_len; i++) {
     iotjs_jval_t jdata = iotjs_jval_get_property_by_index(&jarray, i);
-    req_data->buf_data[i] = iotjs_jval_as_number(&jdata);
+    req_data->buf_data[i] = iotjs_jval_as_number(jdata);
     iotjs_jval_destroy(&jdata);
   }
 
@@ -201,13 +201,13 @@ static void GetI2cArray(const iotjs_jval_t jarray,
 JHANDLER_FUNCTION(I2cCons) {
   DJHANDLER_CHECK_THIS(object);
   // Create I2C object
-  const iotjs_jval_t ji2c = *JHANDLER_GET_THIS(object);
+  const iotjs_jval_t ji2c = JHANDLER_GET_THIS(object);
   iotjs_i2c_t* i2c = iotjs_i2c_create(jhandler, ji2c);
   IOTJS_ASSERT(i2c ==
-               (iotjs_i2c_t*)(iotjs_jval_get_object_native_handle(&ji2c)));
+               (iotjs_i2c_t*)(iotjs_jval_get_object_native_handle(ji2c)));
 
   // Create I2C request wrap
-  const iotjs_jval_t jcallback = *JHANDLER_GET_ARG(1, function);
+  const iotjs_jval_t jcallback = JHANDLER_GET_ARG(1, function);
   iotjs_i2c_reqwrap_t* req_wrap =
       iotjs_i2c_reqwrap_create(jcallback, i2c, kI2cOpOpen);
 
@@ -237,13 +237,13 @@ JHANDLER_FUNCTION(Write) {
   JHANDLER_DECLARE_THIS_PTR(i2c, i2c);
   DJHANDLER_CHECK_ARGS(2, array, function);
 
-  const iotjs_jval_t jcallback = *JHANDLER_GET_ARG(1, function);
+  const iotjs_jval_t jcallback = JHANDLER_GET_ARG(1, function);
 
   iotjs_i2c_reqwrap_t* req_wrap =
       iotjs_i2c_reqwrap_create(jcallback, i2c, kI2cOpWrite);
   iotjs_i2c_reqdata_t* req_data = iotjs_i2c_reqwrap_data(req_wrap);
 
-  GetI2cArray(*JHANDLER_GET_ARG(0, array), req_data);
+  GetI2cArray(JHANDLER_GET_ARG(0, array), req_data);
 
   I2C_ASYNC(Write);
 
@@ -254,7 +254,7 @@ JHANDLER_FUNCTION(Read) {
   JHANDLER_DECLARE_THIS_PTR(i2c, i2c);
   DJHANDLER_CHECK_ARGS(2, number, function);
 
-  const iotjs_jval_t jcallback = *JHANDLER_GET_ARG(1, function);
+  const iotjs_jval_t jcallback = JHANDLER_GET_ARG(1, function);
 
   iotjs_i2c_reqwrap_t* req_wrap =
       iotjs_i2c_reqwrap_create(jcallback, i2c, kI2cOpRead);

--- a/src/modules/iotjs_module_pwm.c
+++ b/src/modules/iotjs_module_pwm.c
@@ -92,7 +92,7 @@ static iotjs_jval_t iotjs_pwm_reqwrap_jcallback(THIS) {
 
 
 static iotjs_pwm_t* iotjs_pwm_instance_from_jval(iotjs_jval_t jpwm) {
-  uintptr_t handle = iotjs_jval_get_object_native_handle(&jpwm);
+  uintptr_t handle = iotjs_jval_get_object_native_handle(jpwm);
   return (iotjs_pwm_t*)handle;
 }
 
@@ -120,24 +120,24 @@ static void iotjs_pwm_set_configuration(iotjs_jval_t jconfiguration,
 
   iotjs_jval_t jpin =
       iotjs_jval_get_property(&jconfiguration, IOTJS_MAGIC_STRING_PIN);
-  _this->pin = iotjs_jval_as_number(&jpin);
+  _this->pin = iotjs_jval_as_number(jpin);
 
 #if defined(__linux__)
   iotjs_jval_t jchip =
       iotjs_jval_get_property(&jconfiguration, IOTJS_MAGIC_STRING_CHIP);
-  _this->chip = iotjs_jval_as_number(&jchip);
+  _this->chip = iotjs_jval_as_number(jchip);
   iotjs_jval_destroy(&jchip);
 #endif
 
   iotjs_jval_t jperiod =
       iotjs_jval_get_property(&jconfiguration, IOTJS_MAGIC_STRING_PERIOD);
-  if (iotjs_jval_is_number(&jperiod))
-    _this->period = iotjs_jval_as_number(&jperiod);
+  if (iotjs_jval_is_number(jperiod))
+    _this->period = iotjs_jval_as_number(jperiod);
 
   iotjs_jval_t jduty_cycle =
       iotjs_jval_get_property(&jconfiguration, IOTJS_MAGIC_STRING_DUTYCYCLE);
-  if (iotjs_jval_is_number(&jduty_cycle))
-    _this->duty_cycle = iotjs_jval_as_number(&jduty_cycle);
+  if (iotjs_jval_is_number(jduty_cycle))
+    _this->duty_cycle = iotjs_jval_as_number(jduty_cycle);
 
   iotjs_jval_destroy(&jpin);
   iotjs_jval_destroy(&jperiod);
@@ -252,12 +252,12 @@ JHANDLER_FUNCTION(PWMConstructor) {
   DJHANDLER_CHECK_ARGS(2, object, function);
 
   // Create PWM object
-  iotjs_jval_t jpwm = *JHANDLER_GET_THIS(object);
+  iotjs_jval_t jpwm = JHANDLER_GET_THIS(object);
   iotjs_pwm_t* pwm = iotjs_pwm_create(jpwm);
   IOTJS_ASSERT(pwm == iotjs_pwm_instance_from_jval(jpwm));
 
-  iotjs_jval_t jconfiguration = *JHANDLER_GET_ARG(0, object);
-  iotjs_jval_t jcallback = *JHANDLER_GET_ARG(1, function);
+  iotjs_jval_t jconfiguration = JHANDLER_GET_ARG(0, object);
+  iotjs_jval_t jcallback = JHANDLER_GET_ARG(1, function);
 
   // Set configuration
   iotjs_pwm_set_configuration(jconfiguration, pwm);

--- a/src/modules/iotjs_module_spi.c
+++ b/src/modules/iotjs_module_spi.c
@@ -114,15 +114,15 @@ iotjs_spi_t* iotjs_spi_instance_from_reqwrap(THIS) {
 static int iotjs_spi_get_array_data(char** buf, iotjs_jval_t jarray) {
   iotjs_jval_t jlength =
       iotjs_jval_get_property(&jarray, IOTJS_MAGIC_STRING_LENGTH);
-  IOTJS_ASSERT(!iotjs_jval_is_undefined(&jlength));
+  IOTJS_ASSERT(!iotjs_jval_is_undefined(jlength));
 
-  size_t length = iotjs_jval_as_number(&jlength);
+  size_t length = iotjs_jval_as_number(jlength);
   IOTJS_ASSERT((int)length >= 0);
   *buf = iotjs_buffer_allocate(length);
 
   for (size_t i = 0; i < length; i++) {
     iotjs_jval_t jdata = iotjs_jval_get_property_by_index(&jarray, i);
-    (*buf)[i] = iotjs_jval_as_number(&jdata);
+    (*buf)[i] = iotjs_jval_as_number(jdata);
     iotjs_jval_destroy(&jdata);
   }
 
@@ -180,42 +180,42 @@ static void iotjs_spi_set_configuration(iotjs_spi_t* spi,
 #if defined(__linux__)
   iotjs_jval_t jdevice =
       iotjs_jval_get_property(&joptions, IOTJS_MAGIC_STRING_DEVICE);
-  _this->device = iotjs_jval_as_string(&jdevice);
+  _this->device = iotjs_jval_as_string(jdevice);
   iotjs_jval_destroy(&jdevice);
 #elif defined(__NUTTX__) || defined(__TIZENRT__)
   iotjs_jval_t jbus =
       iotjs_jval_get_property(&joptions, IOTJS_MAGIC_STRING_BUS);
-  _this->bus = iotjs_jval_as_number(&jbus);
+  _this->bus = iotjs_jval_as_number(jbus);
   iotjs_jval_destroy(&jbus);
 #endif
   iotjs_jval_t jmode =
       iotjs_jval_get_property(&joptions, IOTJS_MAGIC_STRING_MODE);
-  _this->mode = (SpiMode)iotjs_jval_as_number(&jmode);
+  _this->mode = (SpiMode)iotjs_jval_as_number(jmode);
   iotjs_jval_destroy(&jmode);
 
   iotjs_jval_t jchip_select =
       iotjs_jval_get_property(&joptions, IOTJS_MAGIC_STRING_CHIPSELECT);
-  _this->chip_select = (SpiChipSelect)iotjs_jval_as_number(&jchip_select);
+  _this->chip_select = (SpiChipSelect)iotjs_jval_as_number(jchip_select);
   iotjs_jval_destroy(&jchip_select);
 
   iotjs_jval_t jmax_speed =
       iotjs_jval_get_property(&joptions, IOTJS_MAGIC_STRING_MAXSPEED);
-  _this->max_speed = iotjs_jval_as_number(&jmax_speed);
+  _this->max_speed = iotjs_jval_as_number(jmax_speed);
   iotjs_jval_destroy(&jmax_speed);
 
   iotjs_jval_t jbits_per_word =
       iotjs_jval_get_property(&joptions, IOTJS_MAGIC_STRING_BITSPERWORD);
-  _this->bits_per_word = (SpiOrder)iotjs_jval_as_number(&jbits_per_word);
+  _this->bits_per_word = (SpiOrder)iotjs_jval_as_number(jbits_per_word);
   iotjs_jval_destroy(&jbits_per_word);
 
   iotjs_jval_t jbit_order =
       iotjs_jval_get_property(&joptions, IOTJS_MAGIC_STRING_BITORDER);
-  _this->bit_order = (SpiOrder)iotjs_jval_as_number(&jbit_order);
+  _this->bit_order = (SpiOrder)iotjs_jval_as_number(jbit_order);
   iotjs_jval_destroy(&jbit_order);
 
   iotjs_jval_t jloopback =
       iotjs_jval_get_property(&joptions, IOTJS_MAGIC_STRING_LOOPBACK);
-  _this->loopback = iotjs_jval_as_boolean(&jloopback);
+  _this->loopback = iotjs_jval_as_boolean(jloopback);
   iotjs_jval_destroy(&jloopback);
 }
 
@@ -311,7 +311,7 @@ static void iotjs_spi_after_work(uv_work_t* work_req, int status) {
 
 
 iotjs_spi_t* iotjs_spi_get_instance(iotjs_jval_t jspi) {
-  uintptr_t handle = iotjs_jval_get_object_native_handle(&jspi);
+  uintptr_t handle = iotjs_jval_get_object_native_handle(jspi);
   return (iotjs_spi_t*)(handle);
 }
 
@@ -331,15 +331,15 @@ JHANDLER_FUNCTION(SpiConstructor) {
   DJHANDLER_CHECK_ARGS(2, object, function);
 
   // Create SPI object
-  iotjs_jval_t jspi = *JHANDLER_GET_THIS(object);
+  iotjs_jval_t jspi = JHANDLER_GET_THIS(object);
   iotjs_spi_t* spi = iotjs_spi_create(jspi);
   IOTJS_ASSERT(spi == iotjs_spi_get_instance(jspi));
 
   // Set configuration
-  iotjs_jval_t jconfiguration = *JHANDLER_GET_ARG(0, object);
+  iotjs_jval_t jconfiguration = JHANDLER_GET_ARG(0, object);
   iotjs_spi_set_configuration(spi, jconfiguration);
 
-  iotjs_jval_t jcallback = *JHANDLER_GET_ARG(1, function);
+  iotjs_jval_t jcallback = JHANDLER_GET_ARG(1, function);
   SPI_ASYNC(open, spi, jcallback, kSpiOpOpen);
 }
 
@@ -353,8 +353,8 @@ JHANDLER_FUNCTION(TransferArray) {
 
   iotjs_jval_t jcallback = JHANDLER_GET_ARG_IF_EXIST(2, function);
 
-  iotjs_spi_set_array_buffer(spi, *JHANDLER_GET_ARG(0, array),
-                             *JHANDLER_GET_ARG(1, array));
+  iotjs_spi_set_array_buffer(spi, JHANDLER_GET_ARG(0, array),
+                             JHANDLER_GET_ARG(1, array));
 
   if (!jerry_value_is_null(jcallback)) {
     SPI_ASYNC(transfer, spi, jcallback, kSpiOpTransferArray);
@@ -383,8 +383,8 @@ JHANDLER_FUNCTION(TransferBuffer) {
 
   iotjs_jval_t jcallback = JHANDLER_GET_ARG_IF_EXIST(2, function);
 
-  iotjs_spi_set_buffer(spi, *JHANDLER_GET_ARG(0, object),
-                       *JHANDLER_GET_ARG(1, object));
+  iotjs_spi_set_buffer(spi, JHANDLER_GET_ARG(0, object),
+                       JHANDLER_GET_ARG(1, object));
 
   if (!jerry_value_is_null(jcallback)) {
     SPI_ASYNC(transfer, spi, jcallback, kSpiOpTransferBuffer);

--- a/src/modules/iotjs_module_tcp.c
+++ b/src/modules/iotjs_module_tcp.c
@@ -71,7 +71,7 @@ uv_tcp_t* iotjs_tcpwrap_tcp_handle(iotjs_tcpwrap_t* tcpwrap) {
 
 iotjs_jval_t iotjs_tcpwrap_jobject(iotjs_tcpwrap_t* tcpwrap) {
   IOTJS_VALIDATED_STRUCT_METHOD(iotjs_tcpwrap_t, tcpwrap);
-  return *iotjs_handlewrap_jobject(&_this->handlewrap);
+  return iotjs_handlewrap_jobject(&_this->handlewrap);
 }
 
 
@@ -209,7 +209,7 @@ JHANDLER_FUNCTION(TCP) {
   DJHANDLER_CHECK_THIS(object);
   DJHANDLER_CHECK_ARGS(0);
 
-  iotjs_jval_t jtcp = *JHANDLER_GET_THIS(object);
+  iotjs_jval_t jtcp = JHANDLER_GET_THIS(object);
   iotjs_tcpwrap_t* tcp_wrap = iotjs_tcpwrap_create(jtcp);
   IOTJS_UNUSED(tcp_wrap);
 }
@@ -224,12 +224,12 @@ void AfterClose(uv_handle_t* handle) {
   iotjs_handlewrap_t* wrap = iotjs_handlewrap_from_handle(handle);
 
   // tcp object.
-  iotjs_jval_t jtcp = *iotjs_handlewrap_jobject(wrap);
+  iotjs_jval_t jtcp = iotjs_handlewrap_jobject(wrap);
 
   // callback function.
   iotjs_jval_t jcallback =
       iotjs_jval_get_property(&jtcp, IOTJS_MAGIC_STRING_ONCLOSE);
-  if (iotjs_jval_is_function(&jcallback)) {
+  if (iotjs_jval_is_function(jcallback)) {
     iotjs_make_callback(&jcallback, iotjs_jval_get_undefined(),
                         iotjs_jargs_get_empty());
   }
@@ -281,7 +281,7 @@ static void AfterConnect(uv_connect_t* req, int status) {
   // Take callback function object.
   // function afterConnect(status)
   iotjs_jval_t jcallback = iotjs_connect_reqwrap_jcallback(req_wrap);
-  IOTJS_ASSERT(iotjs_jval_is_function(&jcallback));
+  IOTJS_ASSERT(iotjs_jval_is_function(jcallback));
 
   // Only parameter is status code.
   iotjs_jargs_t args = iotjs_jargs_create(1);
@@ -309,7 +309,7 @@ JHANDLER_FUNCTION(Connect) {
 
   iotjs_string_t address = JHANDLER_GET_ARG(0, string);
   int port = JHANDLER_GET_ARG(1, number);
-  iotjs_jval_t jcallback = *JHANDLER_GET_ARG(2, function);
+  iotjs_jval_t jcallback = JHANDLER_GET_ARG(2, function);
 
   sockaddr_in addr;
   int err = uv_ip4_addr(iotjs_string_data(&address), port, &addr);
@@ -348,7 +348,7 @@ static void OnConnection(uv_stream_t* handle, int status) {
   // `onconnection` callback.
   iotjs_jval_t jonconnection =
       iotjs_jval_get_property(&jtcp, IOTJS_MAGIC_STRING_ONCONNECTION);
-  IOTJS_ASSERT(iotjs_jval_is_function(&jonconnection));
+  IOTJS_ASSERT(iotjs_jval_is_function(jonconnection));
 
   // The callback takes two parameter
   // [0] status
@@ -360,15 +360,15 @@ static void OnConnection(uv_stream_t* handle, int status) {
     // Create client socket handle wrapper.
     iotjs_jval_t jcreate_tcp =
         iotjs_jval_get_property(&jtcp, IOTJS_MAGIC_STRING_CREATETCP);
-    IOTJS_ASSERT(iotjs_jval_is_function(&jcreate_tcp));
+    IOTJS_ASSERT(iotjs_jval_is_function(jcreate_tcp));
 
     iotjs_jval_t jclient_tcp =
         iotjs_jhelper_call_ok(&jcreate_tcp, iotjs_jval_get_undefined(),
                               iotjs_jargs_get_empty());
-    IOTJS_ASSERT(iotjs_jval_is_object(&jclient_tcp));
+    IOTJS_ASSERT(iotjs_jval_is_object(jclient_tcp));
 
     iotjs_tcpwrap_t* tcp_wrap_client =
-        (iotjs_tcpwrap_t*)(iotjs_jval_get_object_native_handle(&jclient_tcp));
+        (iotjs_tcpwrap_t*)(iotjs_jval_get_object_native_handle(jclient_tcp));
 
     uv_stream_t* client_handle =
         (uv_stream_t*)(iotjs_tcpwrap_tcp_handle(tcp_wrap_client));
@@ -431,7 +431,7 @@ JHANDLER_FUNCTION(Write) {
   JHANDLER_DECLARE_THIS_PTR(tcpwrap, tcp_wrap);
   DJHANDLER_CHECK_ARGS(2, object, function);
 
-  const iotjs_jval_t jbuffer = *JHANDLER_GET_ARG(0, object);
+  const iotjs_jval_t jbuffer = JHANDLER_GET_ARG(0, object);
   iotjs_bufferwrap_t* buffer_wrap = iotjs_bufferwrap_from_jbuffer(jbuffer);
   char* buffer = iotjs_bufferwrap_buffer(buffer_wrap);
   size_t len = iotjs_bufferwrap_length(buffer_wrap);
@@ -440,7 +440,7 @@ JHANDLER_FUNCTION(Write) {
   buf.base = buffer;
   buf.len = len;
 
-  iotjs_jval_t arg1 = *JHANDLER_GET_ARG(1, object);
+  iotjs_jval_t arg1 = JHANDLER_GET_ARG(1, object);
   iotjs_write_reqwrap_t* req_wrap = iotjs_write_reqwrap_create(arg1);
 
   int err = uv_write(iotjs_write_reqwrap_req(req_wrap),
@@ -474,12 +474,12 @@ void OnRead(uv_stream_t* handle, ssize_t nread, const uv_buf_t* buf) {
   // socket object
   iotjs_jval_t jsocket =
       iotjs_jval_get_property(&jtcp, IOTJS_MAGIC_STRING_OWNER);
-  IOTJS_ASSERT(iotjs_jval_is_object(&jsocket));
+  IOTJS_ASSERT(iotjs_jval_is_object(jsocket));
 
   // onread callback
   iotjs_jval_t jonread =
       iotjs_jval_get_property(&jtcp, IOTJS_MAGIC_STRING_ONREAD);
-  IOTJS_ASSERT(iotjs_jval_is_function(&jonread));
+  IOTJS_ASSERT(iotjs_jval_is_function(jonread));
 
   iotjs_jargs_t jargs = iotjs_jargs_create(4);
   iotjs_jargs_append_jval(&jargs, &jsocket);
@@ -534,7 +534,7 @@ static void AfterShutdown(uv_shutdown_t* req, int status) {
 
   // function onShutdown(status)
   iotjs_jval_t jonshutdown = iotjs_shutdown_reqwrap_jcallback(req_wrap);
-  IOTJS_ASSERT(iotjs_jval_is_function(&jonshutdown));
+  IOTJS_ASSERT(iotjs_jval_is_function(jonshutdown));
 
   iotjs_jargs_t args = iotjs_jargs_create(1);
   iotjs_jargs_append_number(&args, status);
@@ -552,7 +552,7 @@ JHANDLER_FUNCTION(Shutdown) {
 
   DJHANDLER_CHECK_ARGS(1, function);
 
-  iotjs_jval_t arg0 = *JHANDLER_GET_ARG(0, object);
+  iotjs_jval_t arg0 = JHANDLER_GET_ARG(0, object);
   iotjs_shutdown_reqwrap_t* req_wrap = iotjs_shutdown_reqwrap_create(arg0);
 
   int err = uv_shutdown(iotjs_shutdown_reqwrap_req(req_wrap),

--- a/src/modules/iotjs_module_tcp.h
+++ b/src/modules/iotjs_module_tcp.h
@@ -91,7 +91,7 @@ void AddressToJS(iotjs_jval_t obj, const sockaddr* addr);
     DJHANDLER_CHECK_ARGS(1, object);                                           \
                                                                                \
     iotjs_##wraptype##_t* wrap =                                               \
-        iotjs_##wraptype##_from_jobject(*JHANDLER_GET_THIS(object));           \
+        iotjs_##wraptype##_from_jobject(JHANDLER_GET_THIS(object));            \
     IOTJS_ASSERT(wrap != NULL);                                                \
                                                                                \
     sockaddr_storage storage;                                                  \
@@ -99,7 +99,7 @@ void AddressToJS(iotjs_jval_t obj, const sockaddr* addr);
     sockaddr* const addr = (sockaddr*)(&storage);                              \
     int err = function(iotjs_##wraptype##_##handletype(wrap), addr, &addrlen); \
     if (err == 0)                                                              \
-      AddressToJS(*JHANDLER_GET_ARG(0, object), addr);                         \
+      AddressToJS(JHANDLER_GET_ARG(0, object), addr);                          \
     iotjs_jhandler_return_number(jhandler, err);                               \
   }
 

--- a/src/modules/iotjs_module_testdriver.c
+++ b/src/modules/iotjs_module_testdriver.c
@@ -23,14 +23,14 @@ JHANDLER_FUNCTION(IsAliveExceptFor) {
   const iotjs_environment_t* env = iotjs_environment_get();
   uv_loop_t* loop = iotjs_environment_loop(env);
 
-  const iotjs_jval_t arg0 = *iotjs_jhandler_get_arg(jhandler, 0);
+  const iotjs_jval_t arg0 = iotjs_jhandler_get_arg(jhandler, 0);
 
-  if (iotjs_jval_is_null(&arg0)) {
+  if (iotjs_jval_is_null(arg0)) {
     int alive = uv_loop_alive(loop);
 
     iotjs_jhandler_return_boolean(jhandler, alive);
   } else {
-    JHANDLER_CHECK(iotjs_jval_is_object(&arg0));
+    JHANDLER_CHECK(iotjs_jval_is_object(arg0));
 
     iotjs_jval_t jtimer =
         iotjs_jval_get_property(&arg0, IOTJS_MAGIC_STRING_HANDLER);

--- a/src/modules/iotjs_module_timer.c
+++ b/src/modules/iotjs_module_timer.c
@@ -102,8 +102,8 @@ uv_timer_t* iotjs_timerwrap_handle(iotjs_timerwrap_t* timerwrap) {
 
 iotjs_jval_t iotjs_timerwrap_jobject(iotjs_timerwrap_t* timerwrap) {
   IOTJS_VALIDATED_STRUCT_METHOD(iotjs_timerwrap_t, timerwrap);
-  iotjs_jval_t jobject = *iotjs_handlewrap_jobject(&_this->handlewrap);
-  IOTJS_ASSERT(iotjs_jval_is_object(&jobject));
+  iotjs_jval_t jobject = iotjs_handlewrap_jobject(&_this->handlewrap);
+  IOTJS_ASSERT(iotjs_jval_is_object(jobject));
   return jobject;
 }
 
@@ -151,13 +151,13 @@ JHANDLER_FUNCTION(Stop) {
 JHANDLER_FUNCTION(Timer) {
   JHANDLER_CHECK_THIS(object);
 
-  const iotjs_jval_t jtimer = *JHANDLER_GET_THIS(object);
+  const iotjs_jval_t jtimer = JHANDLER_GET_THIS(object);
 
   iotjs_timerwrap_t* timer_wrap = iotjs_timerwrap_create(jtimer);
 
   iotjs_jval_t jobject = iotjs_timerwrap_jobject(timer_wrap);
-  IOTJS_ASSERT(iotjs_jval_is_object(&jobject));
-  IOTJS_ASSERT(iotjs_jval_get_object_native_handle(&jtimer) != 0);
+  IOTJS_ASSERT(iotjs_jval_is_object(jobject));
+  IOTJS_ASSERT(iotjs_jval_get_object_native_handle(jtimer) != 0);
 }
 
 

--- a/src/modules/iotjs_module_uart.c
+++ b/src/modules/iotjs_module_uart.c
@@ -212,7 +212,7 @@ static void iotjs_uart_after_worker(uv_work_t* work_req, int status) {
 
 static void iotjs_uart_onread(iotjs_jval_t jthis, char* buf) {
   iotjs_jval_t jemit = iotjs_jval_get_property(&jthis, "emit");
-  IOTJS_ASSERT(iotjs_jval_is_function(&jemit));
+  IOTJS_ASSERT(iotjs_jval_is_function(jemit));
 
   iotjs_jargs_t jargs = iotjs_jargs_create(2);
   iotjs_jval_t str = iotjs_jval_create_string_raw("data");
@@ -258,15 +258,15 @@ JHANDLER_FUNCTION(UartConstructor) {
   DJHANDLER_CHECK_ARGS(3, object, object, function);
 
   // Create UART object
-  iotjs_jval_t juart = *JHANDLER_GET_THIS(object);
+  iotjs_jval_t juart = JHANDLER_GET_THIS(object);
   iotjs_uart_t* uart = iotjs_uart_create(juart);
   IOTJS_ASSERT(uart == iotjs_uart_instance_from_jval(juart));
   IOTJS_VALIDATED_STRUCT_METHOD(iotjs_uart_t, uart);
 
-  iotjs_jval_t jconfiguration = *JHANDLER_GET_ARG(0, object);
-  iotjs_jval_t jemitter_this = *JHANDLER_GET_ARG(1, object);
+  iotjs_jval_t jconfiguration = JHANDLER_GET_ARG(0, object);
+  iotjs_jval_t jemitter_this = JHANDLER_GET_ARG(1, object);
   _this->jemitter_this = iotjs_jval_create_copied(&jemitter_this);
-  iotjs_jval_t jcallback = *JHANDLER_GET_ARG(2, function);
+  iotjs_jval_t jcallback = JHANDLER_GET_ARG(2, function);
 
   // set configuration
   iotjs_jval_t jdevice =
@@ -276,9 +276,9 @@ JHANDLER_FUNCTION(UartConstructor) {
   iotjs_jval_t jdata_bits =
       iotjs_jval_get_property(&jconfiguration, IOTJS_MAGIC_STRING_DATABITS);
 
-  _this->device_path = iotjs_jval_as_string(&jdevice);
-  _this->baud_rate = iotjs_jval_as_number(&jbaud_rate);
-  _this->data_bits = iotjs_jval_as_number(&jdata_bits);
+  _this->device_path = iotjs_jval_as_string(jdevice);
+  _this->baud_rate = iotjs_jval_as_number(jbaud_rate);
+  _this->data_bits = iotjs_jval_as_number(jdata_bits);
 
   DDDLOG("%s - path: %s, baudRate: %d, dataBits: %d", __func__,
          iotjs_string_data(&_this->device_path), _this->baud_rate,

--- a/src/modules/iotjs_module_udp.c
+++ b/src/modules/iotjs_module_udp.c
@@ -72,7 +72,7 @@ uv_udp_t* iotjs_udpwrap_udp_handle(iotjs_udpwrap_t* udpwrap) {
 
 iotjs_jval_t iotjs_udpwrap_jobject(iotjs_udpwrap_t* udpwrap) {
   IOTJS_VALIDATED_STRUCT_METHOD(iotjs_udpwrap_t, udpwrap);
-  return *iotjs_handlewrap_jobject(&_this->handlewrap);
+  return iotjs_handlewrap_jobject(&_this->handlewrap);
 }
 
 
@@ -127,7 +127,7 @@ JHANDLER_FUNCTION(UDP) {
   DJHANDLER_CHECK_THIS(object);
   DJHANDLER_CHECK_ARGS(0);
 
-  iotjs_jval_t judp = *JHANDLER_GET_THIS(object);
+  iotjs_jval_t judp = JHANDLER_GET_THIS(object);
   iotjs_udpwrap_t* udp_wrap = iotjs_udpwrap_create(judp);
   IOTJS_UNUSED(udp_wrap);
 }
@@ -139,15 +139,15 @@ JHANDLER_FUNCTION(Bind) {
 
   iotjs_string_t address = JHANDLER_GET_ARG(0, string);
   const int port = JHANDLER_GET_ARG(1, number);
-  iotjs_jval_t this_obj = *JHANDLER_GET_THIS(object);
+  iotjs_jval_t this_obj = JHANDLER_GET_THIS(object);
   iotjs_jval_t reuse_addr =
       iotjs_jval_get_property(&this_obj, IOTJS_MAGIC_STRING__REUSEADDR);
-  IOTJS_ASSERT(iotjs_jval_is_boolean(&reuse_addr) ||
-               iotjs_jval_is_undefined(&reuse_addr));
+  IOTJS_ASSERT(iotjs_jval_is_boolean(reuse_addr) ||
+               iotjs_jval_is_undefined(reuse_addr));
 
   unsigned int flags = 0;
-  if (!iotjs_jval_is_undefined(&reuse_addr)) {
-    flags = iotjs_jval_as_boolean(&reuse_addr) ? UV_UDP_REUSEADDR : 0;
+  if (!iotjs_jval_is_undefined(reuse_addr)) {
+    flags = iotjs_jval_as_boolean(reuse_addr) ? UV_UDP_REUSEADDR : 0;
   }
 
   char addr[sizeof(sockaddr_in6)];
@@ -188,12 +188,12 @@ static void OnRecv(uv_udp_t* handle, ssize_t nread, const uv_buf_t* buf,
 
   // udp handle
   iotjs_jval_t judp = iotjs_udpwrap_jobject(udp_wrap);
-  IOTJS_ASSERT(iotjs_jval_is_object(&judp));
+  IOTJS_ASSERT(iotjs_jval_is_object(judp));
 
   // onmessage callback
   iotjs_jval_t jonmessage =
       iotjs_jval_get_property(&judp, IOTJS_MAGIC_STRING_ONMESSAGE);
-  IOTJS_ASSERT(iotjs_jval_is_function(&jonmessage));
+  IOTJS_ASSERT(iotjs_jval_is_function(jonmessage));
 
   iotjs_jargs_t jargs = iotjs_jargs_create(4);
   iotjs_jargs_append_number(&jargs, nread);
@@ -261,7 +261,7 @@ static void OnSend(uv_udp_send_t* req, int status) {
   // Take callback function object.
   iotjs_jval_t jcallback = iotjs_send_reqwrap_jcallback(req_wrap);
 
-  if (iotjs_jval_is_function(&jcallback)) {
+  if (iotjs_jval_is_function(jcallback)) {
     // Take callback function object.
 
     iotjs_jargs_t jargs = iotjs_jargs_create(2);
@@ -287,10 +287,10 @@ JHANDLER_FUNCTION(Send) {
   IOTJS_ASSERT(iotjs_jval_is_function(iotjs_jhandler_get_arg(jhandler, 3)) ||
                iotjs_jval_is_undefined(iotjs_jhandler_get_arg(jhandler, 3)));
 
-  const iotjs_jval_t jbuffer = *JHANDLER_GET_ARG(0, object);
+  const iotjs_jval_t jbuffer = JHANDLER_GET_ARG(0, object);
   const unsigned short port = JHANDLER_GET_ARG(1, number);
   iotjs_string_t address = JHANDLER_GET_ARG(2, string);
-  iotjs_jval_t jcallback = *JHANDLER_GET_ARG(3, object);
+  iotjs_jval_t jcallback = JHANDLER_GET_ARG(3, object);
 
   iotjs_bufferwrap_t* buffer_wrap = iotjs_bufferwrap_from_jbuffer(jbuffer);
   char* buffer = iotjs_bufferwrap_buffer(buffer_wrap);
@@ -401,16 +401,16 @@ void SetMembership(iotjs_jhandler_t* jhandler, uv_membership membership) {
   DJHANDLER_CHECK_ARGS(1, string);
 
   iotjs_string_t address = JHANDLER_GET_ARG(0, string);
-  iotjs_jval_t arg1 = *iotjs_jhandler_get_arg(jhandler, 1);
+  iotjs_jval_t arg1 = iotjs_jhandler_get_arg(jhandler, 1);
   bool isUndefinedOrNull =
-      iotjs_jval_is_undefined(&arg1) || iotjs_jval_is_null(&arg1);
+      iotjs_jval_is_undefined(arg1) || iotjs_jval_is_null(arg1);
   iotjs_string_t iface;
 
   const char* iface_cstr;
   if (isUndefinedOrNull) {
     iface_cstr = NULL;
   } else {
-    iface = iotjs_jval_as_string(&arg1);
+    iface = iotjs_jval_as_string(arg1);
     iface_cstr = iotjs_string_data(&iface);
   }
 

--- a/src/platform/linux/iotjs_module_blehcisocket-linux.c
+++ b/src/platform/linux/iotjs_module_blehcisocket-linux.c
@@ -297,9 +297,9 @@ void iotjs_blehcisocket_poll(THIS) {
       }
     }
 
-    iotjs_jval_t jhcisocket = *iotjs_jobjectwrap_jobject(&_this->jobjectwrap);
+    iotjs_jval_t jhcisocket = iotjs_jobjectwrap_jobject(&_this->jobjectwrap);
     iotjs_jval_t jemit = iotjs_jval_get_property(&jhcisocket, "emit");
-    IOTJS_ASSERT(iotjs_jval_is_function(&jemit));
+    IOTJS_ASSERT(iotjs_jval_is_function(jemit));
 
     iotjs_jargs_t jargs = iotjs_jargs_create(2);
     iotjs_jval_t str = iotjs_jval_create_string_raw("data");
@@ -338,9 +338,9 @@ void iotjs_blehcisocket_write(THIS, char* data, size_t length) {
 void iotjs_blehcisocket_emitErrnoError(THIS) {
   IOTJS_VALIDATED_STRUCT_METHOD(iotjs_blehcisocket_t, blehcisocket);
 
-  iotjs_jval_t jhcisocket = *iotjs_jobjectwrap_jobject(&_this->jobjectwrap);
+  iotjs_jval_t jhcisocket = iotjs_jobjectwrap_jobject(&_this->jobjectwrap);
   iotjs_jval_t jemit = iotjs_jval_get_property(&jhcisocket, "emit");
-  IOTJS_ASSERT(iotjs_jval_is_function(&jemit));
+  IOTJS_ASSERT(iotjs_jval_is_function(jemit));
 
   iotjs_jargs_t jargs = iotjs_jargs_create(2);
   iotjs_jval_t str = iotjs_jval_create_string_raw("error");

--- a/src/platform/linux/iotjs_module_gpio-linux.c
+++ b/src/platform/linux/iotjs_module_gpio-linux.c
@@ -79,9 +79,9 @@ static void gpio_set_value_fd(iotjs_gpio_t* gpio, int fd) {
 static void gpio_emit_change_event(iotjs_gpio_t* gpio) {
   IOTJS_VALIDATED_STRUCT_METHOD(iotjs_gpio_t, gpio);
 
-  iotjs_jval_t jgpio = *iotjs_jobjectwrap_jobject(&_this->jobjectwrap);
+  iotjs_jval_t jgpio = iotjs_jobjectwrap_jobject(&_this->jobjectwrap);
   iotjs_jval_t jonChange = iotjs_jval_get_property(&jgpio, "onChange");
-  IOTJS_ASSERT(iotjs_jval_is_function(&jonChange));
+  IOTJS_ASSERT(iotjs_jval_is_function(jonChange));
 
   iotjs_jhelper_call_ok(&jonChange, &jgpio, iotjs_jargs_get_empty());
 


### PR DESCRIPTION
 * Changed 'iotjs_jval_as_*' functions
 * Changed 'iotjs_jval_is_*' functions
 * Updated the call sites

IoT.js-DCO-1.0-Signed-off-by: László Langó llango.u-szeged@partner.samsung.com