### PR TITLE
Simplify the binding layer.

### DIFF
--- a/src/iotjs.c
+++ b/src/iotjs.c
@@ -114,11 +114,8 @@ static bool iotjs_run(iotjs_environment_t* env) {
 
 
 static int iotjs_start(iotjs_environment_t* env) {
-  // Initialize commonly used jerry values.
-  iotjs_binding_initialize();
-
   // Bind environment to global object.
-  const iotjs_jval_t global = iotjs_jval_get_global_object();
+  const iotjs_jval_t global = jerry_get_global_object();
   jerry_set_object_native_pointer(global, env, NULL);
 
   // Initialize builtin modules.
@@ -127,6 +124,9 @@ static int iotjs_start(iotjs_environment_t* env) {
   // Initialize builtin process module.
   const iotjs_jval_t process = iotjs_init_process_module();
   iotjs_jval_set_property_jval(global, "process", process);
+
+  // Release the global object
+  jerry_release_value(global);
 
   // Set running state.
   iotjs_environment_go_state_running_main(env);
@@ -215,9 +215,6 @@ int iotjs_entry(int argc, char** argv) {
 
   int res = uv_loop_close(iotjs_environment_loop(env));
   IOTJS_ASSERT(res == 0);
-
-  // Release commonly used jerry values.
-  iotjs_binding_finalize();
 
   // Release JerryScript engine.
   iotjs_jerry_release(env);

--- a/src/iotjs_binding_helper.c
+++ b/src/iotjs_binding_helper.c
@@ -25,7 +25,7 @@ void iotjs_uncaught_exception(iotjs_jval_t jexception) {
 
   iotjs_jval_t jonuncaughtexception =
       iotjs_jval_get_property(process, IOTJS_MAGIC_STRING__ONUNCAUGHTEXCEPTION);
-  IOTJS_ASSERT(iotjs_jval_is_function(jonuncaughtexception));
+  IOTJS_ASSERT(jerry_value_is_function(jonuncaughtexception));
 
   iotjs_jargs_t args = iotjs_jargs_create(1);
   iotjs_jargs_append_jval(&args, jexception);
@@ -54,7 +54,7 @@ void iotjs_process_emit_exit(int code) {
 
   iotjs_jval_t jexit =
       iotjs_jval_get_property(process, IOTJS_MAGIC_STRING_EMITEXIT);
-  IOTJS_ASSERT(iotjs_jval_is_function(jexit));
+  IOTJS_ASSERT(jerry_value_is_function(jexit));
 
   iotjs_jargs_t jargs = iotjs_jargs_create(1);
   iotjs_jargs_append_number(&jargs, code);
@@ -84,13 +84,13 @@ bool iotjs_process_next_tick() {
 
   iotjs_jval_t jon_next_tick =
       iotjs_jval_get_property(process, IOTJS_MAGIC_STRING__ONNEXTTICK);
-  IOTJS_ASSERT(iotjs_jval_is_function(jon_next_tick));
+  IOTJS_ASSERT(jerry_value_is_function(jon_next_tick));
 
   iotjs_jval_t jres =
       iotjs_jhelper_call_ok(jon_next_tick, jerry_create_undefined(),
                             iotjs_jargs_get_empty());
 
-  IOTJS_ASSERT(iotjs_jval_is_boolean(jres));
+  IOTJS_ASSERT(jerry_value_is_boolean(jres));
 
   bool ret = iotjs_jval_as_boolean(jres);
   jerry_release_value(jres);
@@ -134,7 +134,7 @@ int iotjs_process_exitcode() {
 
   iotjs_jval_t jexitcode =
       iotjs_jval_get_property(process, IOTJS_MAGIC_STRING_EXITCODE);
-  IOTJS_ASSERT(iotjs_jval_is_number(jexitcode));
+  IOTJS_ASSERT(jerry_value_is_number(jexitcode));
 
   const int exitcode = (int)iotjs_jval_as_number(jexitcode);
   jerry_release_value(jexitcode);

--- a/src/iotjs_module.c
+++ b/src/iotjs_module.c
@@ -48,8 +48,8 @@ void iotjs_module_list_init() {
 #undef INIT_MODULE_LIST
 
 
-#define CLEANUP_MODULE_LIST(upper, Camel, lower)                 \
-  if (!iotjs_jval_is_undefined(modules[MODULE_##upper].jmodule)) \
+#define CLEANUP_MODULE_LIST(upper, Camel, lower)                  \
+  if (!jerry_value_is_undefined(modules[MODULE_##upper].jmodule)) \
     jerry_release_value(modules[MODULE_##upper].jmodule);
 
 void iotjs_module_list_cleanup() {
@@ -63,7 +63,7 @@ const iotjs_jval_t* iotjs_module_initialize_if_necessary(ModuleKind kind) {
   IOTJS_ASSERT(kind < MODULE_COUNT);
   IOTJS_ASSERT(&modules[kind].fn_register != NULL);
 
-  if (iotjs_jval_is_undefined(modules[kind].jmodule)) {
+  if (jerry_value_is_undefined(modules[kind].jmodule)) {
     modules[kind].jmodule = modules[kind].fn_register();
   }
 
@@ -73,6 +73,6 @@ const iotjs_jval_t* iotjs_module_initialize_if_necessary(ModuleKind kind) {
 
 const iotjs_jval_t* iotjs_module_get(ModuleKind kind) {
   IOTJS_ASSERT(kind < MODULE_COUNT);
-  IOTJS_ASSERT(!iotjs_jval_is_undefined(modules[kind].jmodule));
+  IOTJS_ASSERT(!jerry_value_is_undefined(modules[kind].jmodule));
   return &modules[kind].jmodule;
 }

--- a/src/iotjs_objectwrap.c
+++ b/src/iotjs_objectwrap.c
@@ -22,7 +22,7 @@ void iotjs_jobjectwrap_initialize(iotjs_jobjectwrap_t* jobjectwrap,
                                   JNativeInfoType* native_info) {
   IOTJS_VALIDATED_STRUCT_CONSTRUCTOR(iotjs_jobjectwrap_t, jobjectwrap);
 
-  IOTJS_ASSERT(iotjs_jval_is_object(jobject));
+  IOTJS_ASSERT(jerry_value_is_object(jobject));
 
   // This wrapper holds pointer to the javascript object but never increases
   // reference count.
@@ -46,7 +46,7 @@ iotjs_jval_t iotjs_jobjectwrap_jobject(iotjs_jobjectwrap_t* jobjectwrap) {
   iotjs_jval_t jobject = _this->jobject;
   IOTJS_ASSERT((uintptr_t)jobjectwrap ==
                iotjs_jval_get_object_native_handle(jobject));
-  IOTJS_ASSERT(iotjs_jval_is_object(jobject));
+  IOTJS_ASSERT(jerry_value_is_object(jobject));
   return jobject;
 }
 
@@ -54,6 +54,6 @@ iotjs_jval_t iotjs_jobjectwrap_jobject(iotjs_jobjectwrap_t* jobjectwrap) {
 iotjs_jobjectwrap_t* iotjs_jobjectwrap_from_jobject(iotjs_jval_t jobject) {
   iotjs_jobjectwrap_t* wrap =
       (iotjs_jobjectwrap_t*)(iotjs_jval_get_object_native_handle(jobject));
-  IOTJS_ASSERT(iotjs_jval_is_object(iotjs_jobjectwrap_jobject(wrap)));
+  IOTJS_ASSERT(jerry_value_is_object(iotjs_jobjectwrap_jobject(wrap)));
   return wrap;
 }

--- a/src/iotjs_reqwrap.c
+++ b/src/iotjs_reqwrap.c
@@ -20,7 +20,7 @@
 void iotjs_reqwrap_initialize(iotjs_reqwrap_t* reqwrap, iotjs_jval_t jcallback,
                               uv_req_t* request) {
   IOTJS_VALIDATED_STRUCT_CONSTRUCTOR(iotjs_reqwrap_t, reqwrap);
-  IOTJS_ASSERT(iotjs_jval_is_function(jcallback));
+  IOTJS_ASSERT(jerry_value_is_function(jcallback));
   _this->jcallback = jerry_acquire_value(jcallback);
   _this->request = request;
   _this->request->data = reqwrap;

--- a/src/modules/iotjs_module_adc.c
+++ b/src/modules/iotjs_module_adc.c
@@ -226,7 +226,7 @@ JHANDLER_FUNCTION(AdcConstructor) {
 
   if (iotjs_jhandler_get_arg_length(jhandler) > 1) {
     const iotjs_jval_t jcallback = iotjs_jhandler_get_arg(jhandler, 1);
-    if (iotjs_jval_is_function(jcallback)) {
+    if (jerry_value_is_function(jcallback)) {
       ADC_ASYNC(open, adc, jcallback, kAdcOpOpen);
     } else {
       JHANDLER_THROW(TYPE, "Bad arguments - callback should be Function");

--- a/src/modules/iotjs_module_blehcisocket.c
+++ b/src/modules/iotjs_module_blehcisocket.c
@@ -93,7 +93,7 @@ JHANDLER_FUNCTION(BindRaw) {
   int* pDevId = NULL;
 
   iotjs_jval_t raw = iotjs_jhandler_get_arg(jhandler, 0);
-  if (iotjs_jval_is_number(raw)) {
+  if (jerry_value_is_number(raw)) {
     devId = iotjs_jval_as_number(raw);
     pDevId = &devId;
   }

--- a/src/modules/iotjs_module_buffer.c
+++ b/src/modules/iotjs_module_buffer.c
@@ -60,7 +60,7 @@ static void iotjs_bufferwrap_destroy(iotjs_bufferwrap_t* bufferwrap) {
 
 iotjs_bufferwrap_t* iotjs_bufferwrap_from_jbuiltin(
     const iotjs_jval_t jbuiltin) {
-  IOTJS_ASSERT(iotjs_jval_is_object(jbuiltin));
+  IOTJS_ASSERT(jerry_value_is_object(jbuiltin));
   iotjs_bufferwrap_t* buffer =
       (iotjs_bufferwrap_t*)iotjs_jval_get_object_native_handle(jbuiltin);
   IOTJS_ASSERT(buffer != NULL);
@@ -69,7 +69,7 @@ iotjs_bufferwrap_t* iotjs_bufferwrap_from_jbuiltin(
 
 
 iotjs_bufferwrap_t* iotjs_bufferwrap_from_jbuffer(const iotjs_jval_t jbuffer) {
-  IOTJS_ASSERT(iotjs_jval_is_object(jbuffer));
+  IOTJS_ASSERT(jerry_value_is_object(jbuffer));
   iotjs_jval_t jbuiltin =
       iotjs_jval_get_property(jbuffer, IOTJS_MAGIC_STRING__BUILTIN);
   iotjs_bufferwrap_t* buffer = iotjs_bufferwrap_from_jbuiltin(jbuiltin);
@@ -213,18 +213,19 @@ size_t iotjs_bufferwrap_copy(iotjs_bufferwrap_t* bufferwrap, const char* src,
 
 
 iotjs_jval_t iotjs_bufferwrap_create_buffer(size_t len) {
-  iotjs_jval_t jglobal = iotjs_jval_get_global_object();
+  iotjs_jval_t jglobal = jerry_get_global_object();
 
   iotjs_jval_t jbuffer =
       iotjs_jval_get_property(jglobal, IOTJS_MAGIC_STRING_BUFFER);
-  IOTJS_ASSERT(iotjs_jval_is_function(jbuffer));
+  jerry_release_value(jglobal);
+  IOTJS_ASSERT(jerry_value_is_function(jbuffer));
 
   iotjs_jargs_t jargs = iotjs_jargs_create(1);
   iotjs_jargs_append_number(&jargs, len);
 
   iotjs_jval_t jres =
       iotjs_jhelper_call_ok(jbuffer, jerry_create_undefined(), &jargs);
-  IOTJS_ASSERT(iotjs_jval_is_object(jres));
+  IOTJS_ASSERT(jerry_value_is_object(jres));
 
   iotjs_jargs_destroy(&jargs);
   jerry_release_value(jbuffer);

--- a/src/modules/iotjs_module_fs.c
+++ b/src/modules/iotjs_module_fs.c
@@ -50,7 +50,7 @@ static void AfterAsync(uv_fs_t* req) {
   IOTJS_ASSERT(&req_wrap->req == req);
 
   const iotjs_jval_t cb = iotjs_reqwrap_jcallback(&req_wrap->reqwrap);
-  IOTJS_ASSERT(iotjs_jval_is_function(cb));
+  IOTJS_ASSERT(jerry_value_is_function(cb));
 
   iotjs_jargs_t jarg = iotjs_jargs_create(2);
   if (req->result < 0) {
@@ -309,7 +309,7 @@ iotjs_jval_t MakeStatObject(uv_stat_t* statbuf) {
 
   iotjs_jval_t stat_prototype =
       iotjs_jval_get_property(fs, IOTJS_MAGIC_STRING_STATS);
-  IOTJS_ASSERT(iotjs_jval_is_object(stat_prototype));
+  IOTJS_ASSERT(jerry_value_is_object(stat_prototype));
 
   iotjs_jval_t jstat = iotjs_jval_create_object();
   iotjs_jval_set_prototype(jstat, stat_prototype);

--- a/src/modules/iotjs_module_httpparser.c
+++ b/src/modules/iotjs_module_httpparser.c
@@ -93,7 +93,7 @@ static void iotjs_httpparserwrap_create(const iotjs_jval_t jparser,
   _this->parser.data = httpparserwrap;
 
   IOTJS_ASSERT(
-      iotjs_jval_is_object(iotjs_jobjectwrap_jobject(&_this->jobjectwrap)));
+      jerry_value_is_object(iotjs_jobjectwrap_jobject(&_this->jobjectwrap)));
 }
 
 
@@ -134,7 +134,7 @@ static void iotjs_httpparserwrap_flush(iotjs_httpparserwrap_t* httpparserwrap) {
   const iotjs_jval_t jobj = iotjs_jobjectwrap_jobject(&_this->jobjectwrap);
   iotjs_jval_t func =
       iotjs_jval_get_property(jobj, IOTJS_MAGIC_STRING_ONHEADERS);
-  IOTJS_ASSERT(iotjs_jval_is_function(func));
+  IOTJS_ASSERT(jerry_value_is_function(func));
 
   iotjs_jargs_t argv = iotjs_jargs_create(2);
   iotjs_jval_t jheader = iotjs_httpparserwrap_make_header(httpparserwrap);
@@ -243,7 +243,7 @@ static int iotjs_httpparserwrap_on_headers_complete(http_parser* parser) {
   const iotjs_jval_t jobj = iotjs_jobjectwrap_jobject(&_this->jobjectwrap);
   iotjs_jval_t func =
       iotjs_jval_get_property(jobj, IOTJS_MAGIC_STRING_ONHEADERSCOMPLETE);
-  IOTJS_ASSERT(iotjs_jval_is_function(func));
+  IOTJS_ASSERT(jerry_value_is_function(func));
 
   // URL
   iotjs_jargs_t argv = iotjs_jargs_create(1);
@@ -296,9 +296,9 @@ static int iotjs_httpparserwrap_on_headers_complete(http_parser* parser) {
   iotjs_jval_t res = iotjs_make_callback_with_result(func, jobj, &argv);
 
   int ret = 1;
-  if (iotjs_jval_is_boolean(res)) {
+  if (jerry_value_is_boolean(res)) {
     ret = iotjs_jval_as_boolean(res);
-  } else if (iotjs_jval_is_object(res)) {
+  } else if (jerry_value_is_object(res)) {
     // if exception throw occurs in iotjs_make_callback_with_result, then the
     // result can be an object.
     ret = 0;
@@ -320,7 +320,7 @@ static int iotjs_httpparserwrap_on_body(http_parser* parser, const char* at,
   IOTJS_VALIDATED_STRUCT_METHOD(iotjs_httpparserwrap_t, httpparserwrap);
   const iotjs_jval_t jobj = iotjs_jobjectwrap_jobject(&_this->jobjectwrap);
   iotjs_jval_t func = iotjs_jval_get_property(jobj, IOTJS_MAGIC_STRING_ONBODY);
-  IOTJS_ASSERT(iotjs_jval_is_function(func));
+  IOTJS_ASSERT(jerry_value_is_function(func));
 
   iotjs_jargs_t argv = iotjs_jargs_create(3);
   iotjs_jargs_append_jval(&argv, _this->cur_jbuf);
@@ -344,7 +344,7 @@ static int iotjs_httpparserwrap_on_message_complete(http_parser* parser) {
   const iotjs_jval_t jobj = iotjs_jobjectwrap_jobject(&_this->jobjectwrap);
   iotjs_jval_t func =
       iotjs_jval_get_property(jobj, IOTJS_MAGIC_STRING_ONMESSAGECOMPLETE);
-  IOTJS_ASSERT(iotjs_jval_is_function(func));
+  IOTJS_ASSERT(jerry_value_is_function(func));
 
   iotjs_make_callback(func, jobj, iotjs_jargs_get_empty());
 

--- a/src/modules/iotjs_module_https.c
+++ b/src/modules/iotjs_module_https.c
@@ -180,9 +180,9 @@ void iotjs_https_cleanup(iotjs_https_t* https_data) {
   if (_this->to_destroy_read_onwrite) {
     const iotjs_jargs_t* jarg = iotjs_jargs_get_empty();
     iotjs_jval_t jthis = _this->jthis_native;
-    IOTJS_ASSERT(iotjs_jval_is_function((_this->read_onwrite)));
+    IOTJS_ASSERT(jerry_value_is_function((_this->read_onwrite)));
 
-    if (!iotjs_jval_is_undefined((_this->read_callback)))
+    if (!jerry_value_is_undefined((_this->read_callback)))
       iotjs_make_callback(_this->read_callback, jthis, jarg);
 
     iotjs_make_callback(_this->read_onwrite, jthis, jarg);
@@ -299,14 +299,14 @@ bool iotjs_https_jcallback(iotjs_https_t* https_data, const char* property,
                            const iotjs_jargs_t* jarg, bool resultvalue) {
   iotjs_jval_t jthis = iotjs_https_jthis_from_https(https_data);
   bool retval = true;
-  if (iotjs_jval_is_null(jthis))
+  if (jerry_value_is_null(jthis))
     return retval;
 
   iotjs_jval_t jincoming =
       iotjs_jval_get_property(jthis, IOTJS_MAGIC_STRING__INCOMING);
   iotjs_jval_t cb = iotjs_jval_get_property(jincoming, property);
 
-  IOTJS_ASSERT(iotjs_jval_is_function(cb));
+  IOTJS_ASSERT(jerry_value_is_function(cb));
   if (!resultvalue) {
     iotjs_make_callback(cb, jincoming, jarg);
   } else {
@@ -326,13 +326,13 @@ void iotjs_https_call_read_onwrite(uv_timer_t* timer) {
   IOTJS_VALIDATED_STRUCT_METHOD(iotjs_https_t, https_data);
 
   uv_timer_stop(&(_this->async_read_onwrite));
-  if (iotjs_jval_is_null(_this->jthis_native))
+  if (jerry_value_is_null(_this->jthis_native))
     return;
   const iotjs_jargs_t* jarg = iotjs_jargs_get_empty();
   iotjs_jval_t jthis = _this->jthis_native;
-  IOTJS_ASSERT(iotjs_jval_is_function((_this->read_onwrite)));
+  IOTJS_ASSERT(jerry_value_is_function((_this->read_onwrite)));
 
-  if (!iotjs_jval_is_undefined((_this->read_callback)))
+  if (!jerry_value_is_undefined((_this->read_callback)))
     iotjs_make_callback(_this->read_callback, jthis, jarg);
 
   iotjs_make_callback(_this->read_onwrite, jthis, jarg);
@@ -550,7 +550,7 @@ size_t iotjs_https_curl_write_callback(void* contents, size_t size,
   iotjs_https_t* https_data = (iotjs_https_t*)userp;
   IOTJS_VALIDATED_STRUCT_METHOD(iotjs_https_t, https_data);
   size_t real_size = size * nmemb;
-  if (iotjs_jval_is_null(_this->jthis_native))
+  if (jerry_value_is_null(_this->jthis_native))
     return real_size - 1;
   iotjs_jargs_t jarg = iotjs_jargs_create(1);
   iotjs_jval_t jresult_arr = iotjs_jval_create_byte_array(real_size, contents);

--- a/src/modules/iotjs_module_i2c.c
+++ b/src/modules/iotjs_module_i2c.c
@@ -177,7 +177,7 @@ static void GetI2cArray(const iotjs_jval_t jarray,
   // Need to implement a function to get array info from iotjs_jval_t Array.
   iotjs_jval_t jlength =
       iotjs_jval_get_property(jarray, IOTJS_MAGIC_STRING_LENGTH);
-  IOTJS_ASSERT(!iotjs_jval_is_undefined(jlength));
+  IOTJS_ASSERT(!jerry_value_is_undefined(jlength));
 
   req_data->buf_len = iotjs_jval_as_number(jlength);
   req_data->buf_data = iotjs_buffer_allocate(req_data->buf_len);

--- a/src/modules/iotjs_module_pwm.c
+++ b/src/modules/iotjs_module_pwm.c
@@ -131,12 +131,12 @@ static void iotjs_pwm_set_configuration(iotjs_jval_t jconfiguration,
 
   iotjs_jval_t jperiod =
       iotjs_jval_get_property(jconfiguration, IOTJS_MAGIC_STRING_PERIOD);
-  if (iotjs_jval_is_number(jperiod))
+  if (jerry_value_is_number(jperiod))
     _this->period = iotjs_jval_as_number(jperiod);
 
   iotjs_jval_t jduty_cycle =
       iotjs_jval_get_property(jconfiguration, IOTJS_MAGIC_STRING_DUTYCYCLE);
-  if (iotjs_jval_is_number(jduty_cycle))
+  if (jerry_value_is_number(jduty_cycle))
     _this->duty_cycle = iotjs_jval_as_number(jduty_cycle);
 
   jerry_release_value(jpin);

--- a/src/modules/iotjs_module_spi.c
+++ b/src/modules/iotjs_module_spi.c
@@ -114,7 +114,7 @@ iotjs_spi_t* iotjs_spi_instance_from_reqwrap(THIS) {
 static int iotjs_spi_get_array_data(char** buf, iotjs_jval_t jarray) {
   iotjs_jval_t jlength =
       iotjs_jval_get_property(jarray, IOTJS_MAGIC_STRING_LENGTH);
-  IOTJS_ASSERT(!iotjs_jval_is_undefined(jlength));
+  IOTJS_ASSERT(!jerry_value_is_undefined(jlength));
 
   size_t length = iotjs_jval_as_number(jlength);
   IOTJS_ASSERT((int)length >= 0);

--- a/src/modules/iotjs_module_tcp.c
+++ b/src/modules/iotjs_module_tcp.c
@@ -227,7 +227,7 @@ void AfterClose(uv_handle_t* handle) {
   // callback function.
   iotjs_jval_t jcallback =
       iotjs_jval_get_property(jtcp, IOTJS_MAGIC_STRING_ONCLOSE);
-  if (iotjs_jval_is_function(jcallback)) {
+  if (jerry_value_is_function(jcallback)) {
     iotjs_make_callback(jcallback, jerry_create_undefined(),
                         iotjs_jargs_get_empty());
   }
@@ -278,7 +278,7 @@ static void AfterConnect(uv_connect_t* req, int status) {
   // Take callback function object.
   // function afterConnect(status)
   iotjs_jval_t jcallback = iotjs_connect_reqwrap_jcallback(req_wrap);
-  IOTJS_ASSERT(iotjs_jval_is_function(jcallback));
+  IOTJS_ASSERT(jerry_value_is_function(jcallback));
 
   // Only parameter is status code.
   iotjs_jargs_t args = iotjs_jargs_create(1);
@@ -345,7 +345,7 @@ static void OnConnection(uv_stream_t* handle, int status) {
   // `onconnection` callback.
   iotjs_jval_t jonconnection =
       iotjs_jval_get_property(jtcp, IOTJS_MAGIC_STRING_ONCONNECTION);
-  IOTJS_ASSERT(iotjs_jval_is_function(jonconnection));
+  IOTJS_ASSERT(jerry_value_is_function(jonconnection));
 
   // The callback takes two parameter
   // [0] status
@@ -357,12 +357,12 @@ static void OnConnection(uv_stream_t* handle, int status) {
     // Create client socket handle wrapper.
     iotjs_jval_t jcreate_tcp =
         iotjs_jval_get_property(jtcp, IOTJS_MAGIC_STRING_CREATETCP);
-    IOTJS_ASSERT(iotjs_jval_is_function(jcreate_tcp));
+    IOTJS_ASSERT(jerry_value_is_function(jcreate_tcp));
 
     iotjs_jval_t jclient_tcp =
         iotjs_jhelper_call_ok(jcreate_tcp, jerry_create_undefined(),
                               iotjs_jargs_get_empty());
-    IOTJS_ASSERT(iotjs_jval_is_object(jclient_tcp));
+    IOTJS_ASSERT(jerry_value_is_object(jclient_tcp));
 
     iotjs_tcpwrap_t* tcp_wrap_client =
         (iotjs_tcpwrap_t*)(iotjs_jval_get_object_native_handle(jclient_tcp));
@@ -472,12 +472,12 @@ void OnRead(uv_stream_t* handle, ssize_t nread, const uv_buf_t* buf) {
   // socket object
   iotjs_jval_t jsocket =
       iotjs_jval_get_property(jtcp, IOTJS_MAGIC_STRING_OWNER);
-  IOTJS_ASSERT(iotjs_jval_is_object(jsocket));
+  IOTJS_ASSERT(jerry_value_is_object(jsocket));
 
   // onread callback
   iotjs_jval_t jonread =
       iotjs_jval_get_property(jtcp, IOTJS_MAGIC_STRING_ONREAD);
-  IOTJS_ASSERT(iotjs_jval_is_function(jonread));
+  IOTJS_ASSERT(jerry_value_is_function(jonread));
 
   iotjs_jargs_t jargs = iotjs_jargs_create(4);
   iotjs_jargs_append_jval(&jargs, jsocket);
@@ -532,7 +532,7 @@ static void AfterShutdown(uv_shutdown_t* req, int status) {
 
   // function onShutdown(status)
   iotjs_jval_t jonshutdown = iotjs_shutdown_reqwrap_jcallback(req_wrap);
-  IOTJS_ASSERT(iotjs_jval_is_function(jonshutdown));
+  IOTJS_ASSERT(jerry_value_is_function(jonshutdown));
 
   iotjs_jargs_t args = iotjs_jargs_create(1);
   iotjs_jargs_append_number(&args, status);

--- a/src/modules/iotjs_module_testdriver.c
+++ b/src/modules/iotjs_module_testdriver.c
@@ -25,12 +25,12 @@ JHANDLER_FUNCTION(IsAliveExceptFor) {
 
   const iotjs_jval_t arg0 = iotjs_jhandler_get_arg(jhandler, 0);
 
-  if (iotjs_jval_is_null(arg0)) {
+  if (jerry_value_is_null(arg0)) {
     int alive = uv_loop_alive(loop);
 
     iotjs_jhandler_return_boolean(jhandler, alive);
   } else {
-    JHANDLER_CHECK(iotjs_jval_is_object(arg0));
+    JHANDLER_CHECK(jerry_value_is_object(arg0));
 
     iotjs_jval_t jtimer =
         iotjs_jval_get_property(arg0, IOTJS_MAGIC_STRING_HANDLER);

--- a/src/modules/iotjs_module_timer.c
+++ b/src/modules/iotjs_module_timer.c
@@ -103,7 +103,7 @@ uv_timer_t* iotjs_timerwrap_handle(iotjs_timerwrap_t* timerwrap) {
 iotjs_jval_t iotjs_timerwrap_jobject(iotjs_timerwrap_t* timerwrap) {
   IOTJS_VALIDATED_STRUCT_METHOD(iotjs_timerwrap_t, timerwrap);
   iotjs_jval_t jobject = iotjs_handlewrap_jobject(&_this->handlewrap);
-  IOTJS_ASSERT(iotjs_jval_is_object(jobject));
+  IOTJS_ASSERT(jerry_value_is_object(jobject));
   return jobject;
 }
 
@@ -156,7 +156,7 @@ JHANDLER_FUNCTION(Timer) {
   iotjs_timerwrap_t* timer_wrap = iotjs_timerwrap_create(jtimer);
 
   iotjs_jval_t jobject = iotjs_timerwrap_jobject(timer_wrap);
-  IOTJS_ASSERT(iotjs_jval_is_object(jobject));
+  IOTJS_ASSERT(jerry_value_is_object(jobject));
   IOTJS_ASSERT(iotjs_jval_get_object_native_handle(jtimer) != 0);
 }
 

--- a/src/modules/iotjs_module_uart.c
+++ b/src/modules/iotjs_module_uart.c
@@ -212,7 +212,7 @@ static void iotjs_uart_after_worker(uv_work_t* work_req, int status) {
 
 static void iotjs_uart_onread(iotjs_jval_t jthis, char* buf) {
   iotjs_jval_t jemit = iotjs_jval_get_property(jthis, "emit");
-  IOTJS_ASSERT(iotjs_jval_is_function(jemit));
+  IOTJS_ASSERT(jerry_value_is_function(jemit));
 
   iotjs_jargs_t jargs = iotjs_jargs_create(2);
   iotjs_jval_t str = iotjs_jval_create_string_raw("data");

--- a/src/modules/iotjs_module_udp.c
+++ b/src/modules/iotjs_module_udp.c
@@ -140,11 +140,11 @@ JHANDLER_FUNCTION(Bind) {
   iotjs_jval_t this_obj = JHANDLER_GET_THIS(object);
   iotjs_jval_t reuse_addr =
       iotjs_jval_get_property(this_obj, IOTJS_MAGIC_STRING__REUSEADDR);
-  IOTJS_ASSERT(iotjs_jval_is_boolean(reuse_addr) ||
-               iotjs_jval_is_undefined(reuse_addr));
+  IOTJS_ASSERT(jerry_value_is_boolean(reuse_addr) ||
+               jerry_value_is_undefined(reuse_addr));
 
   unsigned int flags = 0;
-  if (!iotjs_jval_is_undefined(reuse_addr)) {
+  if (!jerry_value_is_undefined(reuse_addr)) {
     flags = iotjs_jval_as_boolean(reuse_addr) ? UV_UDP_REUSEADDR : 0;
   }
 
@@ -186,12 +186,12 @@ static void OnRecv(uv_udp_t* handle, ssize_t nread, const uv_buf_t* buf,
 
   // udp handle
   iotjs_jval_t judp = iotjs_udpwrap_jobject(udp_wrap);
-  IOTJS_ASSERT(iotjs_jval_is_object(judp));
+  IOTJS_ASSERT(jerry_value_is_object(judp));
 
   // onmessage callback
   iotjs_jval_t jonmessage =
       iotjs_jval_get_property(judp, IOTJS_MAGIC_STRING_ONMESSAGE);
-  IOTJS_ASSERT(iotjs_jval_is_function(jonmessage));
+  IOTJS_ASSERT(jerry_value_is_function(jonmessage));
 
   iotjs_jargs_t jargs = iotjs_jargs_create(4);
   iotjs_jargs_append_number(&jargs, nread);
@@ -257,7 +257,7 @@ static void OnSend(uv_udp_send_t* req, int status) {
   // Take callback function object.
   iotjs_jval_t jcallback = iotjs_send_reqwrap_jcallback(req_wrap);
 
-  if (iotjs_jval_is_function(jcallback)) {
+  if (jerry_value_is_function(jcallback)) {
     // Take callback function object.
 
     iotjs_jargs_t jargs = iotjs_jargs_create(2);
@@ -280,8 +280,8 @@ static void OnSend(uv_udp_send_t* req, int status) {
 JHANDLER_FUNCTION(Send) {
   JHANDLER_DECLARE_THIS_PTR(udpwrap, udp_wrap);
   DJHANDLER_CHECK_ARGS(3, object, number, string);
-  IOTJS_ASSERT(iotjs_jval_is_function(iotjs_jhandler_get_arg(jhandler, 3)) ||
-               iotjs_jval_is_undefined(iotjs_jhandler_get_arg(jhandler, 3)));
+  IOTJS_ASSERT(jerry_value_is_function(iotjs_jhandler_get_arg(jhandler, 3)) ||
+               jerry_value_is_undefined(iotjs_jhandler_get_arg(jhandler, 3)));
 
   const iotjs_jval_t jbuffer = JHANDLER_GET_ARG(0, object);
   const unsigned short port = JHANDLER_GET_ARG(1, number);
@@ -398,7 +398,7 @@ void SetMembership(iotjs_jhandler_t* jhandler, uv_membership membership) {
   iotjs_string_t address = JHANDLER_GET_ARG(0, string);
   iotjs_jval_t arg1 = iotjs_jhandler_get_arg(jhandler, 1);
   bool isUndefinedOrNull =
-      iotjs_jval_is_undefined(arg1) || iotjs_jval_is_null(arg1);
+      jerry_value_is_undefined(arg1) || jerry_value_is_null(arg1);
   iotjs_string_t iface;
 
   const char* iface_cstr;

--- a/src/platform/linux/iotjs_module_blehcisocket-linux.c
+++ b/src/platform/linux/iotjs_module_blehcisocket-linux.c
@@ -299,7 +299,7 @@ void iotjs_blehcisocket_poll(THIS) {
 
     iotjs_jval_t jhcisocket = iotjs_jobjectwrap_jobject(&_this->jobjectwrap);
     iotjs_jval_t jemit = iotjs_jval_get_property(jhcisocket, "emit");
-    IOTJS_ASSERT(iotjs_jval_is_function(jemit));
+    IOTJS_ASSERT(jerry_value_is_function(jemit));
 
     iotjs_jargs_t jargs = iotjs_jargs_create(2);
     iotjs_jval_t str = iotjs_jval_create_string_raw("data");
@@ -340,7 +340,7 @@ void iotjs_blehcisocket_emitErrnoError(THIS) {
 
   iotjs_jval_t jhcisocket = iotjs_jobjectwrap_jobject(&_this->jobjectwrap);
   iotjs_jval_t jemit = iotjs_jval_get_property(jhcisocket, "emit");
-  IOTJS_ASSERT(iotjs_jval_is_function(jemit));
+  IOTJS_ASSERT(jerry_value_is_function(jemit));
 
   iotjs_jargs_t jargs = iotjs_jargs_create(2);
   iotjs_jval_t str = iotjs_jval_create_string_raw("error");

--- a/src/platform/linux/iotjs_module_gpio-linux.c
+++ b/src/platform/linux/iotjs_module_gpio-linux.c
@@ -81,7 +81,7 @@ static void gpio_emit_change_event(iotjs_gpio_t* gpio) {
 
   iotjs_jval_t jgpio = iotjs_jobjectwrap_jobject(&_this->jobjectwrap);
   iotjs_jval_t jonChange = iotjs_jval_get_property(jgpio, "onChange");
-  IOTJS_ASSERT(iotjs_jval_is_function(jonChange));
+  IOTJS_ASSERT(jerry_value_is_function(jonChange));
 
   iotjs_jhelper_call_ok(jonChange, jgpio, iotjs_jargs_get_empty());
 


### PR DESCRIPTION
 * Removed 'iotjs_jval_is_*' functions
 * Removed 'iotjs_error_t'
 * Removed 'iotjs_binding_initialize' and 'iotjs_binding_finalize'

IoT.js-DCO-1.0-Signed-off-by: László Langó llango.u-szeged@partner.samsung.com