### PR TITLE
Add filtering disabled modules

### DIFF
--- a/build.module
+++ b/build.module
@@ -13,7 +13,8 @@
     },
     "disabled": {
       "board": {
-        "rp2": ["adc"],
+        "x86-linux": ["adc", "ble", "dgram", "gpio", "i2c", "pwm", "spi", "uart"],
+        "rpi2": ["adc"],
         "stm32f4dis": ["ble"],
         "artik05x": ["ble"],
         "artik10": []


### PR DESCRIPTION
This patch refers to target-board along with target-os to build available modules for each travis task.

IoT.js-DCO-1.0-Signed-off-by: Daeyeon Jeong daeyeon.jeong@samsung.com