### PR TITLE
Code cleanup

### DIFF
--- a/src/modules/iotjs_module_buffer.c
+++ b/src/modules/iotjs_module_buffer.c
@@ -243,8 +243,7 @@ JHANDLER_FUNCTION(Buffer) {
 
   iotjs_jval_set_property_jval(jbuiltin, IOTJS_MAGIC_STRING__BUFFER, jbuffer);
 
-  iotjs_bufferwrap_t* buffer_wrap = iotjs_bufferwrap_create(jbuiltin, length);
-  IOTJS_UNUSED(buffer_wrap);
+  iotjs_bufferwrap_create(jbuiltin, length);
 }
 
 

--- a/src/modules/iotjs_module_tcp.c
+++ b/src/modules/iotjs_module_tcp.c
@@ -210,8 +210,7 @@ JHANDLER_FUNCTION(TCP) {
   DJHANDLER_CHECK_ARGS(0);
 
   iotjs_jval_t jtcp = JHANDLER_GET_THIS(object);
-  iotjs_tcpwrap_t* tcp_wrap = iotjs_tcpwrap_create(jtcp);
-  IOTJS_UNUSED(tcp_wrap);
+  iotjs_tcpwrap_create(jtcp);
 }
 
 

--- a/src/modules/iotjs_module_udp.c
+++ b/src/modules/iotjs_module_udp.c
@@ -128,8 +128,7 @@ JHANDLER_FUNCTION(UDP) {
   DJHANDLER_CHECK_ARGS(0);
 
   iotjs_jval_t judp = JHANDLER_GET_THIS(object);
-  iotjs_udpwrap_t* udp_wrap = iotjs_udpwrap_create(judp);
-  IOTJS_UNUSED(udp_wrap);
+  iotjs_udpwrap_create(judp);
 }
 
 


### PR DESCRIPTION
Remove unnecessary variable declerations and IOTJS_UNUSED calls.

IoT.js-DCO-1.0-Signed-off-by: László Langó llango.u-szeged@partner.samsung.com