### PR TITLE
Remove unnecessary binding functions

### DIFF
--- a/docs/devs/Writing-New-Module.md
+++ b/docs/devs/Writing-New-Module.md
@@ -110,7 +110,7 @@ my-module/my_module.c:
 #include "iotjs_def.h"
 
 iotjs_jval_t InitMyNativeModule() {
-  iotjs_jval_t mymodule = iotjs_jval_create_object();
+  jerry_value_t mymodule = jerry_create_object();
   iotjs_jval_set_property_string_raw(mymodule, "message", "Hello world!");
   return mymodule;
 }

--- a/src/iotjs_binding.c
+++ b/src/iotjs_binding.c
@@ -27,10 +27,6 @@ static iotjs_jargs_t jargs_empty = {.unsafe = { 0, 0, NULL },
 #endif /* !NDEBUG */
 };
 
-iotjs_jval_t iotjs_jval_create_number(double v) {
-  return jerry_create_number(v);
-}
-
 
 iotjs_jval_t iotjs_jval_create_string(const iotjs_string_t* v) {
   iotjs_jval_t jval;
@@ -52,26 +48,11 @@ iotjs_jval_t iotjs_jval_get_string_size(const iotjs_string_t* str) {
   iotjs_jval_t str_val = iotjs_jval_create_string(str);
 
   jerry_size_t size = jerry_get_string_size(str_val);
-  iotjs_jval_t jval = iotjs_jval_create_number(size);
+  iotjs_jval_t jval = jerry_create_number(size);
 
   jerry_release_value(str_val);
 
   return jval;
-}
-
-
-iotjs_jval_t iotjs_jval_create_string_raw(const char* data) {
-  return jerry_create_string((const jerry_char_t*)data);
-}
-
-
-iotjs_jval_t iotjs_jval_create_object() {
-  return jerry_create_object();
-}
-
-
-iotjs_jval_t iotjs_jval_create_array(uint32_t len) {
-  return jerry_create_array(len);
 }
 
 
@@ -223,7 +204,7 @@ void iotjs_jval_set_property_boolean(iotjs_jval_t jobj, const char* name,
 
 void iotjs_jval_set_property_number(iotjs_jval_t jobj, const char* name,
                                     double v) {
-  iotjs_jval_t jval = iotjs_jval_create_number(v);
+  iotjs_jval_t jval = jerry_create_number(v);
   iotjs_jval_set_property_jval(jobj, name, jval);
   jerry_release_value(jval);
 }
@@ -239,7 +220,7 @@ void iotjs_jval_set_property_string(iotjs_jval_t jobj, const char* name,
 
 void iotjs_jval_set_property_string_raw(iotjs_jval_t jobj, const char* name,
                                         const char* v) {
-  iotjs_jval_t jval = iotjs_jval_create_string_raw(v);
+  iotjs_jval_t jval = jerry_create_string((const jerry_char_t*)v);
   iotjs_jval_set_property_jval(jobj, name, jval);
   jerry_release_value(jval);
 }
@@ -457,7 +438,7 @@ void iotjs_jargs_append_bool(iotjs_jargs_t* jargs, bool x) {
 
 void iotjs_jargs_append_number(iotjs_jargs_t* jargs, double x) {
   IOTJS_VALIDATABLE_STRUCT_METHOD_VALIDATE(iotjs_jargs_t, jargs);
-  iotjs_jval_t jval = iotjs_jval_create_number(x);
+  iotjs_jval_t jval = jerry_create_number(x);
   iotjs_jargs_append_jval(jargs, jval);
   jerry_release_value(jval);
 }
@@ -481,7 +462,7 @@ void iotjs_jargs_append_error(iotjs_jargs_t* jargs, const char* msg) {
 
 void iotjs_jargs_append_string_raw(iotjs_jargs_t* jargs, const char* x) {
   IOTJS_VALIDATABLE_STRUCT_METHOD_VALIDATE(iotjs_jargs_t, jargs);
-  iotjs_jval_t jval = iotjs_jval_create_string_raw(x);
+  iotjs_jval_t jval = jerry_create_string((const jerry_char_t*)x);
   iotjs_jargs_append_jval(jargs, jval);
   jerry_release_value(jval);
 }

--- a/src/iotjs_binding.h
+++ b/src/iotjs_binding.h
@@ -28,11 +28,7 @@ typedef jerry_length_t JRawLengthType;
 typedef jerry_value_t iotjs_jval_t;
 
 /* Constructors */
-iotjs_jval_t iotjs_jval_create_number(double v);
 iotjs_jval_t iotjs_jval_create_string(const iotjs_string_t* v);
-iotjs_jval_t iotjs_jval_create_string_raw(const char* data);
-iotjs_jval_t iotjs_jval_create_object();
-iotjs_jval_t iotjs_jval_create_array(uint32_t len);
 iotjs_jval_t iotjs_jval_create_byte_array(uint32_t len, const char* data);
 jerry_value_t iotjs_jval_dummy_function(const jerry_value_t function_obj,
                                         const jerry_value_t this_val,

--- a/src/modules/iotjs_module_adc.c
+++ b/src/modules/iotjs_module_adc.c
@@ -300,11 +300,11 @@ JS_FUNCTION(CloseSync) {
 }
 
 iotjs_jval_t InitAdc() {
-  iotjs_jval_t jadc = iotjs_jval_create_object();
+  iotjs_jval_t jadc = jerry_create_object();
   iotjs_jval_t jadcConstructor = jerry_create_external_function(AdcConstructor);
   iotjs_jval_set_property_jval(jadc, IOTJS_MAGIC_STRING_ADC, jadcConstructor);
 
-  iotjs_jval_t jprototype = iotjs_jval_create_object();
+  iotjs_jval_t jprototype = jerry_create_object();
   iotjs_jval_set_method(jprototype, IOTJS_MAGIC_STRING_READ, Read);
   iotjs_jval_set_method(jprototype, IOTJS_MAGIC_STRING_READSYNC, ReadSync);
   iotjs_jval_set_method(jprototype, IOTJS_MAGIC_STRING_CLOSE, Close);

--- a/src/modules/iotjs_module_blehcisocket.c
+++ b/src/modules/iotjs_module_blehcisocket.c
@@ -188,7 +188,7 @@ iotjs_jval_t InitBlehcisocket() {
   iotjs_jval_t jblehcisocketCons =
       jerry_create_external_function(BleHciSocketCons);
 
-  iotjs_jval_t prototype = iotjs_jval_create_object();
+  iotjs_jval_t prototype = jerry_create_object();
 
   iotjs_jval_set_method(prototype, IOTJS_MAGIC_STRING_START, Start);
   iotjs_jval_set_method(prototype, IOTJS_MAGIC_STRING_BINDRAW, BindRaw);

--- a/src/modules/iotjs_module_buffer.c
+++ b/src/modules/iotjs_module_buffer.c
@@ -497,7 +497,7 @@ JS_FUNCTION(ByteLength) {
 iotjs_jval_t InitBuffer() {
   iotjs_jval_t buffer = jerry_create_external_function(Buffer);
 
-  iotjs_jval_t prototype = iotjs_jval_create_object();
+  iotjs_jval_t prototype = jerry_create_object();
   iotjs_jval_set_property_jval(buffer, IOTJS_MAGIC_STRING_PROTOTYPE, prototype);
   iotjs_jval_set_method(buffer, IOTJS_MAGIC_STRING_BYTELENGTH, ByteLength);
 

--- a/src/modules/iotjs_module_console.c
+++ b/src/modules/iotjs_module_console.c
@@ -48,7 +48,7 @@ JS_FUNCTION(Stderr) {
 
 
 iotjs_jval_t InitConsole() {
-  iotjs_jval_t console = iotjs_jval_create_object();
+  iotjs_jval_t console = jerry_create_object();
 
   iotjs_jval_set_method(console, IOTJS_MAGIC_STRING_STDOUT, Stdout);
   iotjs_jval_set_method(console, IOTJS_MAGIC_STRING_STDERR, Stderr);

--- a/src/modules/iotjs_module_constants.c
+++ b/src/modules/iotjs_module_constants.c
@@ -23,7 +23,7 @@
   } while (0)
 
 iotjs_jval_t InitConstants() {
-  iotjs_jval_t constants = iotjs_jval_create_object();
+  iotjs_jval_t constants = jerry_create_object();
 
   SET_CONSTANT(constants, O_APPEND);
   SET_CONSTANT(constants, O_CREAT);

--- a/src/modules/iotjs_module_dns.c
+++ b/src/modules/iotjs_module_dns.c
@@ -253,7 +253,7 @@ JS_FUNCTION(GetAddrInfo) {
 
 
 iotjs_jval_t InitDns() {
-  iotjs_jval_t dns = iotjs_jval_create_object();
+  iotjs_jval_t dns = jerry_create_object();
 
   iotjs_jval_set_method(dns, IOTJS_MAGIC_STRING_GETADDRINFO, GetAddrInfo);
   SET_CONSTANT(dns, AI_ADDRCONFIG);

--- a/src/modules/iotjs_module_fs.c
+++ b/src/modules/iotjs_module_fs.c
@@ -73,9 +73,10 @@ static void AfterAsync(uv_fs_t* req) {
         int r;
         uv_dirent_t ent;
         uint32_t idx = 0;
-        iotjs_jval_t ret = iotjs_jval_create_array(0);
+        iotjs_jval_t ret = jerry_create_array(0);
         while ((r = uv_fs_scandir_next(req, &ent)) != UV_EOF) {
-          iotjs_jval_t name = iotjs_jval_create_string_raw(ent.name);
+          iotjs_jval_t name =
+              jerry_create_string((const jerry_char_t*)ent.name);
           iotjs_jval_set_property_by_index(ret, idx, name);
           jerry_release_value(name);
           idx++;
@@ -133,9 +134,10 @@ static iotjs_jval_t AfterSync(uv_fs_t* req, int err, const char* syscall_name) {
         int r;
         uv_dirent_t ent;
         uint32_t idx = 0;
-        iotjs_jval_t ret = iotjs_jval_create_array(0);
+        iotjs_jval_t ret = jerry_create_array(0);
         while ((r = uv_fs_scandir_next(req, &ent)) != UV_EOF) {
-          iotjs_jval_t name = iotjs_jval_create_string_raw(ent.name);
+          iotjs_jval_t name =
+              jerry_create_string((const jerry_char_t*)ent.name);
           iotjs_jval_set_property_by_index(ret, idx, name);
           jerry_release_value(name);
           idx++;
@@ -312,7 +314,7 @@ iotjs_jval_t MakeStatObject(uv_stat_t* statbuf) {
       iotjs_jval_get_property(fs, IOTJS_MAGIC_STRING_STATS);
   IOTJS_ASSERT(jerry_value_is_object(stat_prototype));
 
-  iotjs_jval_t jstat = iotjs_jval_create_object();
+  iotjs_jval_t jstat = jerry_create_object();
   iotjs_jval_set_prototype(jstat, stat_prototype);
 
   jerry_release_value(stat_prototype);
@@ -515,7 +517,7 @@ JS_FUNCTION(StatsIsFile) {
 }
 
 iotjs_jval_t InitFs() {
-  iotjs_jval_t fs = iotjs_jval_create_object();
+  iotjs_jval_t fs = jerry_create_object();
 
   iotjs_jval_set_method(fs, IOTJS_MAGIC_STRING_CLOSE, Close);
   iotjs_jval_set_method(fs, IOTJS_MAGIC_STRING_OPEN, Open);
@@ -529,7 +531,7 @@ iotjs_jval_t InitFs() {
   iotjs_jval_set_method(fs, IOTJS_MAGIC_STRING_RENAME, Rename);
   iotjs_jval_set_method(fs, IOTJS_MAGIC_STRING_READDIR, ReadDir);
 
-  iotjs_jval_t stats_prototype = iotjs_jval_create_object();
+  iotjs_jval_t stats_prototype = jerry_create_object();
 
   iotjs_jval_set_method(stats_prototype, IOTJS_MAGIC_STRING_ISDIRECTORY,
                         StatsIsDirectory);

--- a/src/modules/iotjs_module_gpio.c
+++ b/src/modules/iotjs_module_gpio.c
@@ -330,13 +330,13 @@ JS_FUNCTION(Close) {
 
 
 iotjs_jval_t InitGpio() {
-  iotjs_jval_t jgpio = iotjs_jval_create_object();
+  iotjs_jval_t jgpio = jerry_create_object();
   iotjs_jval_t jgpioConstructor =
       jerry_create_external_function(GpioConstructor);
   iotjs_jval_set_property_jval(jgpio, IOTJS_MAGIC_STRING_GPIO,
                                jgpioConstructor);
 
-  iotjs_jval_t jprototype = iotjs_jval_create_object();
+  iotjs_jval_t jprototype = jerry_create_object();
   iotjs_jval_set_method(jprototype, IOTJS_MAGIC_STRING_WRITE, Write);
   iotjs_jval_set_method(jprototype, IOTJS_MAGIC_STRING_READ, Read);
   iotjs_jval_set_method(jprototype, IOTJS_MAGIC_STRING_CLOSE, Close);
@@ -346,7 +346,7 @@ iotjs_jval_t InitGpio() {
   jerry_release_value(jgpioConstructor);
 
   // GPIO direction properties
-  iotjs_jval_t jdirection = iotjs_jval_create_object();
+  iotjs_jval_t jdirection = jerry_create_object();
   iotjs_jval_set_property_number(jdirection, IOTJS_MAGIC_STRING_IN,
                                  kGpioDirectionIn);
   iotjs_jval_set_property_number(jdirection, IOTJS_MAGIC_STRING_OUT,
@@ -357,7 +357,7 @@ iotjs_jval_t InitGpio() {
 
 
   // GPIO mode properties
-  iotjs_jval_t jmode = iotjs_jval_create_object();
+  iotjs_jval_t jmode = jerry_create_object();
   iotjs_jval_set_property_number(jmode, IOTJS_MAGIC_STRING_NONE, kGpioModeNone);
 #if defined(__NUTTX__)
   iotjs_jval_set_property_number(jmode, IOTJS_MAGIC_STRING_PULLUP,
@@ -375,7 +375,7 @@ iotjs_jval_t InitGpio() {
   jerry_release_value(jmode);
 
   // GPIO edge properties
-  iotjs_jval_t jedge = iotjs_jval_create_object();
+  iotjs_jval_t jedge = jerry_create_object();
   iotjs_jval_set_property_number(jedge, IOTJS_MAGIC_STRING_NONE, kGpioEdgeNone);
   iotjs_jval_set_property_number(jedge, IOTJS_MAGIC_STRING_RISING_U,
                                  kGpioEdgeRising);

--- a/src/modules/iotjs_module_httpparser.c
+++ b/src/modules/iotjs_module_httpparser.c
@@ -116,7 +116,7 @@ static void iotjs_httpparserwrap_destroy(
 static iotjs_jval_t iotjs_httpparserwrap_make_header(
     iotjs_httpparserwrap_t* httpparserwrap) {
   IOTJS_VALIDATED_STRUCT_METHOD(iotjs_httpparserwrap_t, httpparserwrap);
-  iotjs_jval_t jheader = iotjs_jval_create_array(_this->n_values * 2);
+  iotjs_jval_t jheader = jerry_create_array(_this->n_values * 2);
   for (size_t i = 0; i < _this->n_values; i++) {
     iotjs_jval_t f = iotjs_jval_create_string(&_this->fields[i]);
     iotjs_jval_t v = iotjs_jval_create_string(&_this->values[i]);
@@ -247,7 +247,7 @@ static int iotjs_httpparserwrap_on_headers_complete(http_parser* parser) {
 
   // URL
   iotjs_jargs_t argv = iotjs_jargs_create(1);
-  iotjs_jval_t info = iotjs_jval_create_object();
+  iotjs_jval_t info = jerry_create_object();
 
   if (_this->flushed) {
     // If some headers already are flushed,
@@ -474,7 +474,7 @@ JS_FUNCTION(HTTPParserCons) {
 
 
 iotjs_jval_t InitHttpparser() {
-  iotjs_jval_t httpparser = iotjs_jval_create_object();
+  iotjs_jval_t httpparser = jerry_create_object();
 
   iotjs_jval_t jParserCons = jerry_create_external_function(HTTPParserCons);
   iotjs_jval_set_property_jval(httpparser, IOTJS_MAGIC_STRING_HTTPPARSER,
@@ -485,7 +485,7 @@ iotjs_jval_t InitHttpparser() {
   iotjs_jval_set_property_number(jParserCons, IOTJS_MAGIC_STRING_RESPONSE,
                                  HTTP_RESPONSE);
 
-  iotjs_jval_t methods = iotjs_jval_create_object();
+  iotjs_jval_t methods = jerry_create_object();
 #define V(num, name, string) \
   iotjs_jval_set_property_string_raw(methods, #num, #string);
   HTTP_METHOD_MAP(V)
@@ -494,7 +494,7 @@ iotjs_jval_t InitHttpparser() {
   iotjs_jval_set_property_jval(jParserCons, IOTJS_MAGIC_STRING_METHODS,
                                methods);
 
-  iotjs_jval_t prototype = iotjs_jval_create_object();
+  iotjs_jval_t prototype = jerry_create_object();
 
   iotjs_jval_set_method(prototype, IOTJS_MAGIC_STRING_EXECUTE, Execute);
   iotjs_jval_set_method(prototype, IOTJS_MAGIC_STRING_REINITIALIZE,

--- a/src/modules/iotjs_module_https.c
+++ b/src/modules/iotjs_module_https.c
@@ -857,7 +857,7 @@ JS_FUNCTION(Abort) {
 }
 
 iotjs_jval_t InitHttps() {
-  iotjs_jval_t https = iotjs_jval_create_object();
+  iotjs_jval_t https = jerry_create_object();
 
   iotjs_jval_set_method(https, IOTJS_MAGIC_STRING_CREATEREQUEST, createRequest);
   iotjs_jval_set_method(https, IOTJS_MAGIC_STRING_ADDHEADER, addHeader);

--- a/src/modules/iotjs_module_i2c.c
+++ b/src/modules/iotjs_module_i2c.c
@@ -279,7 +279,7 @@ JS_FUNCTION(Read) {
 iotjs_jval_t InitI2c() {
   iotjs_jval_t jI2cCons = jerry_create_external_function(I2cCons);
 
-  iotjs_jval_t prototype = iotjs_jval_create_object();
+  iotjs_jval_t prototype = jerry_create_object();
 
   iotjs_jval_set_method(prototype, IOTJS_MAGIC_STRING_SETADDRESS, SetAddress);
   iotjs_jval_set_method(prototype, IOTJS_MAGIC_STRING_CLOSE, Close);

--- a/src/modules/iotjs_module_process.c
+++ b/src/modules/iotjs_module_process.c
@@ -225,7 +225,7 @@ static void SetProcessEnv(iotjs_jval_t process) {
   iotjsenv = "";
 #endif
 
-  iotjs_jval_t env = iotjs_jval_create_object();
+  iotjs_jval_t env = jerry_create_object();
   iotjs_jval_set_property_string_raw(env, IOTJS_MAGIC_STRING_HOME, homedir);
   iotjs_jval_set_property_string_raw(env, IOTJS_MAGIC_STRING_IOTJS_PATH,
                                      iotjspath);
@@ -240,7 +240,7 @@ static void SetProcessEnv(iotjs_jval_t process) {
 
 static void SetProcessIotjs(iotjs_jval_t process) {
   // IoT.js specific
-  iotjs_jval_t iotjs = iotjs_jval_create_object();
+  iotjs_jval_t iotjs = jerry_create_object();
   iotjs_jval_set_property_jval(process, IOTJS_MAGIC_STRING_IOTJS, iotjs);
 
   iotjs_jval_set_property_string_raw(iotjs, IOTJS_MAGIC_STRING_BOARD,
@@ -253,11 +253,11 @@ static void SetProcessArgv(iotjs_jval_t process) {
   const iotjs_environment_t* env = iotjs_environment_get();
   uint32_t argc = iotjs_environment_argc(env);
 
-  iotjs_jval_t argv = iotjs_jval_create_array(argc);
+  iotjs_jval_t argv = jerry_create_array(argc);
 
   for (uint32_t i = 0; i < argc; ++i) {
     const char* argvi = iotjs_environment_argv(env, i);
-    iotjs_jval_t arg = iotjs_jval_create_string_raw(argvi);
+    iotjs_jval_t arg = jerry_create_string((const jerry_char_t*)argvi);
     iotjs_jval_set_property_by_index(argv, i, arg);
     jerry_release_value(arg);
   }
@@ -280,7 +280,7 @@ static void SetBuiltinModules(iotjs_jval_t builtin_modules) {
 
 
 iotjs_jval_t InitProcess() {
-  iotjs_jval_t process = iotjs_jval_create_object();
+  iotjs_jval_t process = jerry_create_object();
 
   iotjs_jval_set_method(process, IOTJS_MAGIC_STRING_COMPILE, Compile);
   iotjs_jval_set_method(process, IOTJS_MAGIC_STRING_COMPILENATIVEPTR,
@@ -294,7 +294,7 @@ iotjs_jval_t InitProcess() {
   SetProcessEnv(process);
 
   // process.builtin_modules
-  iotjs_jval_t builtin_modules = iotjs_jval_create_object();
+  iotjs_jval_t builtin_modules = jerry_create_object();
   SetBuiltinModules(builtin_modules);
   iotjs_jval_set_property_jval(process, IOTJS_MAGIC_STRING_BUILTIN_MODULES,
                                builtin_modules);

--- a/src/modules/iotjs_module_pwm.c
+++ b/src/modules/iotjs_module_pwm.c
@@ -362,7 +362,7 @@ iotjs_jval_t InitPwm() {
   iotjs_jval_t jpwm_constructor =
       jerry_create_external_function(PWMConstructor);
 
-  iotjs_jval_t jprototype = iotjs_jval_create_object();
+  iotjs_jval_t jprototype = jerry_create_object();
 
   iotjs_jval_set_method(jprototype, IOTJS_MAGIC_STRING_SETPERIOD, SetPeriod);
   iotjs_jval_set_method(jprototype, IOTJS_MAGIC_STRING_SETDUTYCYCLE,

--- a/src/modules/iotjs_module_spi.c
+++ b/src/modules/iotjs_module_spi.c
@@ -419,11 +419,11 @@ JS_FUNCTION(Close) {
 
 
 iotjs_jval_t InitSpi() {
-  iotjs_jval_t jspi = iotjs_jval_create_object();
+  iotjs_jval_t jspi = jerry_create_object();
   iotjs_jval_t jspiConstructor = jerry_create_external_function(SpiConstructor);
   iotjs_jval_set_property_jval(jspi, IOTJS_MAGIC_STRING_SPI, jspiConstructor);
 
-  iotjs_jval_t prototype = iotjs_jval_create_object();
+  iotjs_jval_t prototype = jerry_create_object();
   iotjs_jval_set_method(prototype, IOTJS_MAGIC_STRING_TRANSFERARRAY,
                         TransferArray);
   iotjs_jval_set_method(prototype, IOTJS_MAGIC_STRING_TRANSFERBUFFER,
@@ -435,7 +435,7 @@ iotjs_jval_t InitSpi() {
   jerry_release_value(jspiConstructor);
 
   // SPI mode properties
-  iotjs_jval_t jmode = iotjs_jval_create_object();
+  iotjs_jval_t jmode = jerry_create_object();
   iotjs_jval_set_property_number(jmode, IOTJS_MAGIC_STRING_0, kSpiMode_0);
   iotjs_jval_set_property_number(jmode, IOTJS_MAGIC_STRING_1, kSpiMode_1);
   iotjs_jval_set_property_number(jmode, IOTJS_MAGIC_STRING_2, kSpiMode_2);
@@ -444,14 +444,14 @@ iotjs_jval_t InitSpi() {
   jerry_release_value(jmode);
 
   // SPI mode properties
-  iotjs_jval_t jcs = iotjs_jval_create_object();
+  iotjs_jval_t jcs = jerry_create_object();
   iotjs_jval_set_property_number(jcs, IOTJS_MAGIC_STRING_NONE, kSpiCsNone);
   iotjs_jval_set_property_number(jcs, IOTJS_MAGIC_STRING_HIGH, kSpiCsHigh);
   iotjs_jval_set_property_jval(jspi, IOTJS_MAGIC_STRING_CHIPSELECT_U, jcs);
   jerry_release_value(jcs);
 
   // SPI order properties
-  iotjs_jval_t jbit_order = iotjs_jval_create_object();
+  iotjs_jval_t jbit_order = jerry_create_object();
   iotjs_jval_set_property_number(jbit_order, IOTJS_MAGIC_STRING_MSB,
                                  kSpiOrderMsb);
   iotjs_jval_set_property_number(jbit_order, IOTJS_MAGIC_STRING_LSB,

--- a/src/modules/iotjs_module_stm32f4dis.c
+++ b/src/modules/iotjs_module_stm32f4dis.c
@@ -18,7 +18,7 @@
 
 
 iotjs_jval_t InitStm32f4dis() {
-  iotjs_jval_t stm32f4dis = iotjs_jval_create_object();
+  iotjs_jval_t stm32f4dis = jerry_create_object();
 
 #if defined(__NUTTX__)
 

--- a/src/modules/iotjs_module_tcp.c
+++ b/src/modules/iotjs_module_tcp.c
@@ -649,7 +649,7 @@ JS_FUNCTION(GetSockeName) {
 iotjs_jval_t InitTcp() {
   iotjs_jval_t tcp = jerry_create_external_function(TCP);
 
-  iotjs_jval_t prototype = iotjs_jval_create_object();
+  iotjs_jval_t prototype = jerry_create_object();
 
   iotjs_jval_set_property_jval(tcp, IOTJS_MAGIC_STRING_PROTOTYPE, prototype);
   iotjs_jval_set_method(tcp, IOTJS_MAGIC_STRING_ERRNAME, ErrName);

--- a/src/modules/iotjs_module_testdriver.c
+++ b/src/modules/iotjs_module_testdriver.c
@@ -61,7 +61,7 @@ JS_FUNCTION(IsAliveExceptFor) {
 
 
 iotjs_jval_t InitTestdriver() {
-  iotjs_jval_t testdriver = iotjs_jval_create_object();
+  iotjs_jval_t testdriver = jerry_create_object();
   iotjs_jval_set_method(testdriver, IOTJS_MAGIC_STRING_ISALIVEEXCEPTFOR,
                         IsAliveExceptFor);
 

--- a/src/modules/iotjs_module_timer.c
+++ b/src/modules/iotjs_module_timer.c
@@ -166,7 +166,7 @@ JS_FUNCTION(Timer) {
 iotjs_jval_t InitTimer() {
   iotjs_jval_t timer = jerry_create_external_function(Timer);
 
-  iotjs_jval_t prototype = iotjs_jval_create_object();
+  iotjs_jval_t prototype = jerry_create_object();
   iotjs_jval_set_property_jval(timer, IOTJS_MAGIC_STRING_PROTOTYPE, prototype);
 
   iotjs_jval_set_method(prototype, IOTJS_MAGIC_STRING_START, Start);

--- a/src/modules/iotjs_module_uart.c
+++ b/src/modules/iotjs_module_uart.c
@@ -215,8 +215,8 @@ static void iotjs_uart_onread(iotjs_jval_t jthis, char* buf) {
   IOTJS_ASSERT(jerry_value_is_function(jemit));
 
   iotjs_jargs_t jargs = iotjs_jargs_create(2);
-  iotjs_jval_t str = iotjs_jval_create_string_raw("data");
-  iotjs_jval_t data = iotjs_jval_create_string_raw(buf);
+  iotjs_jval_t str = jerry_create_string((const jerry_char_t*)"data");
+  iotjs_jval_t data = jerry_create_string((const jerry_char_t*)buf);
   iotjs_jargs_append_jval(&jargs, str);
   iotjs_jargs_append_jval(&jargs, data);
   iotjs_jhelper_call_ok(jemit, jthis, &jargs);
@@ -346,7 +346,7 @@ iotjs_jval_t InitUart() {
   iotjs_jval_t juart_constructor =
       jerry_create_external_function(UartConstructor);
 
-  iotjs_jval_t prototype = iotjs_jval_create_object();
+  iotjs_jval_t prototype = jerry_create_object();
 
   iotjs_jval_set_method(prototype, IOTJS_MAGIC_STRING_WRITE, Write);
   iotjs_jval_set_method(prototype, IOTJS_MAGIC_STRING_CLOSE, Close);

--- a/src/modules/iotjs_module_udp.c
+++ b/src/modules/iotjs_module_udp.c
@@ -215,7 +215,7 @@ static void OnRecv(uv_udp_t* handle, ssize_t nread, const uv_buf_t* buf,
 
   iotjs_jargs_append_jval(&jargs, jbuffer);
 
-  iotjs_jval_t rinfo = iotjs_jval_create_object();
+  iotjs_jval_t rinfo = jerry_create_object();
   AddressToJS(rinfo, addr);
   iotjs_jargs_append_jval(&jargs, rinfo);
 
@@ -466,7 +466,7 @@ JS_FUNCTION(Unref) {
 iotjs_jval_t InitUdp() {
   iotjs_jval_t udp = jerry_create_external_function(UDP);
 
-  iotjs_jval_t prototype = iotjs_jval_create_object();
+  iotjs_jval_t prototype = jerry_create_object();
   iotjs_jval_set_property_jval(udp, IOTJS_MAGIC_STRING_PROTOTYPE, prototype);
 
   iotjs_jval_set_method(prototype, IOTJS_MAGIC_STRING_BIND, Bind);

--- a/src/modules/linux/iotjs_module_blehcisocket-linux.c
+++ b/src/modules/linux/iotjs_module_blehcisocket-linux.c
@@ -302,7 +302,7 @@ void iotjs_blehcisocket_poll(THIS) {
     IOTJS_ASSERT(jerry_value_is_function(jemit));
 
     iotjs_jargs_t jargs = iotjs_jargs_create(2);
-    iotjs_jval_t str = iotjs_jval_create_string_raw("data");
+    iotjs_jval_t str = jerry_create_string((const jerry_char_t*)"data");
     IOTJS_ASSERT(length >= 0);
     iotjs_jval_t jbuf = iotjs_bufferwrap_create_buffer((size_t)length);
     iotjs_bufferwrap_t* buf_wrap = iotjs_bufferwrap_from_jbuffer(jbuf);
@@ -343,7 +343,7 @@ void iotjs_blehcisocket_emitErrnoError(THIS) {
   IOTJS_ASSERT(jerry_value_is_function(jemit));
 
   iotjs_jargs_t jargs = iotjs_jargs_create(2);
-  iotjs_jval_t str = iotjs_jval_create_string_raw("error");
+  iotjs_jval_t str = jerry_create_string((const jerry_char_t*)"error");
   iotjs_jval_t jerror = iotjs_jval_create_error(strerror(errno));
   iotjs_jargs_append_jval(&jargs, str);
   iotjs_jargs_append_jval(&jargs, jerror);

--- a/src/modules/nuttx/iotjs_module_stm32f4dis-nuttx.c
+++ b/src/modules/nuttx/iotjs_module_stm32f4dis-nuttx.c
@@ -122,8 +122,8 @@ static void iotjs_pin_initialize_pwm(iotjs_jval_t jobj) {
   SET_GPIO_CONSTANT(timer, channel, 1);           \
   SET_GPIO_CONSTANT(timer, channel, 2);
 
-#define SET_GPIO_CONSTANT_TIM(timer)                     \
-  iotjs_jval_t jtim##timer = iotjs_jval_create_object(); \
+#define SET_GPIO_CONSTANT_TIM(timer)                \
+  iotjs_jval_t jtim##timer = jerry_create_object(); \
   iotjs_jval_set_property_jval(jobj, "PWM" #timer, jtim##timer);
 
 #define SET_GPIO_CONSTANT_TIM_1(timer) \
@@ -182,7 +182,7 @@ static void iotjs_pin_initialize_pwm(iotjs_jval_t jobj) {
 
 
 void iotjs_stm32f4dis_pin_initialize(iotjs_jval_t jobj) {
-  iotjs_jval_t jpin = iotjs_jval_create_object();
+  iotjs_jval_t jpin = jerry_create_object();
   iotjs_jval_set_property_jval(jobj, "pin", jpin);
 
 #if ENABLE_MODULE_ADC

--- a/test/external_modules/mymodule2/my_module.c
+++ b/test/external_modules/mymodule2/my_module.c
@@ -16,7 +16,7 @@
 #include "iotjs_def.h"
 
 iotjs_jval_t InitMyNativeModule() {
-  iotjs_jval_t mymodule = iotjs_jval_create_object();
+  jerry_value_t mymodule = jerry_create_object();
   iotjs_jval_set_property_string_raw(mymodule, "message", "Hello world!");
   return mymodule;
 }


### PR DESCRIPTION
Removed 'iotjs_jval_create_number', 'iotjs_jval_create_string_raw',
'iotjs_jval_create_object' and 'iotjs_jval_create_array'.

IoT.js-DCO-1.0-Signed-off-by: László Langó llango.u-szeged@partner.samsung.com