### PR TITLE
Stringify object in console module

### DIFF
--- a/src/js/util.js
+++ b/src/js/util.js
@@ -146,6 +146,10 @@ function formatValue(v) {
     return 'undefined';
   } else if (v === null) {
     return 'null';
+  } else if (Array.isArray(v) || v instanceof Error) {
+    return v.toString();
+  } else if (typeof v === 'object') {
+    return JSON.stringify(v, null, 2);
   } else {
     return v.toString();
   }

--- a/test/run_pass/test_console.js
+++ b/test/run_pass/test_console.js
@@ -24,6 +24,7 @@ console.log([1, 2, 3]);
 console.log(1, 2, 3);
 console.log('a', 1, 'b', 2, 'c', 3);
 console.log("test", null, undefined);
+console.log({ a: '123', b: 123, c: [1, 2, 3]});
 
 console.error("Hello IoT.js!!");
 console.error(1);


### PR DESCRIPTION
This patch stringifies the given object in console. 

For instance, `console.log({ a: '123', b: 123, c: [1, 2, 3]});`

- Current:
`[object Object]`

- This patch:
`{"a":"123","b":123,"c":[1,2,3]}`

IoT.js-DCO-1.0-Signed-off-by: Daeyeon Jeong daeyeon.jeong@samsung.com