### PR TITLE
Fix failing tests after the module system rework.

### DIFF
--- a/src/iotjs.c
+++ b/src/iotjs.c
@@ -104,6 +104,7 @@ static bool iotjs_run(iotjs_environment_t* env) {
       jerry_exec_snapshot_at((const void*)iotjs_js_modules_s,
                              iotjs_js_modules_l, module_iotjs_idx, false);
   if (jerry_value_has_error_flag(jmain)) {
+    jerry_value_clear_error_flag(&jmain);
     throws = true;
   }
 #endif


### PR DESCRIPTION
Three tests (test_events_uncaught_error.js, test_process_uncaught_order.js,
test_process_uncaught_simple.js) were failing with 'tools/testrunner.py' in
snapshot mode after the module system rework.

IoT.js-DCO-1.0-Signed-off-by: László Langó llango.u-szeged@partner.samsung.com