### PR TITLE
Fix an invalid type conversion

### DIFF
--- a/src/modules/iotjs_module_i2c.c
+++ b/src/modules/iotjs_module_i2c.c
@@ -206,7 +206,7 @@ JS_FUNCTION(I2cCons) {
   iotjs_string_t device = JS_GET_ARG(0, string);
 #else
   DJS_CHECK_ARGS(2, number, function);
-  double device = JS_GET_ARG(0, number);
+  int device = JS_GET_ARG(0, number);
 #endif
   iotjs_i2c_t* i2c = iotjs_i2c_create(&device, ji2c);
 


### PR DESCRIPTION
'device' is cast to integer pointer in i2c_create_platform_data function

IoT.js-DCO-1.0-Signed-off-by: Hosung Kim hs852.kim@samsung.com