### PR TITLE
Remove usage of CMakeForceCompiler

### DIFF
--- a/cmake/config/arm-linux.cmake
+++ b/cmake/config/arm-linux.cmake
@@ -12,11 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-include(CMakeForceCompiler)
-
 set(CMAKE_SYSTEM_NAME Linux)
 set(CMAKE_SYSTEM_PROCESSOR armv7l)
 
-set(EXTERNAL_CMAKE_C_COMPILER arm-linux-gnueabihf-gcc)
-
-CMAKE_FORCE_C_COMPILER(${EXTERNAL_CMAKE_C_COMPILER} GNU)
+set(CMAKE_C_COMPILER arm-linux-gnueabihf-gcc)
+set(CMAKE_C_COMPILER_WORKS TRUE)

--- a/cmake/config/arm-nuttx.cmake
+++ b/cmake/config/arm-nuttx.cmake
@@ -12,11 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-include(CMakeForceCompiler)
-
 set(CMAKE_SYSTEM_NAME Nuttx)
 set(CMAKE_SYSTEM_PROCESSOR armv7l)
 
-set(EXTERNAL_CMAKE_C_COMPILER arm-none-eabi-gcc)
-
-CMAKE_FORCE_C_COMPILER(${EXTERNAL_CMAKE_C_COMPILER} GNU)
+set(CMAKE_C_COMPILER arm-none-eabi-gcc)
+set(CMAKE_C_COMPILER_WORKS TRUE)

--- a/cmake/config/arm-tizen.cmake
+++ b/cmake/config/arm-tizen.cmake
@@ -12,8 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-include(CMakeForceCompiler)
-
 set(CMAKE_SYSTEM_NAME Linux)
 set(CMAKE_SYSTEM_PROCESSOR armv7l)
 

--- a/cmake/config/arm-tizenrt.cmake
+++ b/cmake/config/arm-tizenrt.cmake
@@ -12,11 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-include(CMakeForceCompiler)
-
 set(CMAKE_SYSTEM_NAME Tizenrt)
 set(CMAKE_SYSTEM_PROCESSOR armv7l)
 
-set(EXTERNAL_CMAKE_C_COMPILER arm-none-eabi-gcc)
-
-CMAKE_FORCE_C_COMPILER(${EXTERNAL_CMAKE_C_COMPILER} GNU)
+set(CMAKE_C_COMPILER arm-none-eabi-gcc)
+set(CMAKE_C_COMPILER_WORKS TRUE)

--- a/cmake/config/i686-linux.cmake
+++ b/cmake/config/i686-linux.cmake
@@ -12,7 +12,5 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-include(CMakeForceCompiler)
-
 set(CMAKE_SYSTEM_NAME Linux)
 set(CMAKE_SYSTEM_PROCESSOR i686)

--- a/cmake/config/x86_64-darwin.cmake
+++ b/cmake/config/x86_64-darwin.cmake
@@ -12,7 +12,5 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-include(CMakeForceCompiler)
-
 set(CMAKE_SYSTEM_NAME Darwin)
 set(CMAKE_SYSTEM_PROCESSOR x86_64)

--- a/cmake/config/x86_64-linux.cmake
+++ b/cmake/config/x86_64-linux.cmake
@@ -12,7 +12,5 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-include(CMakeForceCompiler)
-
 set(CMAKE_SYSTEM_NAME Linux)
 set(CMAKE_SYSTEM_PROCESSOR x86_64)


### PR DESCRIPTION
The CMakeForceCompiler was made deprecated
in cmake by a long time now. Rework the toolchain
files to work without it.

IoT.js-DCO-1.0-Signed-off-by: Peter Gal pgal.u-szeged@partner.samsung.com