### PR TITLE
Use JerryScript snapshot tool to generate snapshots

### DIFF
--- a/cmake/iotjs.cmake
+++ b/cmake/iotjs.cmake
@@ -37,8 +37,7 @@ endif()
 set(IOTJS_CFLAGS ${CFLAGS_COMMON})
 
 if(ENABLE_SNAPSHOT)
-  set(JS2C_SNAPSHOT_ARG --snapshot-generator=${JERRY_HOST}
-                        --snapshot-merger=${JERRY_HOST}-snapshot)
+  set(JS2C_SNAPSHOT_ARG --snapshot-tool=${JERRY_HOST_SNAPSHOT})
   set(IOTJS_CFLAGS ${IOTJS_CFLAGS} -DENABLE_SNAPSHOT)
 endif()
 
@@ -319,7 +318,7 @@ add_custom_command(
        --modules '${IOTJS_JS_MODULES}'
        ${JS2C_SNAPSHOT_ARG}
   DEPENDS ${ROOT_DIR}/tools/js2c.py
-          jerry
+          jerry-snapshot
           ${IOTJS_SOURCE_DIR}/js/*.js
 )
 

--- a/cmake/jerry.cmake
+++ b/cmake/jerry.cmake
@@ -25,17 +25,18 @@ ExternalProject_Add(hostjerry
   CMAKE_ARGS
     -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}
     -DJERRY_LIBC=OFF
-    -DJERRY_CMDLINE=ON
+    -DJERRY_CMDLINE=OFF
     -DJERRY_CMDLINE_MINIMAL=OFF
     -DJERRY_CMDLINE_SNAPSHOT=ON
     -DFEATURE_SNAPSHOT_SAVE=${ENABLE_SNAPSHOT}
     -DFEATURE_PROFILE=es5.1
 )
-add_executable(jerry IMPORTED)
-add_dependencies(jerry hostjerry)
-set_property(TARGET jerry PROPERTY
-  IMPORTED_LOCATION ${CMAKE_BINARY_DIR}/${DEPS_HOST_JERRY}/bin/jerry)
-set(JERRY_HOST ${CMAKE_BINARY_DIR}/${DEPS_HOST_JERRY}/bin/jerry)
+set(JERRY_HOST_SNAPSHOT
+    ${CMAKE_BINARY_DIR}/${DEPS_HOST_JERRY}/bin/jerry-snapshot)
+add_executable(jerry-snapshot IMPORTED)
+add_dependencies(jerry-snapshot hostjerry)
+set_property(TARGET jerry-snapshot PROPERTY
+  IMPORTED_LOCATION ${JERRY_HOST_SNAPSHOT})
 
 # Utility method to add -D<KEY>=<KEY_Value>
 macro(add_cmake_arg TARGET_ARG KEY)


### PR DESCRIPTION
JerryScript moved the snapshot generation into its own tool,
thus an update in IoT.js is required.

IoT.js-DCO-1.0-Signed-off-by: Peter Gal pgal.u-szeged@partner.samsung.com