### PR TITLE
Removed 'iotjs_jval_t' pointer from 'iotjs_jargs_replace' and 'iotjs_…

### DIFF
--- a/src/iotjs_binding.c
+++ b/src/iotjs_binding.c
@@ -392,6 +392,17 @@ iotjs_jval_t iotjs_jval_get_property_by_index(iotjs_jval_t jarr, uint32_t idx) {
 }
 
 
+#ifndef NDEBUG
+static iotjs_jval_t iotjs_jargs_get(const iotjs_jargs_t* jargs,
+                                    uint16_t index) {
+  const IOTJS_VALIDATED_STRUCT_METHOD(iotjs_jargs_t, jargs);
+
+  IOTJS_ASSERT(index < _this->argc);
+  return _this->argv[index];
+}
+#endif
+
+
 iotjs_jval_t iotjs_jhelper_call(iotjs_jval_t jfunc, iotjs_jval_t jthis,
                                 const iotjs_jargs_t* jargs, bool* throws) {
   IOTJS_ASSERT(iotjs_jval_is_object(jfunc));
@@ -406,7 +417,7 @@ iotjs_jval_t iotjs_jhelper_call(iotjs_jval_t jfunc, iotjs_jval_t jthis,
     unsigned buffer_size = sizeof(jerry_value_t) * jargc_;
     jargv_ = (jerry_value_t*)iotjs_buffer_allocate(buffer_size);
     for (unsigned i = 0; i < jargc_; ++i) {
-      jargv_[i] = *iotjs_jargs_get(jargs, i);
+      jargv_[i] = iotjs_jargs_get(jargs, i);
     }
   }
 #endif
@@ -596,23 +607,13 @@ void iotjs_jargs_append_string_raw(iotjs_jargs_t* jargs, const char* x) {
 }
 
 
-void iotjs_jargs_replace(iotjs_jargs_t* jargs, uint16_t index,
-                         const iotjs_jval_t* x) {
+void iotjs_jargs_replace(iotjs_jargs_t* jargs, uint16_t index, iotjs_jval_t x) {
   IOTJS_VALIDATED_STRUCT_METHOD(iotjs_jargs_t, jargs);
 
   IOTJS_ASSERT(index < _this->argc);
 
   iotjs_jval_destroy(&_this->argv[index]);
-  _this->argv[index] = jerry_acquire_value(*x);
-}
-
-
-const iotjs_jval_t* iotjs_jargs_get(const iotjs_jargs_t* jargs,
-                                    uint16_t index) {
-  const IOTJS_VALIDATED_STRUCT_METHOD(iotjs_jargs_t, jargs);
-
-  IOTJS_ASSERT(index < _this->argc);
-  return &_this->argv[index];
+  _this->argv[index] = jerry_acquire_value(x);
 }
 
 

--- a/src/iotjs_binding.h
+++ b/src/iotjs_binding.h
@@ -164,11 +164,7 @@ void iotjs_jargs_append_string_raw(iotjs_jargs_t* jargs, const char* x);
 void iotjs_jargs_append_error(iotjs_jargs_t* jargs, const char* msg);
 
 
-void iotjs_jargs_replace(iotjs_jargs_t* jargs, uint16_t index,
-                         const iotjs_jval_t* x);
-
-const iotjs_jval_t* iotjs_jargs_get(const iotjs_jargs_t* jargs, uint16_t index);
-
+void iotjs_jargs_replace(iotjs_jargs_t* jargs, uint16_t index, iotjs_jval_t x);
 
 // Calls JavaScript function.
 iotjs_jval_t iotjs_jhelper_call(iotjs_jval_t jfunc, iotjs_jval_t jthis,

--- a/src/modules/iotjs_module_tcp.c
+++ b/src/modules/iotjs_module_tcp.c
@@ -493,7 +493,7 @@ void OnRead(uv_stream_t* handle, ssize_t nread, const uv_buf_t* buf) {
     }
     if (nread < 0) {
       if (nread == UV__EOF) {
-        iotjs_jargs_replace(&jargs, 2, iotjs_jval_get_boolean(true));
+        iotjs_jargs_replace(&jargs, 2, *iotjs_jval_get_boolean(true));
       }
 
       iotjs_make_callback(&jonread, iotjs_jval_get_undefined(), &jargs);


### PR DESCRIPTION
…jargs_get'.

IoT.js-DCO-1.0-Signed-off-by: László Langó llango.u-szeged@partner.samsung.com