### PR TITLE
Remove 'iotjs_jval_set_prototype' to reduce binary size.

### DIFF
--- a/src/iotjs_binding.c
+++ b/src/iotjs_binding.c
@@ -173,15 +173,6 @@ iotjs_jval_t iotjs_jval_as_function(iotjs_jval_t jval) {
 }
 
 
-bool iotjs_jval_set_prototype(const iotjs_jval_t jobj, iotjs_jval_t jproto) {
-  jerry_value_t ret = jerry_set_prototype(jobj, jproto);
-  bool error_found = jerry_value_has_error_flag(ret);
-  jerry_release_value(ret);
-
-  return !error_found;
-}
-
-
 void iotjs_jval_set_method(iotjs_jval_t jobj, const char* name,
                            jerry_external_handler_t handler) {
   IOTJS_ASSERT(jerry_value_is_object(jobj));

--- a/src/iotjs_binding.h
+++ b/src/iotjs_binding.h
@@ -56,7 +56,6 @@ iotjs_jval_t iotjs_jval_as_function(iotjs_jval_t);
 /* Methods for General JavaScript Object */
 void iotjs_jval_set_method(iotjs_jval_t jobj, const char* name,
                            jerry_external_handler_t handler);
-bool iotjs_jval_set_prototype(iotjs_jval_t jobj, iotjs_jval_t jproto);
 void iotjs_jval_set_property_jval(iotjs_jval_t jobj, const char* name,
                                   iotjs_jval_t value);
 void iotjs_jval_set_property_null(iotjs_jval_t jobj, const char* name);

--- a/src/modules/iotjs_module_fs.c
+++ b/src/modules/iotjs_module_fs.c
@@ -313,7 +313,7 @@ iotjs_jval_t MakeStatObject(uv_stat_t* statbuf) {
   IOTJS_ASSERT(jerry_value_is_object(stat_prototype));
 
   iotjs_jval_t jstat = iotjs_jval_create_object();
-  iotjs_jval_set_prototype(jstat, stat_prototype);
+  jerry_set_prototype(jstat, stat_prototype);
 
   jerry_release_value(stat_prototype);
 


### PR DESCRIPTION
IoT.js-DCO-1.0-Signed-off-by: László Langó llango.u-szeged@partner.samsung.com