### PR TITLE
Check the given path in fs.exists

### DIFF
--- a/src/js/fs.js
+++ b/src/js/fs.js
@@ -20,6 +20,9 @@ var util = require('util');
 var fsBuiltin = native;
 
 fs.exists = function(path, callback) {
+  if (!(util.isString(path)) && !(util.isBuffer(path))) {
+    throw new TypeError('Path should be a string or a buffer');
+  }
   if (!path || !path.length) {
     process.nextTick(function() {
       if (callback) callback(false);


### PR DESCRIPTION
The path argument passed to fs.exists must be either a String or a Buffer
fixes #1355 

IoT.js-DCO-1.0-Signed-off-by: Daniel Balla dballa@inf.u-szeged.hu