### PR TITLE
Improve built-in native c module generation

### DIFF
--- a/src/iotjs.c
+++ b/src/iotjs.c
@@ -124,9 +124,6 @@ static int iotjs_start(iotjs_environment_t* env) {
   const iotjs_jval_t global = jerry_get_global_object();
   jerry_set_object_native_pointer(global, env, NULL);
 
-  // Initialize builtin modules.
-  iotjs_module_list_init();
-
   // Initialize builtin process module.
   const iotjs_jval_t process = iotjs_module_get("process");
   iotjs_jval_set_property_jval(global, "process", process);

--- a/src/iotjs_module.c
+++ b/src/iotjs_module.c
@@ -15,14 +15,24 @@
 
 #include "iotjs_def.h"
 #include "iotjs_module.h"
+
+typedef struct { iotjs_jval_t jmodule; } iotjs_module_objects_t;
+
 #include "iotjs_module_inl.h"
 
-const unsigned iotjs_modules_count = MODULE_COUNT;
+/**
+ * iotjs_module_inl.h provides:
+ *  - iotjs_modules[]
+ *  - iotjs_module_objects[]
+ */
+
+const unsigned iotjs_modules_count =
+    sizeof(iotjs_modules) / sizeof(iotjs_module_t);
 
 void iotjs_module_list_cleanup() {
   for (unsigned i = 0; i < iotjs_modules_count; i++) {
-    if (!jerry_value_is_undefined(iotjs_modules[i].jmodule)) {
-      jerry_release_value(iotjs_modules[i].jmodule);
+    if (iotjs_module_objects[i].jmodule != 0) {
+      jerry_release_value(iotjs_module_objects[i].jmodule);
     }
   }
 }
@@ -30,11 +40,11 @@ void iotjs_module_list_cleanup() {
 iotjs_jval_t iotjs_module_get(const char* name) {
   for (unsigned i = 0; i < iotjs_modules_count; i++) {
     if (!strcmp(name, iotjs_modules[i].name)) {
-      if (jerry_value_is_undefined(iotjs_modules[i].jmodule)) {
-        iotjs_modules[i].jmodule = iotjs_modules[i].fn_register();
+      if (iotjs_module_objects[i].jmodule == 0) {
+        iotjs_module_objects[i].jmodule = iotjs_modules[i].fn_register();
       }
 
-      return iotjs_modules[i].jmodule;
+      return iotjs_module_objects[i].jmodule;
     }
   }
 

--- a/src/iotjs_module.h
+++ b/src/iotjs_module.h
@@ -22,14 +22,12 @@ typedef iotjs_jval_t (*register_func)();
 
 typedef struct {
   const char* name;
-  iotjs_jval_t jmodule;
   register_func fn_register;
 } iotjs_module_t;
 
 extern const unsigned iotjs_modules_count;
-extern iotjs_module_t iotjs_modules[];
+extern const iotjs_module_t iotjs_modules[];
 
-void iotjs_module_list_init();
 void iotjs_module_list_cleanup();
 
 iotjs_jval_t iotjs_module_get(const char* name);


### PR DESCRIPTION
The change is split into two things:

1) Simplify the module array generation in the iotjs.cmake.
Replace the module initializer function
with an already initialized module array.

2) Split built-in native C modules into two array.

The `iotjs_modules` array is composed of `iotjs_module_t`
elments where only the `jmodule` member is not initialized
statically. Thus the array can not be placed into the rodata
section (if needed).

By extracting the only dynamic member (`jmodule`) into its own
array it is possible to move the original module array into the
rodata section.