### PR TITLE
Removed 'iotjs_jval_t' pointer from 'iotjs_uncaught_exception' and 'iotjs_init_process_module'

### DIFF
--- a/src/iotjs.c
+++ b/src/iotjs.c
@@ -107,7 +107,7 @@ static bool iotjs_run(iotjs_environment_t* env) {
 #endif
 
   if (throws) {
-    iotjs_uncaught_exception(&jmain);
+    iotjs_uncaught_exception(jmain);
   }
 
   iotjs_jval_destroy(&jmain);
@@ -128,7 +128,7 @@ static int iotjs_start(iotjs_environment_t* env) {
   iotjs_module_list_init();
 
   // Initialize builtin process module.
-  const iotjs_jval_t process = *iotjs_init_process_module();
+  const iotjs_jval_t process = iotjs_init_process_module();
   iotjs_jval_set_property_jval(global, "process", process);
 
   // Set running state.

--- a/src/iotjs_binding_helper.c
+++ b/src/iotjs_binding_helper.c
@@ -20,7 +20,7 @@
 #include <string.h>
 
 
-void iotjs_uncaught_exception(const iotjs_jval_t* jexception) {
+void iotjs_uncaught_exception(iotjs_jval_t jexception) {
   const iotjs_jval_t process = *iotjs_module_get(MODULE_PROCESS);
 
   iotjs_jval_t jonuncaughtexception =
@@ -28,7 +28,7 @@ void iotjs_uncaught_exception(const iotjs_jval_t* jexception) {
   IOTJS_ASSERT(iotjs_jval_is_function(jonuncaughtexception));
 
   iotjs_jargs_t args = iotjs_jargs_create(1);
-  iotjs_jargs_append_jval(&args, *jexception);
+  iotjs_jargs_append_jval(&args, jexception);
 
   bool throws;
   iotjs_jval_t jres =
@@ -119,7 +119,7 @@ iotjs_jval_t iotjs_make_callback_with_result(const iotjs_jval_t* jfunction,
   bool throws;
   iotjs_jval_t jres = iotjs_jhelper_call(*jfunction, *jthis, jargs, &throws);
   if (throws) {
-    iotjs_uncaught_exception(&jres);
+    iotjs_uncaught_exception(jres);
   }
 
   // Calls the next tick callbacks.
@@ -150,6 +150,6 @@ void iotjs_set_process_exitcode(int code) {
 }
 
 
-const iotjs_jval_t* iotjs_init_process_module() {
-  return iotjs_module_initialize_if_necessary(MODULE_PROCESS);
+iotjs_jval_t iotjs_init_process_module() {
+  return *iotjs_module_initialize_if_necessary(MODULE_PROCESS);
 }

--- a/src/iotjs_binding_helper.h
+++ b/src/iotjs_binding_helper.h
@@ -20,7 +20,7 @@
 #include "iotjs_binding.h"
 
 
-void iotjs_uncaught_exception(const iotjs_jval_t* jexception);
+void iotjs_uncaught_exception(iotjs_jval_t jexception);
 
 void iotjs_process_emit_exit(int code);
 
@@ -34,7 +34,7 @@ iotjs_jval_t iotjs_make_callback_with_result(const iotjs_jval_t* jfunction,
                                              const iotjs_jargs_t* jargs);
 
 
-const iotjs_jval_t* iotjs_init_process_module();
+iotjs_jval_t iotjs_init_process_module();
 
 int iotjs_process_exitcode();
 void iotjs_set_process_exitcode(int code);


### PR DESCRIPTION
IoT.js-DCO-1.0-Signed-off-by: László Langó llango.u-szeged@partner.samsung.com