### PR TITLE
Fix builtin native C module deinitialization

### DIFF
--- a/src/iotjs_module.c
+++ b/src/iotjs_module.c
@@ -33,6 +33,7 @@ void iotjs_module_list_cleanup() {
   for (unsigned i = 0; i < iotjs_modules_count; i++) {
     if (iotjs_module_objects[i].jmodule != 0) {
       jerry_release_value(iotjs_module_objects[i].jmodule);
+      iotjs_module_objects[i].jmodule = 0;
     }
   }
 }


### PR DESCRIPTION
During the builtin natice C module deinitialization
the values were not zeroed out.

This could case problems if the modules are
re-initialized.

IoT.js-DCO-1.0-Signed-off-by: Peter Gal pgal.u-szeged@partner.samsung.com