### PR TITLE
Fix finding a package entry

### DIFF
--- a/src/js/module.js
+++ b/src/js/module.js
@@ -49,6 +49,10 @@ if (process.env.IOTJS_PATH) {
   moduledirs.push(process.env.IOTJS_PATH + '/iotjs_modules/');
 }
 
+function tryPath(modulePath, ext) {
+  return iotjs_module_t.tryPath(modulePath) ||
+         iotjs_module_t.tryPath(modulePath + ext);
+}
 
 iotjs_module_t.resolveDirectories = function(id, parent) {
   var dirs = moduledirs;
@@ -76,17 +80,11 @@ iotjs_module_t.resolveFilepath = function(id, directories) {
       modulePath = iotjs_module_t.normalizePath(modulePath);
     }
 
-    // 1. 'id'
-    var filepath = iotjs_module_t.tryPath(modulePath);
+    var filepath,
+        ext = '.js';
 
-    if (filepath) {
-      return filepath;
-    }
-
-    // 2. 'id.js'
-    filepath = iotjs_module_t.tryPath(modulePath + '.js');
-
-    if (filepath) {
+    // id[.ext]
+    if (filepath = tryPath(modulePath, ext)) {
       return filepath;
     }
 
@@ -96,13 +94,14 @@ iotjs_module_t.resolveFilepath = function(id, directories) {
     if (filepath) {
       var pkgSrc = process.readSource(jsonpath);
       var pkgMainFile = JSON.parse(pkgSrc).main;
-      filepath = iotjs_module_t.tryPath(modulePath + '/' + pkgMainFile);
-      if (filepath) {
+
+      // pkgmain[.ext]
+      if (filepath = tryPath(modulePath + '/' + pkgMainFile, ext)) {
         return filepath;
       }
-      // index.js
-      filepath = iotjs_module_t.tryPath(modulePath + '/' + 'index.js');
-      if (filepath) {
+
+      // index[.ext] as default
+      if (filepath = tryPath(modulePath + '/index', ext)) {
         return filepath;
       }
     }

--- a/test/run_pass/require1/test_index2/add2.js
+++ b/test/run_pass/require1/test_index2/add2.js
@@ -1,0 +1,18 @@
+/* Copyright 2017-present Samsung Electronics Co., Ltd. and other contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+exports.add2 = function(a, b) {
+  return a + b;
+}

--- a/test/run_pass/require1/test_index2/index_test.js
+++ b/test/run_pass/require1/test_index2/index_test.js
@@ -1,0 +1,22 @@
+/* Copyright 2017-present Samsung Electronics Co., Ltd. and other contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+ exports.add = function(a, b) {
+  return a + b;
+};
+
+var x = require("lib/multi.js");
+exports.multi = x.multi;
+exports.add2 = x.add2;

--- a/test/run_pass/require1/test_index2/lib/multi.js
+++ b/test/run_pass/require1/test_index2/lib/multi.js
@@ -1,0 +1,20 @@
+/* Copyright 2017-present Samsung Electronics Co., Ltd. and other contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+exports.multi = function(a, b) {
+  return a * b;
+};
+
+exports.add2 = require('../add2').add2;

--- a/test/run_pass/require1/test_index2/package.json
+++ b/test/run_pass/require1/test_index2/package.json
@@ -1,0 +1,3 @@
+{
+  "main": "index_test"
+}

--- a/test/run_pass/test_module_require.js
+++ b/test/run_pass/test_module_require.js
@@ -32,6 +32,11 @@ assert.equal(pkg2.add(22, 44), 66);
 assert.equal(pkg2.multi(22, 44), 968);
 assert.equal(pkg2.add2(22, 44), 66);
 
+var pkg3 = require(dir + "test_index2");
+assert.equal(pkg3.add(22, 44), 66);
+assert.equal(pkg3.multi(22, 44), 968);
+assert.equal(pkg3.add2(22, 44), 66);
+
 // Load invalid modules.
 assert.throws(function() {
   var test3 = require('run_pass/require1/babel-template');


### PR DESCRIPTION
This patch contains the followings:

i) fix: If a file, which is named the main property in `id/package.json`, doesn't contain its extension, try loading it with '.js'.
~~ii) change: revert `iotjs_modules` to `node_modules` to leverage node modules which can be used in iotjs.~~

IoT.js-DCO-1.0-Signed-off-by: Daeyeon Jeong daeyeon.jeong@samsung.com