### PR TITLE
Remove object parameter from JS_GET_THIS and DJS_CHECK_THIS

### DIFF
--- a/src/iotjs_binding.h
+++ b/src/iotjs_binding.h
@@ -158,7 +158,7 @@ iotjs_jval_t iotjs_jhelper_eval(const char* name, size_t name_len,
   JS_CHECK(jargc >= argc);       \
   JS_CHECK_ARGS_##argc(__VA_ARGS__)
 
-#define JS_CHECK_THIS(type) JS_CHECK_TYPE(jthis, type);
+#define JS_CHECK_THIS() JS_CHECK_TYPE(jthis, object);
 
 #define JS_GET_ARG(index, type) iotjs_jval_as_##type(jargv[index])
 
@@ -167,7 +167,7 @@ iotjs_jval_t iotjs_jhelper_eval(const char* name, size_t name_len,
        ? jargv[index]                                     \
        : jerry_create_null())
 
-#define JS_GET_THIS(type) iotjs_jval_as_##type(jthis)
+#define JS_GET_THIS() iotjs_jval_as_object(jthis)
 
 #define JS_FUNCTION(name)                                \
   static jerry_value_t name(const jerry_value_t jfunc,   \
@@ -180,12 +180,12 @@ iotjs_jval_t iotjs_jhelper_eval(const char* name, size_t name_len,
 // This code branch is to be in #ifdef NDEBUG
 #define DJS_CHECK_ARG(index, type) ((void)0)
 #define DJS_CHECK_ARGS(argc, ...) ((void)0)
-#define DJS_CHECK_THIS(type) ((void)0)
+#define DJS_CHECK_THIS() ((void)0)
 #define DJS_CHECK_ARG_IF_EXIST(index, type) ((void)0)
 #else
 #define DJS_CHECK_ARG(index, type) JS_CHECK_ARG(index, type)
 #define DJS_CHECK_ARGS(argc, ...) JS_CHECK_ARGS(argc, __VA_ARGS__)
-#define DJS_CHECK_THIS(type) JS_CHECK_THIS(type)
+#define DJS_CHECK_THIS() JS_CHECK_THIS()
 #define DJS_CHECK_ARG_IF_EXIST(index, type) JS_CHECK_ARG_IF_EXIST(index, type)
 #endif
 

--- a/src/modules/iotjs_module_adc.c
+++ b/src/modules/iotjs_module_adc.c
@@ -202,10 +202,10 @@ static void iotjs_adc_close_worker(uv_work_t* work_req) {
   } while (0)
 
 JS_FUNCTION(AdcConstructor) {
-  DJS_CHECK_THIS(object);
+  DJS_CHECK_THIS();
 
   // Create ADC object
-  const iotjs_jval_t jadc = JS_GET_THIS(object);
+  const iotjs_jval_t jadc = JS_GET_THIS();
   iotjs_adc_t* adc = iotjs_adc_create(jadc);
   IOTJS_ASSERT(adc == iotjs_adc_instance_from_jval(jadc));
   IOTJS_VALIDATED_STRUCT_METHOD(iotjs_adc_t, adc);

--- a/src/modules/iotjs_module_blehcisocket.c
+++ b/src/modules/iotjs_module_blehcisocket.c
@@ -172,10 +172,10 @@ JS_FUNCTION(Write) {
 
 
 JS_FUNCTION(BleHciSocketCons) {
-  DJS_CHECK_THIS(object);
+  DJS_CHECK_THIS();
 
   // Create object
-  iotjs_jval_t jblehcisocket = JS_GET_THIS(object);
+  iotjs_jval_t jblehcisocket = JS_GET_THIS();
   iotjs_blehcisocket_t* blehcisocket = iotjs_blehcisocket_create(jblehcisocket);
   IOTJS_ASSERT(blehcisocket ==
                (iotjs_blehcisocket_t*)(iotjs_jval_get_object_native_handle(

--- a/src/modules/iotjs_module_buffer.c
+++ b/src/modules/iotjs_module_buffer.c
@@ -235,10 +235,10 @@ iotjs_jval_t iotjs_bufferwrap_create_buffer(size_t len) {
 
 
 JS_FUNCTION(Buffer) {
-  DJS_CHECK_THIS(object);
+  DJS_CHECK_THIS();
   DJS_CHECK_ARGS(2, object, number);
 
-  const iotjs_jval_t jbuiltin = JS_GET_THIS(object);
+  const iotjs_jval_t jbuiltin = JS_GET_THIS();
   const iotjs_jval_t jbuffer = JS_GET_ARG(0, object);
   size_t length = JS_GET_ARG(1, number);
 
@@ -483,7 +483,7 @@ JS_FUNCTION(ToHexString) {
 
 
 JS_FUNCTION(ByteLength) {
-  DJS_CHECK_THIS(object);
+  DJS_CHECK_THIS();
   DJS_CHECK_ARGS(1, string);
 
   iotjs_string_t str = JS_GET_ARG(0, string);

--- a/src/modules/iotjs_module_dns.c
+++ b/src/modules/iotjs_module_dns.c
@@ -165,7 +165,7 @@ static void AfterGetAddrInfo(uv_getaddrinfo_t* req, int status,
 
 
 JS_FUNCTION(GetAddrInfo) {
-  DJS_CHECK_THIS(object);
+  DJS_CHECK_THIS();
   DJS_CHECK_ARGS(4, string, number, number, function);
 
   iotjs_string_t hostname = JS_GET_ARG(0, string);

--- a/src/modules/iotjs_module_fs.c
+++ b/src/modules/iotjs_module_fs.c
@@ -186,7 +186,7 @@ static inline bool IsWithinBounds(size_t off, size_t len, size_t max) {
 
 
 JS_FUNCTION(Close) {
-  DJS_CHECK_THIS(object);
+  DJS_CHECK_THIS();
   DJS_CHECK_ARGS(1, number);
   DJS_CHECK_ARG_IF_EXIST(1, function);
 
@@ -206,7 +206,7 @@ JS_FUNCTION(Close) {
 
 
 JS_FUNCTION(Open) {
-  DJS_CHECK_THIS(object);
+  DJS_CHECK_THIS();
   DJS_CHECK_ARGS(3, string, number, number);
   DJS_CHECK_ARG_IF_EXIST(3, function);
 
@@ -230,7 +230,7 @@ JS_FUNCTION(Open) {
 
 
 JS_FUNCTION(Read) {
-  DJS_CHECK_THIS(object);
+  DJS_CHECK_THIS();
   DJS_CHECK_ARGS(5, number, object, number, number, number);
   DJS_CHECK_ARG_IF_EXIST(5, function);
 
@@ -269,7 +269,7 @@ JS_FUNCTION(Read) {
 
 
 JS_FUNCTION(Write) {
-  DJS_CHECK_THIS(object);
+  DJS_CHECK_THIS();
   DJS_CHECK_ARGS(5, number, object, number, number, number);
   DJS_CHECK_ARG_IF_EXIST(5, function);
 
@@ -341,7 +341,7 @@ iotjs_jval_t MakeStatObject(uv_stat_t* statbuf) {
 
 
 JS_FUNCTION(Stat) {
-  DJS_CHECK_THIS(object);
+  DJS_CHECK_THIS();
   DJS_CHECK_ARGS(1, string);
   DJS_CHECK_ARG_IF_EXIST(1, function);
 
@@ -363,7 +363,7 @@ JS_FUNCTION(Stat) {
 
 
 JS_FUNCTION(Fstat) {
-  DJS_CHECK_THIS(object);
+  DJS_CHECK_THIS();
   DJS_CHECK_ARGS(1, number);
   DJS_CHECK_ARG_IF_EXIST(1, function);
 
@@ -383,7 +383,7 @@ JS_FUNCTION(Fstat) {
 
 
 JS_FUNCTION(MkDir) {
-  DJS_CHECK_THIS(object);
+  DJS_CHECK_THIS();
   DJS_CHECK_ARGS(2, string, number);
   DJS_CHECK_ARG_IF_EXIST(2, function);
 
@@ -406,7 +406,7 @@ JS_FUNCTION(MkDir) {
 
 
 JS_FUNCTION(RmDir) {
-  DJS_CHECK_THIS(object);
+  DJS_CHECK_THIS();
   DJS_CHECK_ARGS(1, string);
   DJS_CHECK_ARG_IF_EXIST(1, function);
 
@@ -428,7 +428,7 @@ JS_FUNCTION(RmDir) {
 
 
 JS_FUNCTION(Unlink) {
-  DJS_CHECK_THIS(object);
+  DJS_CHECK_THIS();
   DJS_CHECK_ARGS(1, string);
   DJS_CHECK_ARG_IF_EXIST(1, function);
 
@@ -450,7 +450,7 @@ JS_FUNCTION(Unlink) {
 
 
 JS_FUNCTION(Rename) {
-  DJS_CHECK_THIS(object);
+  DJS_CHECK_THIS();
   DJS_CHECK_ARGS(2, string, string);
   DJS_CHECK_ARG_IF_EXIST(2, function);
 
@@ -476,7 +476,7 @@ JS_FUNCTION(Rename) {
 
 
 JS_FUNCTION(ReadDir) {
-  DJS_CHECK_THIS(object);
+  DJS_CHECK_THIS();
   DJS_CHECK_ARGS(1, string);
   DJS_CHECK_ARG_IF_EXIST(1, function);
 
@@ -505,14 +505,14 @@ static iotjs_jval_t StatsIsTypeOf(iotjs_jval_t stats, int type) {
 }
 
 JS_FUNCTION(StatsIsDirectory) {
-  DJS_CHECK_THIS(object);
-  iotjs_jval_t stats = JS_GET_THIS(object);
+  DJS_CHECK_THIS();
+  iotjs_jval_t stats = JS_GET_THIS();
   return StatsIsTypeOf(stats, S_IFDIR);
 }
 
 JS_FUNCTION(StatsIsFile) {
-  DJS_CHECK_THIS(object);
-  iotjs_jval_t stats = JS_GET_THIS(object);
+  DJS_CHECK_THIS();
+  iotjs_jval_t stats = JS_GET_THIS();
   return StatsIsTypeOf(stats, S_IFREG);
 }
 

--- a/src/modules/iotjs_module_gpio.c
+++ b/src/modules/iotjs_module_gpio.c
@@ -254,11 +254,11 @@ static void gpio_set_configurable(iotjs_gpio_t* gpio,
 
 
 JS_FUNCTION(GpioConstructor) {
-  DJS_CHECK_THIS(object);
+  DJS_CHECK_THIS();
   DJS_CHECK_ARGS(2, object, function);
 
   // Create GPIO object
-  const iotjs_jval_t jgpio = JS_GET_THIS(object);
+  const iotjs_jval_t jgpio = JS_GET_THIS();
   iotjs_gpio_t* gpio = iotjs_gpio_create(jgpio);
   IOTJS_ASSERT(gpio == iotjs_gpio_instance_from_jval(jgpio));
 

--- a/src/modules/iotjs_module_httpparser.c
+++ b/src/modules/iotjs_module_httpparser.c
@@ -460,10 +460,10 @@ JS_FUNCTION(Resume) {
 
 
 JS_FUNCTION(HTTPParserCons) {
-  DJS_CHECK_THIS(object);
+  DJS_CHECK_THIS();
   DJS_CHECK_ARGS(1, number);
 
-  const iotjs_jval_t jparser = JS_GET_THIS(object);
+  const iotjs_jval_t jparser = JS_GET_THIS();
 
   http_parser_type httpparser_type = (http_parser_type)(JS_GET_ARG(0, number));
   IOTJS_ASSERT(httpparser_type == HTTP_REQUEST ||

--- a/src/modules/iotjs_module_https.c
+++ b/src/modules/iotjs_module_https.c
@@ -719,7 +719,7 @@ void iotjs_https_poll_destroy(iotjs_https_poll_t* poll_data) {
 // ------------JHANDLERS----------------
 
 JS_FUNCTION(createRequest) {
-  DJS_CHECK_THIS(object);
+  DJS_CHECK_THIS();
   DJS_CHECK_ARGS(1, object);
 
   const iotjs_jval_t joptions = JS_GET_ARG(0, object);
@@ -772,7 +772,7 @@ JS_FUNCTION(createRequest) {
 }
 
 JS_FUNCTION(addHeader) {
-  DJS_CHECK_THIS(object);
+  DJS_CHECK_THIS();
 
   DJS_CHECK_ARGS(2, string, object);
   iotjs_string_t header = JS_GET_ARG(0, string);
@@ -788,7 +788,7 @@ JS_FUNCTION(addHeader) {
 }
 
 JS_FUNCTION(sendRequest) {
-  DJS_CHECK_THIS(object);
+  DJS_CHECK_THIS();
 
   DJS_CHECK_ARG(0, object);
   iotjs_jval_t jarg = JS_GET_ARG(0, object);
@@ -799,7 +799,7 @@ JS_FUNCTION(sendRequest) {
 }
 
 JS_FUNCTION(setTimeout) {
-  DJS_CHECK_THIS(object);
+  DJS_CHECK_THIS();
   DJS_CHECK_ARGS(2, number, object);
 
   double ms = JS_GET_ARG(0, number);
@@ -813,7 +813,7 @@ JS_FUNCTION(setTimeout) {
 }
 
 JS_FUNCTION(_write) {
-  DJS_CHECK_THIS(object);
+  DJS_CHECK_THIS();
   DJS_CHECK_ARGS(2, object, string);
   // Argument 3 can be null, so not checked directly, checked later
   DJS_CHECK_ARG(3, function);
@@ -833,7 +833,7 @@ JS_FUNCTION(_write) {
 }
 
 JS_FUNCTION(finishRequest) {
-  DJS_CHECK_THIS(object);
+  DJS_CHECK_THIS();
   DJS_CHECK_ARG(0, object);
 
   iotjs_jval_t jarg = JS_GET_ARG(0, object);
@@ -845,7 +845,7 @@ JS_FUNCTION(finishRequest) {
 }
 
 JS_FUNCTION(Abort) {
-  DJS_CHECK_THIS(object);
+  DJS_CHECK_THIS();
   DJS_CHECK_ARG(0, object);
 
   iotjs_jval_t jarg = JS_GET_ARG(0, object);

--- a/src/modules/iotjs_module_i2c.c
+++ b/src/modules/iotjs_module_i2c.c
@@ -198,9 +198,9 @@ static void GetI2cArray(const iotjs_jval_t jarray,
   } while (0)
 
 JS_FUNCTION(I2cCons) {
-  DJS_CHECK_THIS(object);
+  DJS_CHECK_THIS();
   // Create I2C object
-  const iotjs_jval_t ji2c = JS_GET_THIS(object);
+  const iotjs_jval_t ji2c = JS_GET_THIS();
 #ifdef __linux__
   DJS_CHECK_ARGS(2, string, function);
   iotjs_string_t device = JS_GET_ARG(0, string);

--- a/src/modules/iotjs_module_pwm.c
+++ b/src/modules/iotjs_module_pwm.c
@@ -248,11 +248,11 @@ static void iotjs_pwm_after_worker(uv_work_t* work_req, int status) {
 
 
 JS_FUNCTION(PWMConstructor) {
-  DJS_CHECK_THIS(object);
+  DJS_CHECK_THIS();
   DJS_CHECK_ARGS(2, object, function);
 
   // Create PWM object
-  iotjs_jval_t jpwm = JS_GET_THIS(object);
+  iotjs_jval_t jpwm = JS_GET_THIS();
   iotjs_pwm_t* pwm = iotjs_pwm_create(jpwm);
   IOTJS_ASSERT(pwm == iotjs_pwm_instance_from_jval(jpwm));
 

--- a/src/modules/iotjs_module_spi.c
+++ b/src/modules/iotjs_module_spi.c
@@ -326,11 +326,11 @@ iotjs_spi_t* iotjs_spi_get_instance(iotjs_jval_t jspi) {
 
 
 JS_FUNCTION(SpiConstructor) {
-  DJS_CHECK_THIS(object);
+  DJS_CHECK_THIS();
   DJS_CHECK_ARGS(2, object, function);
 
   // Create SPI object
-  iotjs_jval_t jspi = JS_GET_THIS(object);
+  iotjs_jval_t jspi = JS_GET_THIS();
   iotjs_spi_t* spi = iotjs_spi_create(jspi);
   IOTJS_ASSERT(spi == iotjs_spi_get_instance(jspi));
 

--- a/src/modules/iotjs_module_tcp.c
+++ b/src/modules/iotjs_module_tcp.c
@@ -206,9 +206,9 @@ iotjs_jval_t iotjs_shutdown_reqwrap_jcallback(THIS) {
 
 
 JS_FUNCTION(TCP) {
-  DJS_CHECK_THIS(object);
+  DJS_CHECK_THIS();
 
-  iotjs_jval_t jtcp = JS_GET_THIS(object);
+  iotjs_jval_t jtcp = JS_GET_THIS();
   iotjs_tcpwrap_create(jtcp);
   return jerry_create_undefined();
 }
@@ -585,7 +585,7 @@ JS_FUNCTION(SetKeepAlive) {
 }
 
 JS_FUNCTION(ErrName) {
-  DJS_CHECK_THIS(object);
+  DJS_CHECK_THIS();
   DJS_CHECK_ARGS(1, number);
 
   int errorcode = JS_GET_ARG(0, number);
@@ -634,7 +634,7 @@ void AddressToJS(iotjs_jval_t obj, const sockaddr* addr) {
 JS_FUNCTION(GetSockeName) {
   DJS_CHECK_ARGS(1, object);
 
-  iotjs_tcpwrap_t* wrap = iotjs_tcpwrap_from_jobject(JS_GET_THIS(object));
+  iotjs_tcpwrap_t* wrap = iotjs_tcpwrap_from_jobject(JS_GET_THIS());
   IOTJS_ASSERT(wrap != NULL);
 
   sockaddr_storage storage;

--- a/src/modules/iotjs_module_timer.c
+++ b/src/modules/iotjs_module_timer.c
@@ -149,9 +149,9 @@ JS_FUNCTION(Stop) {
 
 
 JS_FUNCTION(Timer) {
-  JS_CHECK_THIS(object);
+  JS_CHECK_THIS();
 
-  const iotjs_jval_t jtimer = JS_GET_THIS(object);
+  const iotjs_jval_t jtimer = JS_GET_THIS();
 
   iotjs_timerwrap_t* timer_wrap = iotjs_timerwrap_create(jtimer);
 

--- a/src/modules/iotjs_module_uart.c
+++ b/src/modules/iotjs_module_uart.c
@@ -254,11 +254,11 @@ void iotjs_uart_read_cb(uv_poll_t* req, int status, int events) {
 
 
 JS_FUNCTION(UartConstructor) {
-  DJS_CHECK_THIS(object);
+  DJS_CHECK_THIS();
   DJS_CHECK_ARGS(3, object, object, function);
 
   // Create UART object
-  iotjs_jval_t juart = JS_GET_THIS(object);
+  iotjs_jval_t juart = JS_GET_THIS();
   iotjs_uart_t* uart = iotjs_uart_create(juart);
   IOTJS_ASSERT(uart == iotjs_uart_instance_from_jval(juart));
   IOTJS_VALIDATED_STRUCT_METHOD(iotjs_uart_t, uart);

--- a/src/modules/iotjs_module_udp.c
+++ b/src/modules/iotjs_module_udp.c
@@ -124,9 +124,9 @@ size_t iotjs_send_reqwrap_msg_size(THIS) {
 
 
 JS_FUNCTION(UDP) {
-  DJS_CHECK_THIS(object);
+  DJS_CHECK_THIS();
 
-  iotjs_jval_t judp = JS_GET_THIS(object);
+  iotjs_jval_t judp = JS_GET_THIS();
   iotjs_udpwrap_create(judp);
 
   return jerry_create_undefined();
@@ -139,7 +139,7 @@ JS_FUNCTION(Bind) {
 
   iotjs_string_t address = JS_GET_ARG(0, string);
   const int port = JS_GET_ARG(1, number);
-  iotjs_jval_t this_obj = JS_GET_THIS(object);
+  iotjs_jval_t this_obj = JS_GET_THIS();
   iotjs_jval_t reuse_addr =
       iotjs_jval_get_property(this_obj, IOTJS_MAGIC_STRING__REUSEADDR);
   IOTJS_ASSERT(jerry_value_is_boolean(reuse_addr) ||
@@ -332,7 +332,7 @@ JS_FUNCTION(Close) {
 
 JS_FUNCTION(GetSockeName) {
   DJS_CHECK_ARGS(1, object);
-  iotjs_udpwrap_t* wrap = iotjs_udpwrap_from_jobject(JS_GET_THIS(object));
+  iotjs_udpwrap_t* wrap = iotjs_udpwrap_from_jobject(JS_GET_THIS());
   IOTJS_ASSERT(wrap != NULL);
 
   sockaddr_storage storage;


### PR DESCRIPTION
We always pass `object` to `DJS_JS_CHECK_THIS(type)` since jthis is always object.
It is same for `JS_GET_THIS(type)`. So I remove the redundant parameter.

IoT.js-DCO-1.0-Signed-off-by: Sanggyu Lee sg5.lee@samsung.com