### PR TITLE
Remove 'DJHANDLER_CHECK_ARGS(0)' calls.

### DIFF
--- a/src/iotjs_binding.h
+++ b/src/iotjs_binding.h
@@ -252,13 +252,8 @@ iotjs_jval_t iotjs_jval_create_function_with_dispatch(
   JHANDLER_CHECK_ARGS_4(type0, type1, type2, type3);             \
   JHANDLER_CHECK_ARG(4, type4);
 
-// Workaround for GCC type-limits warning
-static inline bool ge(uint16_t a, uint16_t b) {
-  return a >= b;
-}
-
-#define JHANDLER_CHECK_ARGS(argc, ...)                               \
-  JHANDLER_CHECK(ge(iotjs_jhandler_get_arg_length(jhandler), argc)); \
+#define JHANDLER_CHECK_ARGS(argc, ...)                             \
+  JHANDLER_CHECK(iotjs_jhandler_get_arg_length(jhandler) >= argc); \
   JHANDLER_CHECK_ARGS_##argc(__VA_ARGS__)
 
 #define JHANDLER_CHECK_THIS(type) \

--- a/src/modules/iotjs_module_blehcisocket.c
+++ b/src/modules/iotjs_module_blehcisocket.c
@@ -78,7 +78,6 @@ static void iotjs_blehcisocket_destroy(THIS) {
 
 JHANDLER_FUNCTION(Start) {
   JHANDLER_DECLARE_THIS_PTR(blehcisocket, blehcisocket);
-  DJHANDLER_CHECK_ARGS(0);
 
   iotjs_blehcisocket_start(blehcisocket);
 
@@ -88,7 +87,7 @@ JHANDLER_FUNCTION(Start) {
 
 JHANDLER_FUNCTION(BindRaw) {
   JHANDLER_DECLARE_THIS_PTR(blehcisocket, blehcisocket);
-  JHANDLER_CHECK(ge(iotjs_jhandler_get_arg_length(jhandler), 1));
+  JHANDLER_CHECK(iotjs_jhandler_get_arg_length(jhandler) >= 1);
 
   int devId = 0;
   int* pDevId = NULL;
@@ -120,7 +119,6 @@ JHANDLER_FUNCTION(BindUser) {
 
 JHANDLER_FUNCTION(BindControl) {
   JHANDLER_DECLARE_THIS_PTR(blehcisocket, blehcisocket);
-  DJHANDLER_CHECK_ARGS(0);
 
   iotjs_blehcisocket_bindControl(blehcisocket);
 
@@ -130,7 +128,6 @@ JHANDLER_FUNCTION(BindControl) {
 
 JHANDLER_FUNCTION(IsDevUp) {
   JHANDLER_DECLARE_THIS_PTR(blehcisocket, blehcisocket);
-  DJHANDLER_CHECK_ARGS(0);
 
   bool ret = iotjs_blehcisocket_isDevUp(blehcisocket);
 
@@ -154,7 +151,6 @@ JHANDLER_FUNCTION(SetFilter) {
 
 JHANDLER_FUNCTION(Stop) {
   JHANDLER_DECLARE_THIS_PTR(blehcisocket, blehcisocket);
-  DJHANDLER_CHECK_ARGS(0);
 
   iotjs_blehcisocket_stop(blehcisocket);
 
@@ -178,7 +174,6 @@ JHANDLER_FUNCTION(Write) {
 
 JHANDLER_FUNCTION(BleHciSocketCons) {
   DJHANDLER_CHECK_THIS(object);
-  DJHANDLER_CHECK_ARGS(0);
 
   // Create object
   iotjs_jval_t jblehcisocket = JHANDLER_GET_THIS(object);

--- a/src/modules/iotjs_module_gpio.c
+++ b/src/modules/iotjs_module_gpio.c
@@ -292,7 +292,6 @@ JHANDLER_FUNCTION(Write) {
 
 JHANDLER_FUNCTION(Read) {
   JHANDLER_DECLARE_THIS_PTR(gpio, gpio);
-  DJHANDLER_CHECK_ARGS(0);
   DJHANDLER_CHECK_ARG_IF_EXIST(0, function);
 
   const iotjs_jval_t jcallback = JHANDLER_GET_ARG_IF_EXIST(0, function);

--- a/src/modules/iotjs_module_httpparser.c
+++ b/src/modules/iotjs_module_httpparser.c
@@ -396,7 +396,6 @@ JHANDLER_FUNCTION(Reinitialize) {
 
 JHANDLER_FUNCTION(Finish) {
   JHANDLER_DECLARE_THIS_PTR(httpparserwrap, parser);
-  DJHANDLER_CHECK_ARGS(0);
   IOTJS_VALIDATED_STRUCT_METHOD(iotjs_httpparserwrap_t, parser);
 
   http_parser* nativeparser = &_this->parser;
@@ -439,7 +438,6 @@ JHANDLER_FUNCTION(Execute) {
 
 static void iotjs_httpparser_pause(iotjs_jhandler_t* jhandler, int paused) {
   JHANDLER_DECLARE_THIS_PTR(httpparserwrap, parser);
-  DJHANDLER_CHECK_ARGS(0);
   IOTJS_VALIDATED_STRUCT_METHOD(iotjs_httpparserwrap_t, parser);
 
   http_parser* nativeparser = &_this->parser;

--- a/src/modules/iotjs_module_i2c.c
+++ b/src/modules/iotjs_module_i2c.c
@@ -225,7 +225,6 @@ JHANDLER_FUNCTION(SetAddress) {
 
 JHANDLER_FUNCTION(Close) {
   JHANDLER_DECLARE_THIS_PTR(i2c, i2c);
-  DJHANDLER_CHECK_ARGS(0);
 
   I2cClose(i2c);
   iotjs_i2c_destroy(i2c);

--- a/src/modules/iotjs_module_process.c
+++ b/src/modules/iotjs_module_process.c
@@ -167,8 +167,6 @@ JHANDLER_FUNCTION(ReadSource) {
 
 
 JHANDLER_FUNCTION(Cwd) {
-  DJHANDLER_CHECK_ARGS(0);
-
   char path[IOTJS_MAX_PATH_SIZE];
   size_t size_path = sizeof(path);
   int err = uv_cwd(path, &size_path);

--- a/src/modules/iotjs_module_tcp.c
+++ b/src/modules/iotjs_module_tcp.c
@@ -207,7 +207,6 @@ iotjs_jval_t iotjs_shutdown_reqwrap_jcallback(THIS) {
 
 JHANDLER_FUNCTION(TCP) {
   DJHANDLER_CHECK_THIS(object);
-  DJHANDLER_CHECK_ARGS(0);
 
   iotjs_jval_t jtcp = JHANDLER_GET_THIS(object);
   iotjs_tcpwrap_t* tcp_wrap = iotjs_tcpwrap_create(jtcp);
@@ -240,7 +239,6 @@ void AfterClose(uv_handle_t* handle) {
 // Close socket
 JHANDLER_FUNCTION(Close) {
   JHANDLER_DECLARE_THIS_PTR(handlewrap, wrap);
-  DJHANDLER_CHECK_ARGS(0);
 
   // close uv handle, `AfterClose` will be called after socket closed.
   iotjs_handlewrap_close(wrap, AfterClose);

--- a/src/modules/iotjs_module_udp.c
+++ b/src/modules/iotjs_module_udp.c
@@ -125,7 +125,6 @@ size_t iotjs_send_reqwrap_msg_size(THIS) {
 
 JHANDLER_FUNCTION(UDP) {
   DJHANDLER_CHECK_THIS(object);
-  DJHANDLER_CHECK_ARGS(0);
 
   iotjs_jval_t judp = JHANDLER_GET_THIS(object);
   iotjs_udpwrap_t* udp_wrap = iotjs_udpwrap_create(judp);
@@ -231,7 +230,6 @@ static void OnRecv(uv_udp_t* handle, ssize_t nread, const uv_buf_t* buf,
 
 JHANDLER_FUNCTION(RecvStart) {
   JHANDLER_DECLARE_THIS_PTR(udpwrap, udp_wrap);
-  DJHANDLER_CHECK_ARGS(0);
 
   int err =
       uv_udp_recv_start(iotjs_udpwrap_udp_handle(udp_wrap), OnAlloc, OnRecv);
@@ -246,7 +244,6 @@ JHANDLER_FUNCTION(RecvStart) {
 
 JHANDLER_FUNCTION(RecvStop) {
   JHANDLER_DECLARE_THIS_PTR(udpwrap, udp_wrap);
-  DJHANDLER_CHECK_ARGS(0);
 
   int r = uv_udp_recv_stop(iotjs_udpwrap_udp_handle(udp_wrap));
 
@@ -325,7 +322,6 @@ JHANDLER_FUNCTION(Send) {
 // Close socket
 JHANDLER_FUNCTION(Close) {
   JHANDLER_DECLARE_THIS_PTR(handlewrap, wrap);
-  DJHANDLER_CHECK_ARGS(0);
 
   iotjs_handlewrap_close(wrap, NULL);
 }


### PR DESCRIPTION
This check does not make any sense, because it will always be true,
due to using unsigned integer types.

IoT.js-DCO-1.0-Signed-off-by: László Langó llango.u-szeged@partner.samsung.com