### PR TITLE
Add an error explanation on http client

### DIFF
--- a/test/run_pass/test_net_httpclient_parse_error.js
+++ b/test/run_pass/test_net_httpclient_parse_error.js
@@ -39,7 +39,6 @@ request.on('error', function(err) {
 request.end();
 
 process.on('exit', function() {
-  // The first error is a Parse Error.
-  // The second error is the socket hang up.
-  assert.equal(errors, 2);
+  // The error is a Parse Error.
+  assert.equal(errors, 1);
 });


### PR DESCRIPTION
This patch mainly adds and improves the error handling for dns.lookup and net.socket errors. Users can find the basic clue for errors instead of `socket hang up`.

IoT.js-DCO-1.0-Signed-off-by: Daeyeon Jeong daeyeon.jeong@samsung.com