### PR TITLE
Check the given path in process.readSource

### DIFF
--- a/src/modules/iotjs_module_process.c
+++ b/src/modules/iotjs_module_process.c
@@ -142,6 +142,18 @@ JS_FUNCTION(ReadSource) {
   DJS_CHECK_ARGS(1, string);
 
   iotjs_string_t path = JS_GET_ARG(0, string);
+  const iotjs_environment_t* env = iotjs_environment_get();
+
+  uv_fs_t fs_req;
+  uv_fs_stat(iotjs_environment_loop(env), &fs_req, iotjs_string_data(&path),
+             NULL);
+  uv_fs_req_cleanup(&fs_req);
+
+  if (!S_ISREG(fs_req.statbuf.st_mode)) {
+    iotjs_string_destroy(&path);
+    return JS_CREATE_ERROR(COMMON, "ReadSource error, not a regular file");
+  }
+
   iotjs_string_t code = iotjs_file_read(iotjs_string_data(&path));
 
   iotjs_jval_t ret_val = iotjs_jval_create_string(&code);

--- a/test/run_pass/issue/issue-1351.js
+++ b/test/run_pass/issue/issue-1351.js
@@ -1,0 +1,27 @@
+/* Copyright 2017-present Samsung Electronics Co., Ltd. and other contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+var assert = require('assert');
+var fs = require('fs');
+
+var filePath = process.cwd() + '/resources/';
+
+try {
+  process.readSource(filePath);
+} catch (e) {
+  assert.equal(fs.existsSync(filePath), true);
+  assert.equal(e.name, 'Error');
+  assert.equal(e.message, 'ReadSource error, not a regular file');
+}

--- a/test/testsets.json
+++ b/test/testsets.json
@@ -91,7 +91,7 @@
     { "name": "test_pwm_sync.js", "skip": ["all"], "reason": "need to setup test environment" },
     { "name": "test_spi.js", "skip": ["linux"], "reason": "Differend env on Linux desktop/travis/rpi" },
     { "name": "test_spi_buffer.js", "skip": ["all"], "reason": "need to setup test environment" },
-    { "name": "test_spi_mcp3008.js", "skip": ["all"], "reason": "need to setup test environment" },   
+    { "name": "test_spi_mcp3008.js", "skip": ["all"], "reason": "need to setup test environment" },
     { "name": "test_stream.js" },
     { "name": "test_stream_duplex.js"},
     { "name": "test_timers_arguments.js" },
@@ -111,7 +111,8 @@
     { "name": "issue-816.js" },
     { "name": "issue-1046.js" },
     { "name": "issue-1077.js" },
-    { "name": "issue-1101.js", "skip": ["all"], "reason": "need to setup test environment" }    
+    { "name": "issue-1101.js", "skip": ["all"], "reason": "need to setup test environment" },
+    { "name": "issue-1351.js" }
   ],
   "run_fail":  [
     { "name": "test_assert_equal.js", "expected-failure": true },


### PR DESCRIPTION
The path argument in the process.readSource must point
to an existing file, not a directory.
Fix #1351

IoT.js-DCO-1.0-Signed-off-by: Imre Kiss kissi.szeged@partner.samsung.com