### PR TITLE
Removed unnecessary typdefs from the binding layer to make the code more readable.

### DIFF
--- a/cmake/iotjs.cmake
+++ b/cmake/iotjs.cmake
@@ -253,7 +253,7 @@ foreach(MODULE ${IOTJS_NATIVE_MODULES})
   string(TOLOWER ${MODULE} module)
 
   set(IOTJS_MODULE_INITIALIZERS "${IOTJS_MODULE_INITIALIZERS}
-extern iotjs_jval_t ${${IOTJS_MODULES_JSON}.modules.${module}.init}();")
+extern jerry_value_t ${${IOTJS_MODULES_JSON}.modules.${module}.init}();")
 endforeach()
 
 # Build up module entries

--- a/docs/devs/Inside-IoT.js-Validated-Struct.md
+++ b/docs/devs/Inside-IoT.js-Validated-Struct.md
@@ -137,7 +137,7 @@ typedef struct {
   uv_fs_t req;
 } IOTJS_VALIDATED_STRUCT(iotjs_fsreqwrap_t);
 
-iotjs_fsreqwrap_t* iotjs_fsreqwrap_create(const iotjs_jval_t* jcallback);
+iotjs_fsreqwrap_t* iotjs_fsreqwrap_create(const jerry_value_t* jcallback);
 void iotjs_fsreqwrap_dispatched(iotjs_fsreqwrap_t* fsreqwrap);
 ```
 
@@ -151,7 +151,7 @@ The destructor `iotjs_fsreqwrap_destroy()` is hidden in c file.
  * Implementation in iotjs_module_fs.c
  */
 
-iotjs_fsreqwrap_t* iotjs_fsreqwrap_create(const iotjs_jval_t* jcallback) {
+iotjs_fsreqwrap_t* iotjs_fsreqwrap_create(const jerry_value_t* jcallback) {
   iotjs_fsreqwrap_t* fsreqwrap = IOTJS_ALLOC(iotjs_fsreqwrap_t);
   IOTJS_VALIDATED_STRUCT_CONSTRUCTOR(iotjs_fsreqwrap_t, fsreqwrap);
   iotjs_reqwrap_initialize(&_this->reqwrap, jcallback, (uv_req_t*)&_this->req);
@@ -179,7 +179,7 @@ void callback(uv_fs_t* req) {
     iotjs_fsreqwrap_dispatched(req); /* Call iotjs_*reqwrap_dispatched() when callback called */
 }
 
-void request(iotjs_jval_t* jcallback) {
+void request(jerry_value_t* jcallback) {
     iotjs_fsreqwrap_t* wrap = iotjs_fsreqwrap_create(jcallback);
     uv_fs_request(loop, wrap->req, callback);
 }

--- a/docs/devs/Inside-IoT.js.md
+++ b/docs/devs/Inside-IoT.js.md
@@ -3,7 +3,7 @@ Inside IoT.js
 
 * [Design](#design)
 * [Javascript Binding](#javascript-binding)
-  * iotjs_jval_t
+  * jerry_value_t
   * iotjs_jobjectwrap_t
   * Native handler
   * Embedding API
@@ -36,9 +36,9 @@ Although IoT.js only supports JerryScript for now, there will be a chance that w
 For this reason, we want to keep the layer independent from a specific Javascript engine.
 You can see interface of the layer in [iotjs_binding.h](../../src/iotjs_binding.h).
 
-## iotjs_jval_t
+## jerry_value_t
 
-`iotjs_jval_t` struct stands for a real Javascript object. Upper layers will access Javascript object via this struct.
+`jerry_value_t` struct stands for a real Javascript object. Upper layers will access Javascript object via this struct.
 This struct provides following functionalities:
 
 * Creating a Javascript object using `iotjs_jval_create_*()` constructor.
@@ -56,14 +56,14 @@ This struct provides following functionalities:
 
 ## iotjs_jobjectwrap_t
 
-You can refer Javascript object from C code side using `iotjs_jval_t` as saw above.
-When a reference for a Javascript object was made using `iotjs_jval_t`, it will increase the reference count and will decrease the count when it goes out of scope.
+You can refer Javascript object from C code side using `jerry_value_t` as saw above.
+When a reference for a Javascript object was made using `jerry_value_t`, it will increase the reference count and will decrease the count when it goes out of scope.
 
 ```c
 {
   // Create JavaScript object
   // It increases reference count in JerryScript side.
-  iotjs_jval_t jobject = iotjs_jval_create();
+  jerry_value_t jobject = iotjs_jval_create();
 
   // Use `jobject`
   ...
@@ -78,7 +78,7 @@ But the situation is different if you want to refer a Javascript object through 
 You may write code like this:
 
 ```c
-  iotjs_jval_t* jobject = (iotjs_jval_t*)malloc(sizeof(iotjs_jval_t)); // Not allowed
+  jerry_value_t* jobject = (jerry_value_t*)malloc(sizeof(jerry_value_t)); // Not allowed
 ```
 
 Unfortunately, we strongly do not recommend that kind of pattern. We treat pointer-types variables in special way. (See [Validated Struct](Inside-IoT.js-Validated-Struct.md) for more details.)
@@ -90,7 +90,7 @@ The `iotjs_jobjectwrap_t` instance will be released at the time the correspondin
 
 Do not hold pointer to the wrapper in native code side globally because even if you are holding a wrapper by pointer, Javascript engine probably releases the corresponding Javascript object resulting deallocation of wrapper. Consequentially your pointer will turned into dangling.
 
-The only safe way to get wrapper is to get it from Javascript object. When a wrapper is being created, it links itself with corresponding Javascript object with `iotjs_jval_set_object_native_handle()` method of `iotjs_jval_t`. And you can get the wrapper from the object with `iotjs_jval_get_object_native_handle()` method of `iotjs_jval_t` later when you need it.
+The only safe way to get wrapper is to get it from Javascript object. When a wrapper is being created, it links itself with corresponding Javascript object with `iotjs_jval_set_object_native_handle()` method of `jerry_value_t`. And you can get the wrapper from the object with `iotjs_jval_get_object_native_handle()` method of `jerry_value_t` later when you need it.
 
 
 ## Native handler
@@ -251,7 +251,7 @@ And calling the javascript callback function with the result.
 
 ```c
   iotjs_fsreqwrap_t* req_wrap = (iotjs_fsreqwrap_t*)(req->data); // get request wrapper
-  const iotjs_jval_t* cb = iotjs_fsreqwrap_jcallback(req_wrap); // javascript callback function
+  const jerry_value_t* cb = iotjs_fsreqwrap_jcallback(req_wrap); // javascript callback function
 
   iotjs_jargs_t jarg = iotjs_jargs_create(2);
   iotjs_jargs_append_null(&jarg); // in case of success.

--- a/docs/devs/Writing-New-Module.md
+++ b/docs/devs/Writing-New-Module.md
@@ -109,7 +109,7 @@ my-module/my_module.c:
 ```javascript
 #include "iotjs_def.h"
 
-iotjs_jval_t InitMyNativeModule() {
+jerry_value_t InitMyNativeModule() {
   jerry_value_t mymodule = jerry_create_object();
   iotjs_jval_set_property_string_raw(mymodule, "message", "Hello world!");
   return mymodule;
@@ -211,7 +211,7 @@ JS_FUNCTION(Stdout) {
 
 Using `JS_GET_ARG(index, type)` macro inside `JS_FUNCTION()` will read JS-side argument. Since JavaScript values can have dynamic types, you must check if argument has valid type with `DJS_CHECK_ARGS(number_of_arguments, type1, type2, type3, ...)` macro, which throws JavaScript TypeError when given condition is not satisfied.
 
-`JS_FUNCTION()` must return with an `iotjs_jval_t` into JS-side.
+`JS_FUNCTION()` must return with an `jerry_value_t` into JS-side.
 
 #### Wrapping native object with JS object
 
@@ -225,7 +225,7 @@ There's `iotjs_jobjectwrap_t` struct for that purpose. if you create a new `iotj
 // This wrapper refer javascript object but never increase reference count
 // If the object is freed by GC, then this wrapper instance will be also freed.
 typedef struct {
-  iotjs_jval_t jobject;
+  jerry_value_t jobject;
 } iotjs_jobjectwrap_t;
 
 typedef struct {
@@ -237,7 +237,7 @@ typedef struct {
 static void iotjs_bufferwrap_destroy(iotjs_bufferwrap_t* bufferwrap);
 IOTJS_DEFINE_NATIVE_HANDLE_INFO(bufferwrap);
 
-iotjs_bufferwrap_t* iotjs_bufferwrap_create(const iotjs_jval_t* jbuiltin,
+iotjs_bufferwrap_t* iotjs_bufferwrap_create(const jerry_value_t* jbuiltin,
                                             size_t length) {
   iotjs_bufferwrap_t* bufferwrap = IOTJS_ALLOC(iotjs_bufferwrap_t);
   iotjs_jobjectwrap_initialize(&_this->jobjectwrap,
@@ -256,7 +256,7 @@ void iotjs_bufferwrap_destroy(iotjs_bufferwrap_t* bufferwrap) {
 You can use this code like below:
 
 ```c
-const iotjs_jval_t* jbuiltin = /*...*/;
+const jerry_value_t* jbuiltin = /*...*/;
 iotjs_bufferwrap_t* buffer_wrap = iotjs_bufferwrap_create(jbuiltin, length);
 // Now `jbuiltin` object can be used in JS-side,
 // and when it becomes unreachable, `iotjs_bufferwrap_destroy` will be called.

--- a/src/iotjs.c
+++ b/src/iotjs.c
@@ -97,10 +97,10 @@ static bool iotjs_run(iotjs_environment_t* env) {
   // Evaluating 'iotjs.js' returns a function.
   bool throws = false;
 #ifndef ENABLE_SNAPSHOT
-  iotjs_jval_t jmain = iotjs_jhelper_eval("iotjs.js", strlen("iotjs.js"),
-                                          iotjs_s, iotjs_l, false, &throws);
+  jerry_value_t jmain = iotjs_jhelper_eval("iotjs.js", strlen("iotjs.js"),
+                                           iotjs_s, iotjs_l, false, &throws);
 #else
-  iotjs_jval_t jmain =
+  jerry_value_t jmain =
       jerry_exec_snapshot_at((const void*)iotjs_js_modules_s,
                              iotjs_js_modules_l, module_iotjs_idx, false);
   if (jerry_value_has_error_flag(jmain)) {
@@ -121,11 +121,11 @@ static bool iotjs_run(iotjs_environment_t* env) {
 
 static int iotjs_start(iotjs_environment_t* env) {
   // Bind environment to global object.
-  const iotjs_jval_t global = jerry_get_global_object();
+  const jerry_value_t global = jerry_get_global_object();
   jerry_set_object_native_pointer(global, env, NULL);
 
   // Initialize builtin process module.
-  const iotjs_jval_t process = iotjs_module_get("process");
+  const jerry_value_t process = iotjs_module_get("process");
   iotjs_jval_set_property_jval(global, "process", process);
 
   // Release the global object

--- a/src/iotjs_binding.c
+++ b/src/iotjs_binding.c
@@ -28,8 +28,8 @@ static iotjs_jargs_t jargs_empty = {.unsafe = { 0, 0, NULL },
 };
 
 
-iotjs_jval_t iotjs_jval_create_string(const iotjs_string_t* v) {
-  iotjs_jval_t jval;
+jerry_value_t iotjs_jval_create_string(const iotjs_string_t* v) {
+  jerry_value_t jval;
 
   const jerry_char_t* data = (const jerry_char_t*)(iotjs_string_data(v));
   jerry_size_t size = iotjs_string_size(v);
@@ -44,11 +44,11 @@ iotjs_jval_t iotjs_jval_create_string(const iotjs_string_t* v) {
 }
 
 
-iotjs_jval_t iotjs_jval_get_string_size(const iotjs_string_t* str) {
-  iotjs_jval_t str_val = iotjs_jval_create_string(str);
+jerry_value_t iotjs_jval_get_string_size(const iotjs_string_t* str) {
+  jerry_value_t str_val = iotjs_jval_create_string(str);
 
   jerry_size_t size = jerry_get_string_size(str_val);
-  iotjs_jval_t jval = jerry_create_number(size);
+  jerry_value_t jval = jerry_create_number(size);
 
   jerry_release_value(str_val);
 
@@ -56,10 +56,10 @@ iotjs_jval_t iotjs_jval_get_string_size(const iotjs_string_t* str) {
 }
 
 
-iotjs_jval_t iotjs_jval_create_byte_array(uint32_t len, const char* data) {
+jerry_value_t iotjs_jval_create_byte_array(uint32_t len, const char* data) {
   IOTJS_ASSERT(data != NULL);
 
-  iotjs_jval_t jval = jerry_create_array(len);
+  jerry_value_t jval = jerry_create_array(len);
 
   for (uint32_t i = 0; i < len; i++) {
     jerry_value_t val = jerry_create_number((double)data[i]);
@@ -77,8 +77,8 @@ jerry_value_t iotjs_jval_dummy_function(const jerry_value_t function_obj,
   return this_val;
 }
 
-iotjs_jval_t iotjs_jval_create_function(JHandlerType handler) {
-  iotjs_jval_t jval = jerry_create_external_function(handler);
+jerry_value_t iotjs_jval_create_function(jerry_external_handler_t handler) {
+  jerry_value_t jval = jerry_create_external_function(handler);
 
   IOTJS_ASSERT(jerry_value_is_constructor(jval));
 
@@ -86,13 +86,14 @@ iotjs_jval_t iotjs_jval_create_function(JHandlerType handler) {
 }
 
 
-iotjs_jval_t iotjs_jval_create_error(const char* msg) {
+jerry_value_t iotjs_jval_create_error(const char* msg) {
   return iotjs_jval_create_error_type(JERRY_ERROR_COMMON, msg);
 }
 
 
-iotjs_jval_t iotjs_jval_create_error_type(jerry_error_t type, const char* msg) {
-  iotjs_jval_t jval;
+jerry_value_t iotjs_jval_create_error_type(jerry_error_t type,
+                                           const char* msg) {
+  jerry_value_t jval;
 
   const jerry_char_t* jmsg = (const jerry_char_t*)(msg);
   jval = jerry_create_error(type, jmsg);
@@ -102,19 +103,19 @@ iotjs_jval_t iotjs_jval_create_error_type(jerry_error_t type, const char* msg) {
 }
 
 
-bool iotjs_jval_as_boolean(iotjs_jval_t jval) {
+bool iotjs_jval_as_boolean(jerry_value_t jval) {
   IOTJS_ASSERT(jerry_value_is_boolean(jval));
   return jerry_get_boolean_value(jval);
 }
 
 
-double iotjs_jval_as_number(iotjs_jval_t jval) {
+double iotjs_jval_as_number(jerry_value_t jval) {
   IOTJS_ASSERT(jerry_value_is_number(jval));
   return jerry_get_number_value(jval);
 }
 
 
-iotjs_string_t iotjs_jval_as_string(iotjs_jval_t jval) {
+iotjs_string_t iotjs_jval_as_string(jerry_value_t jval) {
   IOTJS_ASSERT(jerry_value_is_string(jval));
 
   jerry_size_t size = jerry_get_string_size(jval);
@@ -136,25 +137,25 @@ iotjs_string_t iotjs_jval_as_string(iotjs_jval_t jval) {
 }
 
 
-iotjs_jval_t iotjs_jval_as_object(iotjs_jval_t jval) {
+jerry_value_t iotjs_jval_as_object(jerry_value_t jval) {
   IOTJS_ASSERT(jerry_value_is_object(jval));
   return jval;
 }
 
 
-iotjs_jval_t iotjs_jval_as_array(iotjs_jval_t jval) {
+jerry_value_t iotjs_jval_as_array(jerry_value_t jval) {
   IOTJS_ASSERT(jerry_value_is_array(jval));
   return jval;
 }
 
 
-iotjs_jval_t iotjs_jval_as_function(iotjs_jval_t jval) {
+jerry_value_t iotjs_jval_as_function(jerry_value_t jval) {
   IOTJS_ASSERT(jerry_value_is_function(jval));
   return jval;
 }
 
 
-bool iotjs_jval_set_prototype(const iotjs_jval_t jobj, iotjs_jval_t jproto) {
+bool iotjs_jval_set_prototype(const jerry_value_t jobj, jerry_value_t jproto) {
   jerry_value_t ret = jerry_set_prototype(jobj, jproto);
   bool error_found = jerry_value_has_error_flag(ret);
   jerry_release_value(ret);
@@ -163,18 +164,18 @@ bool iotjs_jval_set_prototype(const iotjs_jval_t jobj, iotjs_jval_t jproto) {
 }
 
 
-void iotjs_jval_set_method(iotjs_jval_t jobj, const char* name,
+void iotjs_jval_set_method(jerry_value_t jobj, const char* name,
                            jerry_external_handler_t handler) {
   IOTJS_ASSERT(jerry_value_is_object(jobj));
 
-  iotjs_jval_t jfunc = jerry_create_external_function(handler);
+  jerry_value_t jfunc = jerry_create_external_function(handler);
   iotjs_jval_set_property_jval(jobj, name, jfunc);
   jerry_release_value(jfunc);
 }
 
 
-void iotjs_jval_set_property_jval(iotjs_jval_t jobj, const char* name,
-                                  iotjs_jval_t value) {
+void iotjs_jval_set_property_jval(jerry_value_t jobj, const char* name,
+                                  jerry_value_t value) {
   IOTJS_ASSERT(jerry_value_is_object(jobj));
 
   jerry_value_t prop_name = jerry_create_string((const jerry_char_t*)(name));
@@ -186,47 +187,47 @@ void iotjs_jval_set_property_jval(iotjs_jval_t jobj, const char* name,
 }
 
 
-void iotjs_jval_set_property_null(iotjs_jval_t jobj, const char* name) {
+void iotjs_jval_set_property_null(jerry_value_t jobj, const char* name) {
   iotjs_jval_set_property_jval(jobj, name, jerry_create_null());
 }
 
 
-void iotjs_jval_set_property_undefined(iotjs_jval_t jobj, const char* name) {
+void iotjs_jval_set_property_undefined(jerry_value_t jobj, const char* name) {
   iotjs_jval_set_property_jval(jobj, name, jerry_create_undefined());
 }
 
 
-void iotjs_jval_set_property_boolean(iotjs_jval_t jobj, const char* name,
+void iotjs_jval_set_property_boolean(jerry_value_t jobj, const char* name,
                                      bool v) {
   iotjs_jval_set_property_jval(jobj, name, jerry_create_boolean(v));
 }
 
 
-void iotjs_jval_set_property_number(iotjs_jval_t jobj, const char* name,
+void iotjs_jval_set_property_number(jerry_value_t jobj, const char* name,
                                     double v) {
-  iotjs_jval_t jval = jerry_create_number(v);
+  jerry_value_t jval = jerry_create_number(v);
   iotjs_jval_set_property_jval(jobj, name, jval);
   jerry_release_value(jval);
 }
 
 
-void iotjs_jval_set_property_string(iotjs_jval_t jobj, const char* name,
+void iotjs_jval_set_property_string(jerry_value_t jobj, const char* name,
                                     const iotjs_string_t* v) {
-  iotjs_jval_t jval = iotjs_jval_create_string(v);
+  jerry_value_t jval = iotjs_jval_create_string(v);
   iotjs_jval_set_property_jval(jobj, name, jval);
   jerry_release_value(jval);
 }
 
 
-void iotjs_jval_set_property_string_raw(iotjs_jval_t jobj, const char* name,
+void iotjs_jval_set_property_string_raw(jerry_value_t jobj, const char* name,
                                         const char* v) {
-  iotjs_jval_t jval = jerry_create_string((const jerry_char_t*)v);
+  jerry_value_t jval = jerry_create_string((const jerry_char_t*)v);
   iotjs_jval_set_property_jval(jobj, name, jval);
   jerry_release_value(jval);
 }
 
 
-iotjs_jval_t iotjs_jval_get_property(iotjs_jval_t jobj, const char* name) {
+jerry_value_t iotjs_jval_get_property(jerry_value_t jobj, const char* name) {
   IOTJS_ASSERT(jerry_value_is_object(jobj));
 
   jerry_value_t prop_name = jerry_create_string((const jerry_char_t*)(name));
@@ -242,7 +243,7 @@ iotjs_jval_t iotjs_jval_get_property(iotjs_jval_t jobj, const char* name) {
 }
 
 
-uintptr_t iotjs_jval_get_object_native_handle(iotjs_jval_t jobj) {
+uintptr_t iotjs_jval_get_object_native_handle(jerry_value_t jobj) {
   IOTJS_ASSERT(jerry_value_is_object(jobj));
 
   uintptr_t ptr = 0x0;
@@ -253,8 +254,8 @@ uintptr_t iotjs_jval_get_object_native_handle(iotjs_jval_t jobj) {
 }
 
 
-void iotjs_jval_set_property_by_index(iotjs_jval_t jarr, uint32_t idx,
-                                      iotjs_jval_t jval) {
+void iotjs_jval_set_property_by_index(jerry_value_t jarr, uint32_t idx,
+                                      jerry_value_t jval) {
   IOTJS_ASSERT(jerry_value_is_object(jarr));
 
   jerry_value_t ret_val = jerry_set_property_by_index(jarr, idx, jval);
@@ -263,7 +264,8 @@ void iotjs_jval_set_property_by_index(iotjs_jval_t jarr, uint32_t idx,
 }
 
 
-iotjs_jval_t iotjs_jval_get_property_by_index(iotjs_jval_t jarr, uint32_t idx) {
+jerry_value_t iotjs_jval_get_property_by_index(jerry_value_t jarr,
+                                               uint32_t idx) {
   IOTJS_ASSERT(jerry_value_is_object(jarr));
 
   jerry_value_t res = jerry_get_property_by_index(jarr, idx);
@@ -278,8 +280,8 @@ iotjs_jval_t iotjs_jval_get_property_by_index(iotjs_jval_t jarr, uint32_t idx) {
 
 
 #ifndef NDEBUG
-static iotjs_jval_t iotjs_jargs_get(const iotjs_jargs_t* jargs,
-                                    uint16_t index) {
+static jerry_value_t iotjs_jargs_get(const iotjs_jargs_t* jargs,
+                                     uint16_t index) {
   const IOTJS_VALIDATED_STRUCT_METHOD(iotjs_jargs_t, jargs);
 
   IOTJS_ASSERT(index < _this->argc);
@@ -288,8 +290,8 @@ static iotjs_jval_t iotjs_jargs_get(const iotjs_jargs_t* jargs,
 #endif
 
 
-iotjs_jval_t iotjs_jhelper_call(iotjs_jval_t jfunc, iotjs_jval_t jthis,
-                                const iotjs_jargs_t* jargs, bool* throws) {
+jerry_value_t iotjs_jhelper_call(jerry_value_t jfunc, jerry_value_t jthis,
+                                 const iotjs_jargs_t* jargs, bool* throws) {
   IOTJS_ASSERT(jerry_value_is_object(jfunc));
 
   jerry_value_t* jargv_ = NULL;
@@ -323,18 +325,18 @@ iotjs_jval_t iotjs_jhelper_call(iotjs_jval_t jfunc, iotjs_jval_t jthis,
 }
 
 
-iotjs_jval_t iotjs_jhelper_call_ok(iotjs_jval_t jfunc, iotjs_jval_t jthis,
-                                   const iotjs_jargs_t* jargs) {
+jerry_value_t iotjs_jhelper_call_ok(jerry_value_t jfunc, jerry_value_t jthis,
+                                    const iotjs_jargs_t* jargs) {
   bool throws;
-  iotjs_jval_t jres = iotjs_jhelper_call(jfunc, jthis, jargs, &throws);
+  jerry_value_t jres = iotjs_jhelper_call(jfunc, jthis, jargs, &throws);
   IOTJS_ASSERT(!throws);
   return jres;
 }
 
 
-iotjs_jval_t iotjs_jhelper_eval(const char* name, size_t name_len,
-                                const uint8_t* data, size_t size,
-                                bool strict_mode, bool* throws) {
+jerry_value_t iotjs_jhelper_eval(const char* name, size_t name_len,
+                                 const uint8_t* data, size_t size,
+                                 bool strict_mode, bool* throws) {
   jerry_value_t res =
       jerry_parse_named_resource((const jerry_char_t*)name, name_len,
                                  (const jerry_char_t*)data, size, strict_mode);
@@ -376,8 +378,8 @@ iotjs_jargs_t iotjs_jargs_create(uint16_t capacity) {
 
   _this->capacity = capacity;
   _this->argc = 0;
-  unsigned buffer_size = sizeof(iotjs_jval_t) * capacity;
-  _this->argv = (iotjs_jval_t*)iotjs_buffer_allocate(buffer_size);
+  unsigned buffer_size = sizeof(jerry_value_t) * capacity;
+  _this->argv = (jerry_value_t*)iotjs_buffer_allocate(buffer_size);
 
   return jargs;
 }
@@ -411,7 +413,7 @@ uint16_t iotjs_jargs_length(const iotjs_jargs_t* jargs) {
 }
 
 
-void iotjs_jargs_append_jval(iotjs_jargs_t* jargs, iotjs_jval_t x) {
+void iotjs_jargs_append_jval(iotjs_jargs_t* jargs, jerry_value_t x) {
   IOTJS_VALIDATED_STRUCT_METHOD(iotjs_jargs_t, jargs);
   IOTJS_ASSERT(_this->argc < _this->capacity);
   _this->argv[_this->argc++] = jerry_acquire_value(x);
@@ -438,7 +440,7 @@ void iotjs_jargs_append_bool(iotjs_jargs_t* jargs, bool x) {
 
 void iotjs_jargs_append_number(iotjs_jargs_t* jargs, double x) {
   IOTJS_VALIDATABLE_STRUCT_METHOD_VALIDATE(iotjs_jargs_t, jargs);
-  iotjs_jval_t jval = jerry_create_number(x);
+  jerry_value_t jval = jerry_create_number(x);
   iotjs_jargs_append_jval(jargs, jval);
   jerry_release_value(jval);
 }
@@ -446,7 +448,7 @@ void iotjs_jargs_append_number(iotjs_jargs_t* jargs, double x) {
 
 void iotjs_jargs_append_string(iotjs_jargs_t* jargs, const iotjs_string_t* x) {
   IOTJS_VALIDATABLE_STRUCT_METHOD_VALIDATE(iotjs_jargs_t, jargs);
-  iotjs_jval_t jval = iotjs_jval_create_string(x);
+  jerry_value_t jval = iotjs_jval_create_string(x);
   iotjs_jargs_append_jval(jargs, jval);
   jerry_release_value(jval);
 }
@@ -454,7 +456,7 @@ void iotjs_jargs_append_string(iotjs_jargs_t* jargs, const iotjs_string_t* x) {
 
 void iotjs_jargs_append_error(iotjs_jargs_t* jargs, const char* msg) {
   IOTJS_VALIDATABLE_STRUCT_METHOD_VALIDATE(iotjs_jargs_t, jargs);
-  iotjs_jval_t error = iotjs_jval_create_error(msg);
+  jerry_value_t error = iotjs_jval_create_error(msg);
   iotjs_jargs_append_jval(jargs, error);
   jerry_release_value(error);
 }
@@ -462,13 +464,14 @@ void iotjs_jargs_append_error(iotjs_jargs_t* jargs, const char* msg) {
 
 void iotjs_jargs_append_string_raw(iotjs_jargs_t* jargs, const char* x) {
   IOTJS_VALIDATABLE_STRUCT_METHOD_VALIDATE(iotjs_jargs_t, jargs);
-  iotjs_jval_t jval = jerry_create_string((const jerry_char_t*)x);
+  jerry_value_t jval = jerry_create_string((const jerry_char_t*)x);
   iotjs_jargs_append_jval(jargs, jval);
   jerry_release_value(jval);
 }
 
 
-void iotjs_jargs_replace(iotjs_jargs_t* jargs, uint16_t index, iotjs_jval_t x) {
+void iotjs_jargs_replace(iotjs_jargs_t* jargs, uint16_t index,
+                         jerry_value_t x) {
   IOTJS_VALIDATED_STRUCT_METHOD(iotjs_jargs_t, jargs);
 
   IOTJS_ASSERT(index < _this->argc);

--- a/src/iotjs_binding.h
+++ b/src/iotjs_binding.h
@@ -22,63 +22,61 @@
 #include <stdio.h>
 
 
-typedef jerry_external_handler_t JHandlerType;
 typedef const jerry_object_native_info_t JNativeInfoType;
-typedef jerry_length_t JRawLengthType;
-typedef jerry_value_t iotjs_jval_t;
 
 /* Constructors */
-iotjs_jval_t iotjs_jval_create_string(const iotjs_string_t* v);
-iotjs_jval_t iotjs_jval_create_byte_array(uint32_t len, const char* data);
+jerry_value_t iotjs_jval_create_string(const iotjs_string_t* v);
+jerry_value_t iotjs_jval_create_byte_array(uint32_t len, const char* data);
 jerry_value_t iotjs_jval_dummy_function(const jerry_value_t function_obj,
                                         const jerry_value_t this_val,
                                         const jerry_value_t args_p[],
                                         const jerry_length_t args_count);
-iotjs_jval_t iotjs_jval_create_function(JHandlerType handler);
-iotjs_jval_t iotjs_jval_create_error(const char* msg);
-iotjs_jval_t iotjs_jval_create_error_type(jerry_error_t type, const char* msg);
+jerry_value_t iotjs_jval_create_function(jerry_external_handler_t handler);
+jerry_value_t iotjs_jval_create_error(const char* msg);
+jerry_value_t iotjs_jval_create_error_type(jerry_error_t type, const char* msg);
 
-iotjs_jval_t iotjs_jval_get_string_size(const iotjs_string_t* str);
+jerry_value_t iotjs_jval_get_string_size(const iotjs_string_t* str);
 
 
 /* Type Converters */
-bool iotjs_jval_as_boolean(iotjs_jval_t);
-double iotjs_jval_as_number(iotjs_jval_t);
-iotjs_string_t iotjs_jval_as_string(iotjs_jval_t);
-iotjs_jval_t iotjs_jval_as_object(iotjs_jval_t);
-iotjs_jval_t iotjs_jval_as_array(iotjs_jval_t);
-iotjs_jval_t iotjs_jval_as_function(iotjs_jval_t);
+bool iotjs_jval_as_boolean(jerry_value_t);
+double iotjs_jval_as_number(jerry_value_t);
+iotjs_string_t iotjs_jval_as_string(jerry_value_t);
+jerry_value_t iotjs_jval_as_object(jerry_value_t);
+jerry_value_t iotjs_jval_as_array(jerry_value_t);
+jerry_value_t iotjs_jval_as_function(jerry_value_t);
 
 /* Methods for General JavaScript Object */
-void iotjs_jval_set_method(iotjs_jval_t jobj, const char* name,
+void iotjs_jval_set_method(jerry_value_t jobj, const char* name,
                            jerry_external_handler_t handler);
-bool iotjs_jval_set_prototype(iotjs_jval_t jobj, iotjs_jval_t jproto);
-void iotjs_jval_set_property_jval(iotjs_jval_t jobj, const char* name,
-                                  iotjs_jval_t value);
-void iotjs_jval_set_property_null(iotjs_jval_t jobj, const char* name);
-void iotjs_jval_set_property_undefined(iotjs_jval_t jobj, const char* name);
-void iotjs_jval_set_property_boolean(iotjs_jval_t jobj, const char* name,
+bool iotjs_jval_set_prototype(jerry_value_t jobj, jerry_value_t jproto);
+void iotjs_jval_set_property_jval(jerry_value_t jobj, const char* name,
+                                  jerry_value_t value);
+void iotjs_jval_set_property_null(jerry_value_t jobj, const char* name);
+void iotjs_jval_set_property_undefined(jerry_value_t jobj, const char* name);
+void iotjs_jval_set_property_boolean(jerry_value_t jobj, const char* name,
                                      bool v);
-void iotjs_jval_set_property_number(iotjs_jval_t jobj, const char* name,
+void iotjs_jval_set_property_number(jerry_value_t jobj, const char* name,
                                     double v);
-void iotjs_jval_set_property_string(iotjs_jval_t jobj, const char* name,
+void iotjs_jval_set_property_string(jerry_value_t jobj, const char* name,
                                     const iotjs_string_t* v);
-void iotjs_jval_set_property_string_raw(iotjs_jval_t jobj, const char* name,
+void iotjs_jval_set_property_string_raw(jerry_value_t jobj, const char* name,
                                         const char* v);
 
-iotjs_jval_t iotjs_jval_get_property(iotjs_jval_t jobj, const char* name);
+jerry_value_t iotjs_jval_get_property(jerry_value_t jobj, const char* name);
 
-uintptr_t iotjs_jval_get_object_native_handle(iotjs_jval_t jobj);
+uintptr_t iotjs_jval_get_object_native_handle(jerry_value_t jobj);
 
-void iotjs_jval_set_property_by_index(iotjs_jval_t jarr, uint32_t idx,
-                                      iotjs_jval_t jval);
-iotjs_jval_t iotjs_jval_get_property_by_index(iotjs_jval_t jarr, uint32_t idx);
+void iotjs_jval_set_property_by_index(jerry_value_t jarr, uint32_t idx,
+                                      jerry_value_t jval);
+jerry_value_t iotjs_jval_get_property_by_index(jerry_value_t jarr,
+                                               uint32_t idx);
 
 
 typedef struct {
   uint16_t capacity;
   uint16_t argc;
-  iotjs_jval_t* argv;
+  jerry_value_t* argv;
 } IOTJS_VALIDATED_STRUCT(iotjs_jargs_t);
 
 
@@ -90,7 +88,7 @@ void iotjs_jargs_destroy(iotjs_jargs_t* jargs);
 
 uint16_t iotjs_jargs_length(const iotjs_jargs_t* jargs);
 
-void iotjs_jargs_append_jval(iotjs_jargs_t* jargs, iotjs_jval_t x);
+void iotjs_jargs_append_jval(iotjs_jargs_t* jargs, jerry_value_t x);
 void iotjs_jargs_append_undefined(iotjs_jargs_t* jargs);
 void iotjs_jargs_append_null(iotjs_jargs_t* jargs);
 void iotjs_jargs_append_bool(iotjs_jargs_t* jargs, bool x);
@@ -100,20 +98,20 @@ void iotjs_jargs_append_string_raw(iotjs_jargs_t* jargs, const char* x);
 void iotjs_jargs_append_error(iotjs_jargs_t* jargs, const char* msg);
 
 
-void iotjs_jargs_replace(iotjs_jargs_t* jargs, uint16_t index, iotjs_jval_t x);
+void iotjs_jargs_replace(iotjs_jargs_t* jargs, uint16_t index, jerry_value_t x);
 
 // Calls JavaScript function.
-iotjs_jval_t iotjs_jhelper_call(iotjs_jval_t jfunc, iotjs_jval_t jthis,
-                                const iotjs_jargs_t* jargs, bool* throws);
+jerry_value_t iotjs_jhelper_call(jerry_value_t jfunc, jerry_value_t jthis,
+                                 const iotjs_jargs_t* jargs, bool* throws);
 
 // Calls javascript function.
-iotjs_jval_t iotjs_jhelper_call_ok(iotjs_jval_t jfunc, iotjs_jval_t jthis,
-                                   const iotjs_jargs_t* jargs);
+jerry_value_t iotjs_jhelper_call_ok(jerry_value_t jfunc, jerry_value_t jthis,
+                                    const iotjs_jargs_t* jargs);
 
 // Evaluates javascript source file.
-iotjs_jval_t iotjs_jhelper_eval(const char* name, size_t name_len,
-                                const uint8_t* data, size_t size,
-                                bool strict_mode, bool* throws);
+jerry_value_t iotjs_jhelper_eval(const char* name, size_t name_len,
+                                 const uint8_t* data, size_t size,
+                                 bool strict_mode, bool* throws);
 
 #define JS_CREATE_ERROR(TYPE, message) \
   jerry_create_error(JERRY_ERROR_##TYPE, (const jerry_char_t*)message);
@@ -212,7 +210,7 @@ iotjs_jval_t iotjs_jhelper_eval(const char* name, size_t name_len,
 
 #define DJS_GET_REQUIRED_CONF_VALUE(src, target, property, type)            \
   do {                                                                      \
-    iotjs_jval_t jtmp = iotjs_jval_get_property(src, property);             \
+    jerry_value_t jtmp = iotjs_jval_get_property(src, property);            \
     if (jerry_value_is_undefined(jtmp)) {                                   \
       return JS_CREATE_ERROR(TYPE, "Missing argument, required " property); \
     } else if (jerry_value_is_##type(jtmp)) {                               \

--- a/src/iotjs_binding_helper.c
+++ b/src/iotjs_binding_helper.c
@@ -20,10 +20,10 @@
 #include <string.h>
 
 
-void iotjs_uncaught_exception(iotjs_jval_t jexception) {
-  const iotjs_jval_t process = iotjs_module_get("process");
+void iotjs_uncaught_exception(jerry_value_t jexception) {
+  const jerry_value_t process = iotjs_module_get("process");
 
-  iotjs_jval_t jonuncaughtexception =
+  jerry_value_t jonuncaughtexception =
       iotjs_jval_get_property(process, IOTJS_MAGIC_STRING__ONUNCAUGHTEXCEPTION);
   IOTJS_ASSERT(jerry_value_is_function(jonuncaughtexception));
 
@@ -31,7 +31,7 @@ void iotjs_uncaught_exception(iotjs_jval_t jexception) {
   iotjs_jargs_append_jval(&args, jexception);
 
   bool throws;
-  iotjs_jval_t jres =
+  jerry_value_t jres =
       iotjs_jhelper_call(jonuncaughtexception, process, &args, &throws);
 
   iotjs_jargs_destroy(&args);
@@ -50,9 +50,9 @@ void iotjs_uncaught_exception(iotjs_jval_t jexception) {
 
 
 void iotjs_process_emit_exit(int code) {
-  const iotjs_jval_t process = iotjs_module_get("process");
+  const jerry_value_t process = iotjs_module_get("process");
 
-  iotjs_jval_t jexit =
+  jerry_value_t jexit =
       iotjs_jval_get_property(process, IOTJS_MAGIC_STRING_EMITEXIT);
   IOTJS_ASSERT(jerry_value_is_function(jexit));
 
@@ -60,7 +60,7 @@ void iotjs_process_emit_exit(int code) {
   iotjs_jargs_append_number(&jargs, code);
 
   bool throws;
-  iotjs_jval_t jres = iotjs_jhelper_call(jexit, process, &jargs, &throws);
+  jerry_value_t jres = iotjs_jhelper_call(jexit, process, &jargs, &throws);
 
   iotjs_jargs_destroy(&jargs);
   jerry_release_value(jres);
@@ -80,13 +80,13 @@ bool iotjs_process_next_tick() {
     return false;
   }
 
-  const iotjs_jval_t process = iotjs_module_get("process");
+  const jerry_value_t process = iotjs_module_get("process");
 
-  iotjs_jval_t jon_next_tick =
+  jerry_value_t jon_next_tick =
       iotjs_jval_get_property(process, IOTJS_MAGIC_STRING__ONNEXTTICK);
   IOTJS_ASSERT(jerry_value_is_function(jon_next_tick));
 
-  iotjs_jval_t jres =
+  jerry_value_t jres =
       iotjs_jhelper_call_ok(jon_next_tick, jerry_create_undefined(),
                             iotjs_jargs_get_empty());
 
@@ -103,20 +103,20 @@ bool iotjs_process_next_tick() {
 // Make a callback for the given `function` with `this_` binding and `args`
 // arguments. The next tick callbacks registered via `process.nextTick()`
 // will be called after the callback function `function` returns.
-void iotjs_make_callback(iotjs_jval_t jfunction, iotjs_jval_t jthis,
+void iotjs_make_callback(jerry_value_t jfunction, jerry_value_t jthis,
                          const iotjs_jargs_t* jargs) {
-  iotjs_jval_t result =
+  jerry_value_t result =
       iotjs_make_callback_with_result(jfunction, jthis, jargs);
   jerry_release_value(result);
 }
 
 
-iotjs_jval_t iotjs_make_callback_with_result(iotjs_jval_t jfunction,
-                                             iotjs_jval_t jthis,
-                                             const iotjs_jargs_t* jargs) {
+jerry_value_t iotjs_make_callback_with_result(jerry_value_t jfunction,
+                                              jerry_value_t jthis,
+                                              const iotjs_jargs_t* jargs) {
   // Calls back the function.
   bool throws;
-  iotjs_jval_t jres = iotjs_jhelper_call(jfunction, jthis, jargs, &throws);
+  jerry_value_t jres = iotjs_jhelper_call(jfunction, jthis, jargs, &throws);
   if (throws) {
     iotjs_uncaught_exception(jres);
   }
@@ -130,9 +130,9 @@ iotjs_jval_t iotjs_make_callback_with_result(iotjs_jval_t jfunction,
 
 
 int iotjs_process_exitcode() {
-  const iotjs_jval_t process = iotjs_module_get("process");
+  const jerry_value_t process = iotjs_module_get("process");
 
-  iotjs_jval_t jexitcode =
+  jerry_value_t jexitcode =
       iotjs_jval_get_property(process, IOTJS_MAGIC_STRING_EXITCODE);
   IOTJS_ASSERT(jerry_value_is_number(jexitcode));
 
@@ -144,6 +144,6 @@ int iotjs_process_exitcode() {
 
 
 void iotjs_set_process_exitcode(int code) {
-  const iotjs_jval_t process = iotjs_module_get("process");
+  const jerry_value_t process = iotjs_module_get("process");
   iotjs_jval_set_property_number(process, IOTJS_MAGIC_STRING_EXITCODE, code);
 }

--- a/src/iotjs_binding_helper.h
+++ b/src/iotjs_binding_helper.h
@@ -20,18 +20,18 @@
 #include "iotjs_binding.h"
 
 
-void iotjs_uncaught_exception(iotjs_jval_t jexception);
+void iotjs_uncaught_exception(jerry_value_t jexception);
 
 void iotjs_process_emit_exit(int code);
 
 bool iotjs_process_next_tick();
 
-void iotjs_make_callback(iotjs_jval_t jfunction, iotjs_jval_t jthis,
+void iotjs_make_callback(jerry_value_t jfunction, jerry_value_t jthis,
                          const iotjs_jargs_t* jargs);
 
-iotjs_jval_t iotjs_make_callback_with_result(iotjs_jval_t jfunction,
-                                             iotjs_jval_t jthis,
-                                             const iotjs_jargs_t* jargs);
+jerry_value_t iotjs_make_callback_with_result(jerry_value_t jfunction,
+                                              jerry_value_t jthis,
+                                              const iotjs_jargs_t* jargs);
 
 int iotjs_process_exitcode();
 void iotjs_set_process_exitcode(int code);

--- a/src/iotjs_exception.c
+++ b/src/iotjs_exception.c
@@ -22,7 +22,7 @@
 #include "uv.h"
 
 
-iotjs_jval_t iotjs_create_uv_exception(int errorno, const char* syscall) {
+jerry_value_t iotjs_create_uv_exception(int errorno, const char* syscall) {
   static char msg[256];
   snprintf(msg, sizeof(msg), "'%s' %s", syscall, uv_strerror(errorno));
   return iotjs_jval_create_error(msg);

--- a/src/iotjs_exception.h
+++ b/src/iotjs_exception.h
@@ -17,7 +17,7 @@
 #define IOTJS_EXCEPTION_H
 
 
-iotjs_jval_t iotjs_create_uv_exception(int errorno, const char* syscall);
+jerry_value_t iotjs_create_uv_exception(int errorno, const char* syscall);
 
 
 #endif /* IOTJS_EXCEPTION_H */

--- a/src/iotjs_handlewrap.c
+++ b/src/iotjs_handlewrap.c
@@ -18,13 +18,13 @@
 
 
 void iotjs_handlewrap_initialize(iotjs_handlewrap_t* handlewrap,
-                                 iotjs_jval_t jobject, uv_handle_t* handle,
+                                 jerry_value_t jobject, uv_handle_t* handle,
                                  JNativeInfoType* native_info) {
   IOTJS_VALIDATED_STRUCT_CONSTRUCTOR(iotjs_handlewrap_t, handlewrap);
 
   // Increase ref count of Javascript object to guarantee it is alive until the
   // handle has closed.
-  iotjs_jval_t jobjectref = jerry_acquire_value(jobject);
+  jerry_value_t jobjectref = jerry_acquire_value(jobject);
   iotjs_jobjectwrap_initialize(&_this->jobjectwrap, jobjectref, native_info);
 
   _this->handle = handle;
@@ -53,7 +53,7 @@ iotjs_handlewrap_t* iotjs_handlewrap_from_handle(uv_handle_t* handle) {
 }
 
 
-iotjs_handlewrap_t* iotjs_handlewrap_from_jobject(iotjs_jval_t jobject) {
+iotjs_handlewrap_t* iotjs_handlewrap_from_jobject(jerry_value_t jobject) {
   iotjs_handlewrap_t* handlewrap =
       (iotjs_handlewrap_t*)(iotjs_jval_get_object_native_handle(jobject));
   iotjs_handlewrap_validate(handlewrap);
@@ -68,7 +68,7 @@ uv_handle_t* iotjs_handlewrap_get_uv_handle(iotjs_handlewrap_t* handlewrap) {
 }
 
 
-iotjs_jval_t iotjs_handlewrap_jobject(iotjs_handlewrap_t* handlewrap) {
+jerry_value_t iotjs_handlewrap_jobject(iotjs_handlewrap_t* handlewrap) {
   IOTJS_VALIDATED_STRUCT_METHOD(iotjs_handlewrap_t, handlewrap);
   iotjs_handlewrap_validate(handlewrap);
   return iotjs_jobjectwrap_jobject(&_this->jobjectwrap);
@@ -89,7 +89,7 @@ static void iotjs_handlewrap_on_close(iotjs_handlewrap_t* handlewrap) {
 
   // Decrease ref count of Javascript object. From now the object can be
   // reclaimed.
-  iotjs_jval_t jval = iotjs_jobjectwrap_jobject(&_this->jobjectwrap);
+  jerry_value_t jval = iotjs_jobjectwrap_jobject(&_this->jobjectwrap);
   jerry_release_value(jval);
 }
 

--- a/src/iotjs_handlewrap.h
+++ b/src/iotjs_handlewrap.h
@@ -51,7 +51,7 @@ typedef struct {
 
 // jobject: Object that connect with the uv handle
 void iotjs_handlewrap_initialize(iotjs_handlewrap_t* handlewrap,
-                                 iotjs_jval_t jobject, uv_handle_t* handle,
+                                 jerry_value_t jobject, uv_handle_t* handle,
                                  JNativeInfoType* native_info);
 
 void iotjs_handlewrap_destroy(iotjs_handlewrap_t* handlewrap);
@@ -60,10 +60,10 @@ void iotjs_handlewrap_close(iotjs_handlewrap_t* handlewrap,
                             OnCloseHandler on_close_cb);
 
 iotjs_handlewrap_t* iotjs_handlewrap_from_handle(uv_handle_t* handle);
-iotjs_handlewrap_t* iotjs_handlewrap_from_jobject(iotjs_jval_t jobject);
+iotjs_handlewrap_t* iotjs_handlewrap_from_jobject(jerry_value_t jobject);
 
 uv_handle_t* iotjs_handlewrap_get_uv_handle(iotjs_handlewrap_t* handlewrap);
-iotjs_jval_t iotjs_handlewrap_jobject(iotjs_handlewrap_t* handlewrap);
+jerry_value_t iotjs_handlewrap_jobject(iotjs_handlewrap_t* handlewrap);
 
 void iotjs_handlewrap_validate(iotjs_handlewrap_t* handlewrap);
 

--- a/src/iotjs_module.c
+++ b/src/iotjs_module.c
@@ -16,7 +16,7 @@
 #include "iotjs_def.h"
 #include "iotjs_module.h"
 
-typedef struct { iotjs_jval_t jmodule; } iotjs_module_objects_t;
+typedef struct { jerry_value_t jmodule; } iotjs_module_objects_t;
 
 #include "iotjs_module_inl.h"
 
@@ -38,7 +38,7 @@ void iotjs_module_list_cleanup() {
   }
 }
 
-iotjs_jval_t iotjs_module_get(const char* name) {
+jerry_value_t iotjs_module_get(const char* name) {
   for (unsigned i = 0; i < iotjs_modules_count; i++) {
     if (!strcmp(name, iotjs_modules[i].name)) {
       if (iotjs_module_objects[i].jmodule == 0) {

--- a/src/iotjs_module.h
+++ b/src/iotjs_module.h
@@ -18,7 +18,7 @@
 
 #include "iotjs_binding.h"
 
-typedef iotjs_jval_t (*register_func)();
+typedef jerry_value_t (*register_func)();
 
 typedef struct {
   const char* name;
@@ -30,6 +30,6 @@ extern const iotjs_module_t iotjs_modules[];
 
 void iotjs_module_list_cleanup();
 
-iotjs_jval_t iotjs_module_get(const char* name);
+jerry_value_t iotjs_module_get(const char* name);
 
 #endif /* IOTJS_MODULE_H */

--- a/src/iotjs_objectwrap.c
+++ b/src/iotjs_objectwrap.c
@@ -18,7 +18,7 @@
 
 
 void iotjs_jobjectwrap_initialize(iotjs_jobjectwrap_t* jobjectwrap,
-                                  iotjs_jval_t jobject,
+                                  jerry_value_t jobject,
                                   JNativeInfoType* native_info) {
   IOTJS_VALIDATED_STRUCT_CONSTRUCTOR(iotjs_jobjectwrap_t, jobjectwrap);
 
@@ -41,9 +41,9 @@ void iotjs_jobjectwrap_destroy(iotjs_jobjectwrap_t* jobjectwrap) {
 }
 
 
-iotjs_jval_t iotjs_jobjectwrap_jobject(iotjs_jobjectwrap_t* jobjectwrap) {
+jerry_value_t iotjs_jobjectwrap_jobject(iotjs_jobjectwrap_t* jobjectwrap) {
   IOTJS_VALIDATED_STRUCT_METHOD(iotjs_jobjectwrap_t, jobjectwrap);
-  iotjs_jval_t jobject = _this->jobject;
+  jerry_value_t jobject = _this->jobject;
   IOTJS_ASSERT((uintptr_t)jobjectwrap ==
                iotjs_jval_get_object_native_handle(jobject));
   IOTJS_ASSERT(jerry_value_is_object(jobject));
@@ -51,7 +51,7 @@ iotjs_jval_t iotjs_jobjectwrap_jobject(iotjs_jobjectwrap_t* jobjectwrap) {
 }
 
 
-iotjs_jobjectwrap_t* iotjs_jobjectwrap_from_jobject(iotjs_jval_t jobject) {
+iotjs_jobjectwrap_t* iotjs_jobjectwrap_from_jobject(jerry_value_t jobject) {
   iotjs_jobjectwrap_t* wrap =
       (iotjs_jobjectwrap_t*)(iotjs_jval_get_object_native_handle(jobject));
   IOTJS_ASSERT(jerry_value_is_object(iotjs_jobjectwrap_jobject(wrap)));

--- a/src/iotjs_objectwrap.h
+++ b/src/iotjs_objectwrap.h
@@ -23,17 +23,17 @@
 // This wrapper refer javascript object but never increase reference count
 // If the object is freed by GC, then this wrapper instance will be also freed.
 typedef struct {
-  iotjs_jval_t jobject;
+  jerry_value_t jobject;
 } IOTJS_VALIDATED_STRUCT(iotjs_jobjectwrap_t);
 
 void iotjs_jobjectwrap_initialize(iotjs_jobjectwrap_t* jobjectwrap,
-                                  iotjs_jval_t jobject,
+                                  jerry_value_t jobject,
                                   JNativeInfoType* native_info);
 
 void iotjs_jobjectwrap_destroy(iotjs_jobjectwrap_t* jobjectwrap);
 
-iotjs_jval_t iotjs_jobjectwrap_jobject(iotjs_jobjectwrap_t* jobjectwrap);
-iotjs_jobjectwrap_t* iotjs_jobjectwrap_from_jobject(iotjs_jval_t jobject);
+jerry_value_t iotjs_jobjectwrap_jobject(iotjs_jobjectwrap_t* jobjectwrap);
+iotjs_jobjectwrap_t* iotjs_jobjectwrap_from_jobject(jerry_value_t jobject);
 
 #define IOTJS_DEFINE_NATIVE_HANDLE_INFO_THIS_MODULE(name)                  \
   static void iotjs_##name##_destroy(iotjs_##name##_t* wrap);              \

--- a/src/iotjs_reqwrap.c
+++ b/src/iotjs_reqwrap.c
@@ -17,7 +17,7 @@
 #include "iotjs_reqwrap.h"
 
 
-void iotjs_reqwrap_initialize(iotjs_reqwrap_t* reqwrap, iotjs_jval_t jcallback,
+void iotjs_reqwrap_initialize(iotjs_reqwrap_t* reqwrap, jerry_value_t jcallback,
                               uv_req_t* request) {
   IOTJS_VALIDATED_STRUCT_CONSTRUCTOR(iotjs_reqwrap_t, reqwrap);
   IOTJS_ASSERT(jerry_value_is_function(jcallback));
@@ -39,7 +39,7 @@ static void iotjs_reqwrap_validate(iotjs_reqwrap_t* reqwrap) {
 }
 
 
-iotjs_jval_t iotjs_reqwrap_jcallback(iotjs_reqwrap_t* reqwrap) {
+jerry_value_t iotjs_reqwrap_jcallback(iotjs_reqwrap_t* reqwrap) {
   IOTJS_VALIDATED_STRUCT_METHOD(iotjs_reqwrap_t, reqwrap);
   iotjs_reqwrap_validate(reqwrap);
   return _this->jcallback;

--- a/src/iotjs_reqwrap.h
+++ b/src/iotjs_reqwrap.h
@@ -28,17 +28,17 @@
 // for JavaScript callback function to prevent it from reclaimed by GC. The
 // reference count will decrease back when wrapper is being freed.
 typedef struct {
-  iotjs_jval_t jcallback;
+  jerry_value_t jcallback;
   uv_req_t* request;
 } IOTJS_VALIDATED_STRUCT(iotjs_reqwrap_t);
 
 
-void iotjs_reqwrap_initialize(iotjs_reqwrap_t* reqwrap, iotjs_jval_t jcallback,
+void iotjs_reqwrap_initialize(iotjs_reqwrap_t* reqwrap, jerry_value_t jcallback,
                               uv_req_t* request);
 void iotjs_reqwrap_destroy(iotjs_reqwrap_t* reqwrap);
 
 // To retrieve javascript callback function object.
-iotjs_jval_t iotjs_reqwrap_jcallback(iotjs_reqwrap_t* reqwrap);
+jerry_value_t iotjs_reqwrap_jcallback(iotjs_reqwrap_t* reqwrap);
 
 // To retrieve pointer to uv request.
 uv_req_t* iotjs_reqwrap_req(iotjs_reqwrap_t* reqwrap);

--- a/src/modules/iotjs_module_adc.c
+++ b/src/modules/iotjs_module_adc.c
@@ -21,10 +21,10 @@
 static JNativeInfoType this_module_native_info = {.free_cb = NULL };
 
 
-static iotjs_adc_t* iotjs_adc_instance_from_jval(const iotjs_jval_t jadc);
+static iotjs_adc_t* iotjs_adc_instance_from_jval(const jerry_value_t jadc);
 
 
-static iotjs_adc_t* iotjs_adc_create(const iotjs_jval_t jadc) {
+static iotjs_adc_t* iotjs_adc_create(const jerry_value_t jadc) {
   iotjs_adc_t* adc = IOTJS_ALLOC(iotjs_adc_t);
   IOTJS_VALIDATED_STRUCT_CONSTRUCTOR(iotjs_adc_t, adc);
   iotjs_jobjectwrap_initialize(&_this->jobjectwrap, jadc,
@@ -48,7 +48,7 @@ static void iotjs_adc_destroy(iotjs_adc_t* adc) {
 
 
 static iotjs_adc_reqwrap_t* iotjs_adc_reqwrap_create(
-    const iotjs_jval_t jcallback, iotjs_adc_t* adc, AdcOp op) {
+    const jerry_value_t jcallback, iotjs_adc_t* adc, AdcOp op) {
   iotjs_adc_reqwrap_t* adc_reqwrap = IOTJS_ALLOC(iotjs_adc_reqwrap_t);
   IOTJS_VALIDATED_STRUCT_CONSTRUCTOR(iotjs_adc_reqwrap_t, adc_reqwrap);
 
@@ -78,13 +78,13 @@ static uv_work_t* iotjs_adc_reqwrap_req(THIS) {
 }
 
 
-static iotjs_jval_t iotjs_adc_reqwrap_jcallback(THIS) {
+static jerry_value_t iotjs_adc_reqwrap_jcallback(THIS) {
   IOTJS_VALIDATED_STRUCT_METHOD(iotjs_adc_reqwrap_t, adc_reqwrap);
   return iotjs_reqwrap_jcallback(&_this->reqwrap);
 }
 
 
-static iotjs_adc_t* iotjs_adc_instance_from_jval(const iotjs_jval_t jadc) {
+static iotjs_adc_t* iotjs_adc_instance_from_jval(const jerry_value_t jadc) {
   uintptr_t handle = iotjs_jval_get_object_native_handle(jadc);
   return (iotjs_adc_t*)handle;
 }
@@ -119,7 +119,7 @@ static void iotjs_adc_after_work(uv_work_t* work_req, int status) {
   bool result = req_data->result;
 
   if (status) {
-    iotjs_jval_t error = iotjs_jval_create_error("System error");
+    jerry_value_t error = iotjs_jval_create_error("System error");
     iotjs_jargs_append_jval(&jargs, error);
     jerry_release_value(error);
   } else {
@@ -153,7 +153,7 @@ static void iotjs_adc_after_work(uv_work_t* work_req, int status) {
     }
   }
 
-  const iotjs_jval_t jcallback = iotjs_adc_reqwrap_jcallback(req_wrap);
+  const jerry_value_t jcallback = iotjs_adc_reqwrap_jcallback(req_wrap);
   iotjs_make_callback(jcallback, jerry_create_undefined(), &jargs);
 
   if (req_data->op == kAdcOpClose) {
@@ -205,12 +205,12 @@ JS_FUNCTION(AdcConstructor) {
   DJS_CHECK_THIS();
 
   // Create ADC object
-  const iotjs_jval_t jadc = JS_GET_THIS();
+  const jerry_value_t jadc = JS_GET_THIS();
   iotjs_adc_t* adc = iotjs_adc_create(jadc);
   IOTJS_ASSERT(adc == iotjs_adc_instance_from_jval(jadc));
   IOTJS_VALIDATED_STRUCT_METHOD(iotjs_adc_t, adc);
 
-  const iotjs_jval_t jconfiguration = JS_GET_ARG_IF_EXIST(0, object);
+  const jerry_value_t jconfiguration = JS_GET_ARG_IF_EXIST(0, object);
   if (jerry_value_is_null(jconfiguration)) {
     return JS_CREATE_ERROR(TYPE,
                            "Bad arguments - configuration should be Object");
@@ -225,7 +225,7 @@ JS_FUNCTION(AdcConstructor) {
 #endif
 
   if (jargc > 1) {
-    const iotjs_jval_t jcallback = jargv[1];
+    const jerry_value_t jcallback = jargv[1];
     if (jerry_value_is_function(jcallback)) {
       ADC_ASYNC(open, adc, jcallback, kAdcOpOpen);
     } else {
@@ -233,7 +233,7 @@ JS_FUNCTION(AdcConstructor) {
                              "Bad arguments - callback should be Function");
     }
   } else {
-    iotjs_jval_t jdummycallback =
+    jerry_value_t jdummycallback =
         iotjs_jval_create_function(&iotjs_jval_dummy_function);
     ADC_ASYNC(open, adc, jdummycallback, kAdcOpOpen);
     jerry_release_value(jdummycallback);
@@ -247,7 +247,7 @@ JS_FUNCTION(Read) {
   JS_DECLARE_THIS_PTR(adc, adc);
   DJS_CHECK_ARG_IF_EXIST(0, function);
 
-  iotjs_jval_t jcallback = JS_GET_ARG_IF_EXIST(0, function);
+  jerry_value_t jcallback = JS_GET_ARG_IF_EXIST(0, function);
 
   if (jerry_value_is_null(jcallback)) {
     return JS_CREATE_ERROR(TYPE, "Bad arguments - callback required");
@@ -273,10 +273,10 @@ JS_FUNCTION(Close) {
   JS_DECLARE_THIS_PTR(adc, adc);
   DJS_CHECK_ARG_IF_EXIST(0, function);
 
-  iotjs_jval_t jcallback = JS_GET_ARG_IF_EXIST(0, function);
+  jerry_value_t jcallback = JS_GET_ARG_IF_EXIST(0, function);
 
   if (jerry_value_is_null(jcallback)) {
-    iotjs_jval_t jdummycallback =
+    jerry_value_t jdummycallback =
         iotjs_jval_create_function(&iotjs_jval_dummy_function);
     ADC_ASYNC(close, adc, jdummycallback, kAdcOpClose);
     jerry_release_value(jdummycallback);
@@ -299,12 +299,13 @@ JS_FUNCTION(CloseSync) {
   return jerry_create_null();
 }
 
-iotjs_jval_t InitAdc() {
-  iotjs_jval_t jadc = jerry_create_object();
-  iotjs_jval_t jadcConstructor = jerry_create_external_function(AdcConstructor);
+jerry_value_t InitAdc() {
+  jerry_value_t jadc = jerry_create_object();
+  jerry_value_t jadcConstructor =
+      jerry_create_external_function(AdcConstructor);
   iotjs_jval_set_property_jval(jadc, IOTJS_MAGIC_STRING_ADC, jadcConstructor);
 
-  iotjs_jval_t jprototype = jerry_create_object();
+  jerry_value_t jprototype = jerry_create_object();
   iotjs_jval_set_method(jprototype, IOTJS_MAGIC_STRING_READ, Read);
   iotjs_jval_set_method(jprototype, IOTJS_MAGIC_STRING_READSYNC, ReadSync);
   iotjs_jval_set_method(jprototype, IOTJS_MAGIC_STRING_CLOSE, Close);

--- a/src/modules/iotjs_module_blehcisocket.c
+++ b/src/modules/iotjs_module_blehcisocket.c
@@ -48,7 +48,7 @@
 IOTJS_DEFINE_NATIVE_HANDLE_INFO_THIS_MODULE(blehcisocket);
 
 
-iotjs_blehcisocket_t* iotjs_blehcisocket_create(iotjs_jval_t jble) {
+iotjs_blehcisocket_t* iotjs_blehcisocket_create(jerry_value_t jble) {
   THIS = IOTJS_ALLOC(iotjs_blehcisocket_t);
   IOTJS_VALIDATED_STRUCT_CONSTRUCTOR(iotjs_blehcisocket_t, blehcisocket);
 
@@ -61,7 +61,8 @@ iotjs_blehcisocket_t* iotjs_blehcisocket_create(iotjs_jval_t jble) {
 }
 
 
-iotjs_blehcisocket_t* iotjs_blehcisocket_instance_from_jval(iotjs_jval_t jble) {
+iotjs_blehcisocket_t* iotjs_blehcisocket_instance_from_jval(
+    jerry_value_t jble) {
   iotjs_jobjectwrap_t* jobjectwrap = iotjs_jobjectwrap_from_jobject(jble);
   return (iotjs_blehcisocket_t*)jobjectwrap;
 }
@@ -175,7 +176,7 @@ JS_FUNCTION(BleHciSocketCons) {
   DJS_CHECK_THIS();
 
   // Create object
-  iotjs_jval_t jblehcisocket = JS_GET_THIS();
+  jerry_value_t jblehcisocket = JS_GET_THIS();
   iotjs_blehcisocket_t* blehcisocket = iotjs_blehcisocket_create(jblehcisocket);
   IOTJS_ASSERT(blehcisocket ==
                (iotjs_blehcisocket_t*)(iotjs_jval_get_object_native_handle(
@@ -184,11 +185,11 @@ JS_FUNCTION(BleHciSocketCons) {
 }
 
 
-iotjs_jval_t InitBlehcisocket() {
-  iotjs_jval_t jblehcisocketCons =
+jerry_value_t InitBlehcisocket() {
+  jerry_value_t jblehcisocketCons =
       jerry_create_external_function(BleHciSocketCons);
 
-  iotjs_jval_t prototype = jerry_create_object();
+  jerry_value_t prototype = jerry_create_object();
 
   iotjs_jval_set_method(prototype, IOTJS_MAGIC_STRING_START, Start);
   iotjs_jval_set_method(prototype, IOTJS_MAGIC_STRING_BINDRAW, BindRaw);

--- a/src/modules/iotjs_module_blehcisocket.h
+++ b/src/modules/iotjs_module_blehcisocket.h
@@ -58,8 +58,8 @@ typedef struct {
 #define THIS iotjs_blehcisocket_t* iotjs_blehcisocket
 
 
-iotjs_blehcisocket_t* iotjs_blehcisocket_create(iotjs_jval_t jble);
-iotjs_blehcisocket_t* iotjs_blehcisocket_instance_from_jval(iotjs_jval_t jble);
+iotjs_blehcisocket_t* iotjs_blehcisocket_create(jerry_value_t jble);
+iotjs_blehcisocket_t* iotjs_blehcisocket_instance_from_jval(jerry_value_t jble);
 
 
 void iotjs_blehcisocket_initialize(THIS);

--- a/src/modules/iotjs_module_buffer.c
+++ b/src/modules/iotjs_module_buffer.c
@@ -24,7 +24,7 @@
 IOTJS_DEFINE_NATIVE_HANDLE_INFO_THIS_MODULE(bufferwrap);
 
 
-iotjs_bufferwrap_t* iotjs_bufferwrap_create(const iotjs_jval_t jbuiltin,
+iotjs_bufferwrap_t* iotjs_bufferwrap_create(const jerry_value_t jbuiltin,
                                             size_t length) {
   iotjs_bufferwrap_t* bufferwrap = IOTJS_ALLOC(iotjs_bufferwrap_t);
   IOTJS_VALIDATED_STRUCT_CONSTRUCTOR(iotjs_bufferwrap_t, bufferwrap);
@@ -59,7 +59,7 @@ static void iotjs_bufferwrap_destroy(iotjs_bufferwrap_t* bufferwrap) {
 
 
 iotjs_bufferwrap_t* iotjs_bufferwrap_from_jbuiltin(
-    const iotjs_jval_t jbuiltin) {
+    const jerry_value_t jbuiltin) {
   IOTJS_ASSERT(jerry_value_is_object(jbuiltin));
   iotjs_bufferwrap_t* buffer =
       (iotjs_bufferwrap_t*)iotjs_jval_get_object_native_handle(jbuiltin);
@@ -68,9 +68,9 @@ iotjs_bufferwrap_t* iotjs_bufferwrap_from_jbuiltin(
 }
 
 
-iotjs_bufferwrap_t* iotjs_bufferwrap_from_jbuffer(const iotjs_jval_t jbuffer) {
+iotjs_bufferwrap_t* iotjs_bufferwrap_from_jbuffer(const jerry_value_t jbuffer) {
   IOTJS_ASSERT(jerry_value_is_object(jbuffer));
-  iotjs_jval_t jbuiltin =
+  jerry_value_t jbuiltin =
       iotjs_jval_get_property(jbuffer, IOTJS_MAGIC_STRING__BUILTIN);
   iotjs_bufferwrap_t* buffer = iotjs_bufferwrap_from_jbuiltin(jbuiltin);
   jerry_release_value(jbuiltin);
@@ -78,15 +78,15 @@ iotjs_bufferwrap_t* iotjs_bufferwrap_from_jbuffer(const iotjs_jval_t jbuffer) {
 }
 
 
-iotjs_jval_t iotjs_bufferwrap_jbuiltin(iotjs_bufferwrap_t* bufferwrap) {
+jerry_value_t iotjs_bufferwrap_jbuiltin(iotjs_bufferwrap_t* bufferwrap) {
   IOTJS_VALIDATED_STRUCT_METHOD(iotjs_bufferwrap_t, bufferwrap);
   return iotjs_jobjectwrap_jobject(&_this->jobjectwrap);
 }
 
 
-iotjs_jval_t iotjs_bufferwrap_jbuffer(iotjs_bufferwrap_t* bufferwrap) {
+jerry_value_t iotjs_bufferwrap_jbuffer(iotjs_bufferwrap_t* bufferwrap) {
   IOTJS_VALIDATABLE_STRUCT_METHOD_VALIDATE(iotjs_bufferwrap_t, bufferwrap);
-  iotjs_jval_t jbuiltin = iotjs_bufferwrap_jbuiltin(bufferwrap);
+  jerry_value_t jbuiltin = iotjs_bufferwrap_jbuiltin(bufferwrap);
   return iotjs_jval_get_property(jbuiltin, IOTJS_MAGIC_STRING__BUFFER);
 }
 
@@ -100,8 +100,8 @@ char* iotjs_bufferwrap_buffer(iotjs_bufferwrap_t* bufferwrap) {
 size_t iotjs_bufferwrap_length(iotjs_bufferwrap_t* bufferwrap) {
   IOTJS_VALIDATED_STRUCT_METHOD(iotjs_bufferwrap_t, bufferwrap);
 #ifndef NDEBUG
-  iotjs_jval_t jbuf = iotjs_bufferwrap_jbuffer(bufferwrap);
-  iotjs_jval_t jlength =
+  jerry_value_t jbuf = iotjs_bufferwrap_jbuffer(bufferwrap);
+  jerry_value_t jlength =
       iotjs_jval_get_property(jbuf, IOTJS_MAGIC_STRING_LENGTH);
   size_t length = iotjs_jval_as_number(jlength);
   IOTJS_ASSERT(length == _this->length);
@@ -212,10 +212,10 @@ size_t iotjs_bufferwrap_copy(iotjs_bufferwrap_t* bufferwrap, const char* src,
 }
 
 
-iotjs_jval_t iotjs_bufferwrap_create_buffer(size_t len) {
-  iotjs_jval_t jglobal = jerry_get_global_object();
+jerry_value_t iotjs_bufferwrap_create_buffer(size_t len) {
+  jerry_value_t jglobal = jerry_get_global_object();
 
-  iotjs_jval_t jbuffer =
+  jerry_value_t jbuffer =
       iotjs_jval_get_property(jglobal, IOTJS_MAGIC_STRING_BUFFER);
   jerry_release_value(jglobal);
   IOTJS_ASSERT(jerry_value_is_function(jbuffer));
@@ -223,7 +223,7 @@ iotjs_jval_t iotjs_bufferwrap_create_buffer(size_t len) {
   iotjs_jargs_t jargs = iotjs_jargs_create(1);
   iotjs_jargs_append_number(&jargs, len);
 
-  iotjs_jval_t jres =
+  jerry_value_t jres =
       iotjs_jhelper_call_ok(jbuffer, jerry_create_undefined(), &jargs);
   IOTJS_ASSERT(jerry_value_is_object(jres));
 
@@ -238,8 +238,8 @@ JS_FUNCTION(Buffer) {
   DJS_CHECK_THIS();
   DJS_CHECK_ARGS(2, object, number);
 
-  const iotjs_jval_t jbuiltin = JS_GET_THIS();
-  const iotjs_jval_t jbuffer = JS_GET_ARG(0, object);
+  const jerry_value_t jbuiltin = JS_GET_THIS();
+  const jerry_value_t jbuffer = JS_GET_ARG(0, object);
   size_t length = JS_GET_ARG(1, number);
 
   iotjs_jval_set_property_jval(jbuiltin, IOTJS_MAGIC_STRING__BUFFER, jbuffer);
@@ -262,7 +262,7 @@ JS_FUNCTION(Copy) {
   JS_DECLARE_THIS_PTR(bufferwrap, src_buffer_wrap);
   DJS_CHECK_ARGS(4, object, number, number, number);
 
-  const iotjs_jval_t jdst_buffer = JS_GET_ARG(0, object);
+  const jerry_value_t jdst_buffer = JS_GET_ARG(0, object);
   iotjs_bufferwrap_t* dst_buffer_wrap =
       iotjs_bufferwrap_from_jbuffer(jdst_buffer);
 
@@ -420,7 +420,7 @@ JS_FUNCTION(Slice) {
 
   size_t length = (size_t)(end_idx - start_idx);
 
-  iotjs_jval_t jnew_buffer = iotjs_bufferwrap_create_buffer(length);
+  jerry_value_t jnew_buffer = iotjs_bufferwrap_create_buffer(length);
   iotjs_bufferwrap_t* new_buffer_wrap =
       iotjs_bufferwrap_from_jbuffer(jnew_buffer);
   iotjs_bufferwrap_copy_internal(new_buffer_wrap,
@@ -475,7 +475,7 @@ JS_FUNCTION(ToHexString) {
     buffer++;
   }
 
-  iotjs_jval_t ret_value = iotjs_jval_create_string(&str);
+  jerry_value_t ret_value = iotjs_jval_create_string(&str);
   iotjs_string_destroy(&str);
 
   return ret_value;
@@ -487,17 +487,17 @@ JS_FUNCTION(ByteLength) {
   DJS_CHECK_ARGS(1, string);
 
   iotjs_string_t str = JS_GET_ARG(0, string);
-  iotjs_jval_t size = iotjs_jval_get_string_size(&str);
+  jerry_value_t size = iotjs_jval_get_string_size(&str);
 
   iotjs_string_destroy(&str);
   return size;
 }
 
 
-iotjs_jval_t InitBuffer() {
-  iotjs_jval_t buffer = jerry_create_external_function(Buffer);
+jerry_value_t InitBuffer() {
+  jerry_value_t buffer = jerry_create_external_function(Buffer);
 
-  iotjs_jval_t prototype = jerry_create_object();
+  jerry_value_t prototype = jerry_create_object();
   iotjs_jval_set_property_jval(buffer, IOTJS_MAGIC_STRING_PROTOTYPE, prototype);
   iotjs_jval_set_method(buffer, IOTJS_MAGIC_STRING_BYTELENGTH, ByteLength);
 

--- a/src/modules/iotjs_module_buffer.h
+++ b/src/modules/iotjs_module_buffer.h
@@ -27,14 +27,15 @@ typedef struct {
 } IOTJS_VALIDATED_STRUCT(iotjs_bufferwrap_t);
 
 
-iotjs_bufferwrap_t* iotjs_bufferwrap_create(const iotjs_jval_t jbuiltin,
+iotjs_bufferwrap_t* iotjs_bufferwrap_create(const jerry_value_t jbuiltin,
                                             size_t length);
 
-iotjs_bufferwrap_t* iotjs_bufferwrap_from_jbuiltin(const iotjs_jval_t jbuiltin);
-iotjs_bufferwrap_t* iotjs_bufferwrap_from_jbuffer(const iotjs_jval_t jbuffer);
+iotjs_bufferwrap_t* iotjs_bufferwrap_from_jbuiltin(
+    const jerry_value_t jbuiltin);
+iotjs_bufferwrap_t* iotjs_bufferwrap_from_jbuffer(const jerry_value_t jbuffer);
 
-iotjs_jval_t iotjs_bufferwrap_jbuiltin(iotjs_bufferwrap_t* bufferwrap);
-iotjs_jval_t iotjs_bufferwrap_jbuffer(iotjs_bufferwrap_t* bufferwrap);
+jerry_value_t iotjs_bufferwrap_jbuiltin(iotjs_bufferwrap_t* bufferwrap);
+jerry_value_t iotjs_bufferwrap_jbuffer(iotjs_bufferwrap_t* bufferwrap);
 
 char* iotjs_bufferwrap_buffer(iotjs_bufferwrap_t* bufferwrap);
 size_t iotjs_bufferwrap_length(iotjs_bufferwrap_t* bufferwrap);
@@ -46,7 +47,7 @@ size_t iotjs_bufferwrap_copy(iotjs_bufferwrap_t* bufferwrap, const char* src,
                              size_t len);
 
 // Create buffer object.
-iotjs_jval_t iotjs_bufferwrap_create_buffer(size_t len);
+jerry_value_t iotjs_bufferwrap_create_buffer(size_t len);
 
 
 #endif /* IOTJS_MODULE_BUFFER_H */

--- a/src/modules/iotjs_module_console.c
+++ b/src/modules/iotjs_module_console.c
@@ -17,8 +17,8 @@
 
 // This function should be able to print utf8 encoded string
 // as utf8 is internal string representation in Jerryscript
-static iotjs_jval_t Print(const jerry_value_t* jargv,
-                          const jerry_length_t jargc, FILE* out_fd) {
+static jerry_value_t Print(const jerry_value_t* jargv,
+                           const jerry_length_t jargc, FILE* out_fd) {
   JS_CHECK_ARGS(1, string);
   iotjs_string_t msg = JS_GET_ARG(0, string);
   const char* str = iotjs_string_data(&msg);
@@ -47,8 +47,8 @@ JS_FUNCTION(Stderr) {
 }
 
 
-iotjs_jval_t InitConsole() {
-  iotjs_jval_t console = jerry_create_object();
+jerry_value_t InitConsole() {
+  jerry_value_t console = jerry_create_object();
 
   iotjs_jval_set_method(console, IOTJS_MAGIC_STRING_STDOUT, Stdout);
   iotjs_jval_set_method(console, IOTJS_MAGIC_STRING_STDERR, Stderr);

--- a/src/modules/iotjs_module_constants.c
+++ b/src/modules/iotjs_module_constants.c
@@ -22,8 +22,8 @@
     iotjs_jval_set_property_number(object, #constant, constant); \
   } while (0)
 
-iotjs_jval_t InitConstants() {
-  iotjs_jval_t constants = jerry_create_object();
+jerry_value_t InitConstants() {
+  jerry_value_t constants = jerry_create_object();
 
   SET_CONSTANT(constants, O_APPEND);
   SET_CONSTANT(constants, O_CREAT);

--- a/src/modules/iotjs_module_dns.c
+++ b/src/modules/iotjs_module_dns.c
@@ -24,7 +24,7 @@
 #define THIS iotjs_getaddrinfo_reqwrap_t* getaddrinfo_reqwrap
 
 iotjs_getaddrinfo_reqwrap_t* iotjs_getaddrinfo_reqwrap_create(
-    const iotjs_jval_t jcallback) {
+    const jerry_value_t jcallback) {
   iotjs_getaddrinfo_reqwrap_t* getaddrinfo_reqwrap =
       IOTJS_ALLOC(iotjs_getaddrinfo_reqwrap_t);
   IOTJS_VALIDATED_STRUCT_CONSTRUCTOR(iotjs_getaddrinfo_reqwrap_t,
@@ -56,7 +56,7 @@ uv_getaddrinfo_t* iotjs_getaddrinfo_reqwrap_req(THIS) {
 }
 
 
-iotjs_jval_t iotjs_getaddrinfo_reqwrap_jcallback(THIS) {
+jerry_value_t iotjs_getaddrinfo_reqwrap_jcallback(THIS) {
   IOTJS_VALIDATED_STRUCT_METHOD(iotjs_getaddrinfo_reqwrap_t,
                                 getaddrinfo_reqwrap);
   return iotjs_reqwrap_jcallback(&_this->reqwrap);
@@ -154,7 +154,7 @@ static void AfterGetAddrInfo(uv_getaddrinfo_t* req, int status,
   uv_freeaddrinfo(res);
 
   // Make the callback into JavaScript
-  iotjs_jval_t jcallback = iotjs_getaddrinfo_reqwrap_jcallback(req_wrap);
+  jerry_value_t jcallback = iotjs_getaddrinfo_reqwrap_jcallback(req_wrap);
   iotjs_make_callback(jcallback, jerry_create_undefined(), &args);
 
   iotjs_jargs_destroy(&args);
@@ -172,7 +172,7 @@ JS_FUNCTION(GetAddrInfo) {
   int option = JS_GET_ARG(1, number);
   int flags = JS_GET_ARG(2, number);
   int error = 0;
-  const iotjs_jval_t jcallback = JS_GET_ARG(3, function);
+  const jerry_value_t jcallback = JS_GET_ARG(3, function);
 
   int family;
   if (option == 0) {
@@ -252,8 +252,8 @@ JS_FUNCTION(GetAddrInfo) {
   } while (0)
 
 
-iotjs_jval_t InitDns() {
-  iotjs_jval_t dns = jerry_create_object();
+jerry_value_t InitDns() {
+  jerry_value_t dns = jerry_create_object();
 
   iotjs_jval_set_method(dns, IOTJS_MAGIC_STRING_GETADDRINFO, GetAddrInfo);
   SET_CONSTANT(dns, AI_ADDRCONFIG);

--- a/src/modules/iotjs_module_dns.h
+++ b/src/modules/iotjs_module_dns.h
@@ -30,12 +30,12 @@ typedef struct {
 #define THIS iotjs_getaddrinfo_reqwrap_t* getaddrinfo_reqwrap
 
 iotjs_getaddrinfo_reqwrap_t* iotjs_getaddrinfo_reqwrap_create(
-    const iotjs_jval_t jcallback);
+    const jerry_value_t jcallback);
 
 void iotjs_getaddrinfo_reqwrap_dispatched(THIS);
 
 uv_getaddrinfo_t* iotjs_getaddrinfo_reqwrap_req(THIS);
-iotjs_jval_t iotjs_getaddrinfo_reqwrap_jcallback(THIS);
+jerry_value_t iotjs_getaddrinfo_reqwrap_jcallback(THIS);
 
 #undef THIS
 

--- a/src/modules/iotjs_module_https.c
+++ b/src/modules/iotjs_module_https.c
@@ -32,7 +32,7 @@ iotjs_https_t* iotjs_https_create(const char* URL, const char* method,
                                   const char* ca, const char* cert,
                                   const char* key,
                                   const bool reject_unauthorized,
-                                  iotjs_jval_t jthis) {
+                                  jerry_value_t jthis) {
   iotjs_https_t* https_data = IOTJS_ALLOC(iotjs_https_t);
   IOTJS_VALIDATED_STRUCT_CONSTRUCTOR(iotjs_https_t, https_data);
 
@@ -181,7 +181,7 @@ void iotjs_https_cleanup(iotjs_https_t* https_data) {
 
   if (_this->to_destroy_read_onwrite) {
     const iotjs_jargs_t* jarg = iotjs_jargs_get_empty();
-    iotjs_jval_t jthis = _this->jthis_native;
+    jerry_value_t jthis = _this->jthis_native;
     IOTJS_ASSERT(jerry_value_is_function((_this->read_onwrite)));
 
     if (!jerry_value_is_undefined((_this->read_callback)))
@@ -291,7 +291,7 @@ void iotjs_https_initialize_curl_opts(iotjs_https_t* https_data) {
 }
 
 // Get https.ClientRequest from struct
-iotjs_jval_t iotjs_https_jthis_from_https(iotjs_https_t* https_data) {
+jerry_value_t iotjs_https_jthis_from_https(iotjs_https_t* https_data) {
   IOTJS_VALIDATED_STRUCT_METHOD(iotjs_https_t, https_data);
   return _this->jthis_native;
 }
@@ -299,20 +299,20 @@ iotjs_jval_t iotjs_https_jthis_from_https(iotjs_https_t* https_data) {
 // Call any property of ClientRequest._Incoming
 bool iotjs_https_jcallback(iotjs_https_t* https_data, const char* property,
                            const iotjs_jargs_t* jarg, bool resultvalue) {
-  iotjs_jval_t jthis = iotjs_https_jthis_from_https(https_data);
+  jerry_value_t jthis = iotjs_https_jthis_from_https(https_data);
   bool retval = true;
   if (jerry_value_is_null(jthis))
     return retval;
 
-  iotjs_jval_t jincoming =
+  jerry_value_t jincoming =
       iotjs_jval_get_property(jthis, IOTJS_MAGIC_STRING__INCOMING);
-  iotjs_jval_t cb = iotjs_jval_get_property(jincoming, property);
+  jerry_value_t cb = iotjs_jval_get_property(jincoming, property);
 
   IOTJS_ASSERT(jerry_value_is_function(cb));
   if (!resultvalue) {
     iotjs_make_callback(cb, jincoming, jarg);
   } else {
-    iotjs_jval_t result = iotjs_make_callback_with_result(cb, jincoming, jarg);
+    jerry_value_t result = iotjs_make_callback_with_result(cb, jincoming, jarg);
     retval = iotjs_jval_as_boolean(result);
     jerry_release_value(result);
   }
@@ -331,7 +331,7 @@ void iotjs_https_call_read_onwrite(uv_timer_t* timer) {
   if (jerry_value_is_null(_this->jthis_native))
     return;
   const iotjs_jargs_t* jarg = iotjs_jargs_get_empty();
-  iotjs_jval_t jthis = _this->jthis_native;
+  jerry_value_t jthis = _this->jthis_native;
   IOTJS_ASSERT(jerry_value_is_function((_this->read_onwrite)));
 
   if (!jerry_value_is_undefined((_this->read_callback)))
@@ -364,8 +364,8 @@ void iotjs_https_add_header(iotjs_https_t* https_data,
 
 // Recieved data to write from ClientRequest._write
 void iotjs_https_data_to_write(iotjs_https_t* https_data,
-                               iotjs_string_t read_chunk, iotjs_jval_t callback,
-                               iotjs_jval_t onwrite) {
+                               iotjs_string_t read_chunk,
+                               jerry_value_t callback, jerry_value_t onwrite) {
   IOTJS_VALIDATED_STRUCT_METHOD(iotjs_https_t, https_data);
 
   if (_this->to_destroy_read_onwrite) {
@@ -557,7 +557,7 @@ size_t iotjs_https_curl_write_callback(void* contents, size_t size,
 
   iotjs_jargs_t jarg = iotjs_jargs_create(1);
 
-  iotjs_jval_t jbuffer = iotjs_bufferwrap_create_buffer((size_t)real_size);
+  jerry_value_t jbuffer = iotjs_bufferwrap_create_buffer((size_t)real_size);
   iotjs_bufferwrap_t* buffer_wrap = iotjs_bufferwrap_from_jbuffer(jbuffer);
   iotjs_bufferwrap_copy(buffer_wrap, contents, (size_t)real_size);
 
@@ -722,32 +722,33 @@ JS_FUNCTION(createRequest) {
   DJS_CHECK_THIS();
   DJS_CHECK_ARGS(1, object);
 
-  const iotjs_jval_t joptions = JS_GET_ARG(0, object);
+  const jerry_value_t joptions = JS_GET_ARG(0, object);
 
-  iotjs_jval_t jhost =
+  jerry_value_t jhost =
       iotjs_jval_get_property(joptions, IOTJS_MAGIC_STRING_HOST);
   iotjs_string_t host = iotjs_jval_as_string(jhost);
   jerry_release_value(jhost);
 
-  iotjs_jval_t jmethod =
+  jerry_value_t jmethod =
       iotjs_jval_get_property(joptions, IOTJS_MAGIC_STRING_METHOD);
   iotjs_string_t method = iotjs_jval_as_string(jmethod);
   jerry_release_value(jmethod);
 
-  iotjs_jval_t jca = iotjs_jval_get_property(joptions, IOTJS_MAGIC_STRING_CA);
+  jerry_value_t jca = iotjs_jval_get_property(joptions, IOTJS_MAGIC_STRING_CA);
   iotjs_string_t ca = iotjs_jval_as_string(jca);
   jerry_release_value(jca);
 
-  iotjs_jval_t jcert =
+  jerry_value_t jcert =
       iotjs_jval_get_property(joptions, IOTJS_MAGIC_STRING_CERT);
   iotjs_string_t cert = iotjs_jval_as_string(jcert);
   jerry_release_value(jcert);
 
-  iotjs_jval_t jkey = iotjs_jval_get_property(joptions, IOTJS_MAGIC_STRING_KEY);
+  jerry_value_t jkey =
+      iotjs_jval_get_property(joptions, IOTJS_MAGIC_STRING_KEY);
   iotjs_string_t key = iotjs_jval_as_string(jkey);
   jerry_release_value(jkey);
 
-  iotjs_jval_t jreject_unauthorized =
+  jerry_value_t jreject_unauthorized =
       iotjs_jval_get_property(joptions, IOTJS_MAGIC_STRING_REJECTUNAUTHORIZED);
   const bool reject_unauthorized = iotjs_jval_as_boolean(jreject_unauthorized);
 
@@ -778,7 +779,7 @@ JS_FUNCTION(addHeader) {
   iotjs_string_t header = JS_GET_ARG(0, string);
   const char* char_header = iotjs_string_data(&header);
 
-  iotjs_jval_t jarg = JS_GET_ARG(1, object);
+  jerry_value_t jarg = JS_GET_ARG(1, object);
   iotjs_https_t* https_data =
       (iotjs_https_t*)iotjs_jval_get_object_native_handle(jarg);
   iotjs_https_add_header(https_data, char_header);
@@ -791,7 +792,7 @@ JS_FUNCTION(sendRequest) {
   DJS_CHECK_THIS();
 
   DJS_CHECK_ARG(0, object);
-  iotjs_jval_t jarg = JS_GET_ARG(0, object);
+  jerry_value_t jarg = JS_GET_ARG(0, object);
   iotjs_https_t* https_data =
       (iotjs_https_t*)iotjs_jval_get_object_native_handle(jarg);
   iotjs_https_send_request(https_data);
@@ -803,7 +804,7 @@ JS_FUNCTION(setTimeout) {
   DJS_CHECK_ARGS(2, number, object);
 
   double ms = JS_GET_ARG(0, number);
-  iotjs_jval_t jarg = JS_GET_ARG(1, object);
+  jerry_value_t jarg = JS_GET_ARG(1, object);
 
   iotjs_https_t* https_data =
       (iotjs_https_t*)iotjs_jval_get_object_native_handle(jarg);
@@ -818,11 +819,11 @@ JS_FUNCTION(_write) {
   // Argument 3 can be null, so not checked directly, checked later
   DJS_CHECK_ARG(3, function);
 
-  iotjs_jval_t jarg = JS_GET_ARG(0, object);
+  jerry_value_t jarg = JS_GET_ARG(0, object);
   iotjs_string_t read_chunk = JS_GET_ARG(1, string);
 
-  iotjs_jval_t callback = jargv[2];
-  iotjs_jval_t onwrite = JS_GET_ARG(3, function);
+  jerry_value_t callback = jargv[2];
+  jerry_value_t onwrite = JS_GET_ARG(3, function);
 
   iotjs_https_t* https_data =
       (iotjs_https_t*)iotjs_jval_get_object_native_handle(jarg);
@@ -836,7 +837,7 @@ JS_FUNCTION(finishRequest) {
   DJS_CHECK_THIS();
   DJS_CHECK_ARG(0, object);
 
-  iotjs_jval_t jarg = JS_GET_ARG(0, object);
+  jerry_value_t jarg = JS_GET_ARG(0, object);
   iotjs_https_t* https_data =
       (iotjs_https_t*)iotjs_jval_get_object_native_handle(jarg);
   iotjs_https_finish_request(https_data);
@@ -848,7 +849,7 @@ JS_FUNCTION(Abort) {
   DJS_CHECK_THIS();
   DJS_CHECK_ARG(0, object);
 
-  iotjs_jval_t jarg = JS_GET_ARG(0, object);
+  jerry_value_t jarg = JS_GET_ARG(0, object);
   iotjs_https_t* https_data =
       (iotjs_https_t*)iotjs_jval_get_object_native_handle(jarg);
   iotjs_https_cleanup(https_data);
@@ -856,8 +857,8 @@ JS_FUNCTION(Abort) {
   return jerry_create_null();
 }
 
-iotjs_jval_t InitHttps() {
-  iotjs_jval_t https = jerry_create_object();
+jerry_value_t InitHttps() {
+  jerry_value_t https = jerry_create_object();
 
   iotjs_jval_set_method(https, IOTJS_MAGIC_STRING_CREATEREQUEST, createRequest);
   iotjs_jval_set_method(https, IOTJS_MAGIC_STRING_ADDHEADER, addHeader);

--- a/src/modules/iotjs_module_https.h
+++ b/src/modules/iotjs_module_https.h
@@ -56,7 +56,7 @@ typedef struct {
 
   // Handles
   uv_loop_t* loop;
-  iotjs_jval_t jthis_native;
+  jerry_value_t jthis_native;
   CURLM* curl_multi_handle;
   uv_timer_t timeout;
   CURL* curl_easy_handle;
@@ -79,8 +79,8 @@ typedef struct {
   bool stream_ended;
   bool to_destroy_read_onwrite;
   iotjs_string_t read_chunk;
-  iotjs_jval_t read_callback;
-  iotjs_jval_t read_onwrite;
+  jerry_value_t read_callback;
+  jerry_value_t read_onwrite;
   uv_timer_t async_read_onwrite;
 
 } IOTJS_VALIDATED_STRUCT(iotjs_https_t);
@@ -89,7 +89,7 @@ iotjs_https_t* iotjs_https_create(const char* URL, const char* method,
                                   const char* ca, const char* cert,
                                   const char* key,
                                   const bool reject_unauthorized,
-                                  iotjs_jval_t jthis);
+                                  jerry_value_t jthis);
 
 #define THIS iotjs_https_t* https_data
 // Some utility functions
@@ -97,7 +97,7 @@ void iotjs_https_check_done(THIS);
 void iotjs_https_cleanup(THIS);
 CURLM* iotjs_https_get_multi_handle(THIS);
 void iotjs_https_initialize_curl_opts(THIS);
-iotjs_jval_t iotjs_https_jthis_from_https(THIS);
+jerry_value_t iotjs_https_jthis_from_https(THIS);
 bool iotjs_https_jcallback(THIS, const char* property,
                            const iotjs_jargs_t* jarg, bool resultvalue);
 void iotjs_https_call_read_onwrite(uv_timer_t* timer);
@@ -106,7 +106,7 @@ void iotjs_https_call_read_onwrite_async(THIS);
 // Functions almost directly called by JS via JHANDLER
 void iotjs_https_add_header(THIS, const char* char_header);
 void iotjs_https_data_to_write(THIS, iotjs_string_t read_chunk,
-                               iotjs_jval_t callback, iotjs_jval_t onwrite);
+                               jerry_value_t callback, jerry_value_t onwrite);
 void iotjs_https_finish_request(THIS);
 void iotjs_https_send_request(THIS);
 void iotjs_https_set_timeout(long ms, THIS);

--- a/src/modules/iotjs_module_i2c.h
+++ b/src/modules/iotjs_module_i2c.h
@@ -64,12 +64,12 @@ typedef struct {
 } IOTJS_VALIDATED_STRUCT(iotjs_i2c_reqwrap_t);
 
 
-iotjs_i2c_t* iotjs_i2c_instance_from_jval(const iotjs_jval_t ji2c);
+iotjs_i2c_t* iotjs_i2c_instance_from_jval(const jerry_value_t ji2c);
 iotjs_i2c_reqwrap_t* iotjs_i2c_reqwrap_from_request(uv_work_t* req);
 #define THIS iotjs_i2c_reqwrap_t* i2c_reqwrap
 void iotjs_i2c_reqwrap_dispatched(THIS);
 uv_work_t* iotjs_i2c_reqwrap_req(THIS);
-iotjs_jval_t iotjs_i2c_reqwrap_jcallback(THIS);
+jerry_value_t iotjs_i2c_reqwrap_jcallback(THIS);
 iotjs_i2c_reqdata_t* iotjs_i2c_reqwrap_data(THIS);
 iotjs_i2c_t* iotjs_i2c_instance_from_reqwrap(THIS);
 #undef THIS

--- a/src/modules/iotjs_module_process.c
+++ b/src/modules/iotjs_module_process.c
@@ -20,8 +20,8 @@
 #include <stdlib.h>
 
 
-static iotjs_jval_t WrapEval(const char* name, size_t name_len,
-                             const char* source, size_t length) {
+static jerry_value_t WrapEval(const char* name, size_t name_len,
+                              const char* source, size_t length) {
   static const char* args = "exports, require, module, native";
   jerry_value_t res =
       jerry_parse_function((const jerry_char_t*)name, name_len,
@@ -45,7 +45,7 @@ JS_FUNCTION(Compile) {
     jerry_debugger_stop();
   }
 
-  iotjs_jval_t jres =
+  jerry_value_t jres =
       WrapEval(filename, strlen(filename), iotjs_string_data(&source),
                iotjs_string_size(&source));
 
@@ -84,10 +84,10 @@ JS_FUNCTION(DebuggerSourceCompile) {
 JS_FUNCTION(CompileModule) {
   DJS_CHECK_ARGS(2, object, function);
 
-  iotjs_jval_t jmodule = JS_GET_ARG(0, object);
-  iotjs_jval_t jrequire = JS_GET_ARG(1, function);
+  jerry_value_t jmodule = JS_GET_ARG(0, object);
+  jerry_value_t jrequire = JS_GET_ARG(1, function);
 
-  iotjs_jval_t jid = iotjs_jval_get_property(jmodule, "id");
+  jerry_value_t jid = iotjs_jval_get_property(jmodule, "id");
   iotjs_string_t id = iotjs_jval_as_string(jid);
   jerry_release_value(jid);
   const char* name = iotjs_string_data(&id);
@@ -101,13 +101,13 @@ JS_FUNCTION(CompileModule) {
     i++;
   }
 
-  iotjs_jval_t native_module_jval = iotjs_module_get(name);
+  jerry_value_t native_module_jval = iotjs_module_get(name);
   if (jerry_value_has_error_flag(native_module_jval)) {
     return native_module_jval;
   }
 
-  iotjs_jval_t jexports = iotjs_jval_get_property(jmodule, "exports");
-  iotjs_jval_t jres = jerry_create_undefined();
+  jerry_value_t jexports = iotjs_jval_get_property(jmodule, "exports");
+  jerry_value_t jres = jerry_create_undefined();
 
   if (js_modules[i].name != NULL) {
 #ifdef ENABLE_SNAPSHOT
@@ -119,11 +119,12 @@ JS_FUNCTION(CompileModule) {
 #endif
 
     if (!jerry_value_has_error_flag(jres)) {
-      iotjs_jval_t args[] = { jexports, jrequire, jmodule, native_module_jval };
+      jerry_value_t args[] = { jexports, jrequire, jmodule,
+                               native_module_jval };
 
-      iotjs_jval_t jfunc = jres;
+      jerry_value_t jfunc = jres;
       jres = jerry_call_function(jfunc, jerry_create_undefined(), args,
-                                 sizeof(args) / sizeof(iotjs_jval_t));
+                                 sizeof(args) / sizeof(jerry_value_t));
       jerry_release_value(jfunc);
     }
   } else if (!jerry_value_is_undefined(native_module_jval)) {
@@ -144,7 +145,7 @@ JS_FUNCTION(ReadSource) {
   iotjs_string_t path = JS_GET_ARG(0, string);
   iotjs_string_t code = iotjs_file_read(iotjs_string_data(&path));
 
-  iotjs_jval_t ret_val = iotjs_jval_create_string(&code);
+  jerry_value_t ret_val = iotjs_jval_create_string(&code);
 
   iotjs_string_destroy(&path);
   iotjs_string_destroy(&code);
@@ -194,7 +195,7 @@ JS_FUNCTION(DoExit) {
 }
 
 
-void SetNativeSources(iotjs_jval_t native_sources) {
+void SetNativeSources(jerry_value_t native_sources) {
   for (int i = 0; js_modules[i].name; i++) {
     iotjs_jval_set_property_jval(native_sources, js_modules[i].name,
                                  jerry_create_boolean(true));
@@ -202,7 +203,7 @@ void SetNativeSources(iotjs_jval_t native_sources) {
 }
 
 
-static void SetProcessEnv(iotjs_jval_t process) {
+static void SetProcessEnv(jerry_value_t process) {
   const char *homedir, *iotjspath, *iotjsenv;
 
   homedir = getenv("HOME");
@@ -225,7 +226,7 @@ static void SetProcessEnv(iotjs_jval_t process) {
   iotjsenv = "";
 #endif
 
-  iotjs_jval_t env = jerry_create_object();
+  jerry_value_t env = jerry_create_object();
   iotjs_jval_set_property_string_raw(env, IOTJS_MAGIC_STRING_HOME, homedir);
   iotjs_jval_set_property_string_raw(env, IOTJS_MAGIC_STRING_IOTJS_PATH,
                                      iotjspath);
@@ -238,9 +239,9 @@ static void SetProcessEnv(iotjs_jval_t process) {
 }
 
 
-static void SetProcessIotjs(iotjs_jval_t process) {
+static void SetProcessIotjs(jerry_value_t process) {
   // IoT.js specific
-  iotjs_jval_t iotjs = jerry_create_object();
+  jerry_value_t iotjs = jerry_create_object();
   iotjs_jval_set_property_jval(process, IOTJS_MAGIC_STRING_IOTJS, iotjs);
 
   iotjs_jval_set_property_string_raw(iotjs, IOTJS_MAGIC_STRING_BOARD,
@@ -249,15 +250,15 @@ static void SetProcessIotjs(iotjs_jval_t process) {
 }
 
 
-static void SetProcessArgv(iotjs_jval_t process) {
+static void SetProcessArgv(jerry_value_t process) {
   const iotjs_environment_t* env = iotjs_environment_get();
   uint32_t argc = iotjs_environment_argc(env);
 
-  iotjs_jval_t argv = jerry_create_array(argc);
+  jerry_value_t argv = jerry_create_array(argc);
 
   for (uint32_t i = 0; i < argc; ++i) {
     const char* argvi = iotjs_environment_argv(env, i);
-    iotjs_jval_t arg = jerry_create_string((const jerry_char_t*)argvi);
+    jerry_value_t arg = jerry_create_string((const jerry_char_t*)argvi);
     iotjs_jval_set_property_by_index(argv, i, arg);
     jerry_release_value(arg);
   }
@@ -267,7 +268,7 @@ static void SetProcessArgv(iotjs_jval_t process) {
 }
 
 
-static void SetBuiltinModules(iotjs_jval_t builtin_modules) {
+static void SetBuiltinModules(jerry_value_t builtin_modules) {
   for (unsigned i = 0; js_modules[i].name; i++) {
     iotjs_jval_set_property_jval(builtin_modules, js_modules[i].name,
                                  jerry_create_boolean(true));
@@ -279,8 +280,8 @@ static void SetBuiltinModules(iotjs_jval_t builtin_modules) {
 }
 
 
-iotjs_jval_t InitProcess() {
-  iotjs_jval_t process = jerry_create_object();
+jerry_value_t InitProcess() {
+  jerry_value_t process = jerry_create_object();
 
   iotjs_jval_set_method(process, IOTJS_MAGIC_STRING_COMPILE, Compile);
   iotjs_jval_set_method(process, IOTJS_MAGIC_STRING_COMPILENATIVEPTR,
@@ -294,7 +295,7 @@ iotjs_jval_t InitProcess() {
   SetProcessEnv(process);
 
   // process.builtin_modules
-  iotjs_jval_t builtin_modules = jerry_create_object();
+  jerry_value_t builtin_modules = jerry_create_object();
   SetBuiltinModules(builtin_modules);
   iotjs_jval_set_property_jval(process, IOTJS_MAGIC_STRING_BUILTIN_MODULES,
                                builtin_modules);
@@ -326,7 +327,7 @@ iotjs_jval_t InitProcess() {
     SetProcessArgv(process);
   }
 
-  iotjs_jval_t wait_source_val = jerry_create_boolean(wait_source);
+  jerry_value_t wait_source_val = jerry_create_boolean(wait_source);
   iotjs_jval_set_property_jval(process, IOTJS_MAGIC_STRING_DEBUGGER_WAIT_SOURCE,
                                wait_source_val);
   jerry_release_value(wait_source_val);

--- a/src/modules/iotjs_module_pwm.c
+++ b/src/modules/iotjs_module_pwm.c
@@ -17,12 +17,12 @@
 #include "iotjs_module_pwm.h"
 #include "iotjs_objectwrap.h"
 
-static iotjs_pwm_t* iotjs_pwm_instance_from_jval(iotjs_jval_t jpwm);
+static iotjs_pwm_t* iotjs_pwm_instance_from_jval(jerry_value_t jpwm);
 
 IOTJS_DEFINE_NATIVE_HANDLE_INFO_THIS_MODULE(pwm);
 
 
-static iotjs_pwm_t* iotjs_pwm_create(iotjs_jval_t jpwm) {
+static iotjs_pwm_t* iotjs_pwm_create(jerry_value_t jpwm) {
   iotjs_pwm_t* pwm = IOTJS_ALLOC(iotjs_pwm_t);
   IOTJS_VALIDATED_STRUCT_CONSTRUCTOR(iotjs_pwm_t, pwm);
   iotjs_jobjectwrap_initialize(&_this->jobjectwrap, jpwm,
@@ -50,7 +50,7 @@ static void iotjs_pwm_destroy(iotjs_pwm_t* pwm) {
 #define THIS iotjs_pwm_reqwrap_t* pwm_reqwrap
 
 
-static iotjs_pwm_reqwrap_t* iotjs_pwm_reqwrap_create(iotjs_jval_t jcallback,
+static iotjs_pwm_reqwrap_t* iotjs_pwm_reqwrap_create(jerry_value_t jcallback,
                                                      iotjs_pwm_t* pwm,
                                                      PwmOp op) {
   iotjs_pwm_reqwrap_t* pwm_reqwrap = IOTJS_ALLOC(iotjs_pwm_reqwrap_t);
@@ -85,13 +85,13 @@ static uv_work_t* iotjs_pwm_reqwrap_req(THIS) {
 }
 
 
-static iotjs_jval_t iotjs_pwm_reqwrap_jcallback(THIS) {
+static jerry_value_t iotjs_pwm_reqwrap_jcallback(THIS) {
   IOTJS_VALIDATED_STRUCT_METHOD(iotjs_pwm_reqwrap_t, pwm_reqwrap);
   return iotjs_reqwrap_jcallback(&_this->reqwrap);
 }
 
 
-static iotjs_pwm_t* iotjs_pwm_instance_from_jval(iotjs_jval_t jpwm) {
+static iotjs_pwm_t* iotjs_pwm_instance_from_jval(jerry_value_t jpwm) {
   uintptr_t handle = iotjs_jval_get_object_native_handle(jpwm);
   return (iotjs_pwm_t*)handle;
 }
@@ -114,27 +114,27 @@ iotjs_pwm_t* iotjs_pwm_instance_from_reqwrap(THIS) {
 }
 
 
-static void iotjs_pwm_set_configuration(iotjs_jval_t jconfiguration,
+static void iotjs_pwm_set_configuration(jerry_value_t jconfiguration,
                                         iotjs_pwm_t* pwm) {
   IOTJS_VALIDATED_STRUCT_METHOD(iotjs_pwm_t, pwm);
 
-  iotjs_jval_t jpin =
+  jerry_value_t jpin =
       iotjs_jval_get_property(jconfiguration, IOTJS_MAGIC_STRING_PIN);
   _this->pin = iotjs_jval_as_number(jpin);
 
 #if defined(__linux__)
-  iotjs_jval_t jchip =
+  jerry_value_t jchip =
       iotjs_jval_get_property(jconfiguration, IOTJS_MAGIC_STRING_CHIP);
   _this->chip = iotjs_jval_as_number(jchip);
   jerry_release_value(jchip);
 #endif
 
-  iotjs_jval_t jperiod =
+  jerry_value_t jperiod =
       iotjs_jval_get_property(jconfiguration, IOTJS_MAGIC_STRING_PERIOD);
   if (jerry_value_is_number(jperiod))
     _this->period = iotjs_jval_as_number(jperiod);
 
-  iotjs_jval_t jduty_cycle =
+  jerry_value_t jduty_cycle =
       iotjs_jval_get_property(jconfiguration, IOTJS_MAGIC_STRING_DUTYCYCLE);
   if (jerry_value_is_number(jduty_cycle))
     _this->duty_cycle = iotjs_jval_as_number(jduty_cycle);
@@ -168,7 +168,7 @@ static void iotjs_pwm_after_worker(uv_work_t* work_req, int status) {
   bool result = req_data->result;
 
   if (status) {
-    iotjs_jval_t error = iotjs_jval_create_error("System error");
+    jerry_value_t error = iotjs_jval_create_error("System error");
     iotjs_jargs_append_jval(&jargs, error);
     jerry_release_value(error);
   } else {
@@ -215,7 +215,7 @@ static void iotjs_pwm_after_worker(uv_work_t* work_req, int status) {
     }
   }
 
-  iotjs_jval_t jcallback = iotjs_pwm_reqwrap_jcallback(req_wrap);
+  jerry_value_t jcallback = iotjs_pwm_reqwrap_jcallback(req_wrap);
   iotjs_make_callback(jcallback, jerry_create_undefined(), &jargs);
 
   iotjs_jargs_destroy(&jargs);
@@ -252,12 +252,12 @@ JS_FUNCTION(PWMConstructor) {
   DJS_CHECK_ARGS(2, object, function);
 
   // Create PWM object
-  iotjs_jval_t jpwm = JS_GET_THIS();
+  jerry_value_t jpwm = JS_GET_THIS();
   iotjs_pwm_t* pwm = iotjs_pwm_create(jpwm);
   IOTJS_ASSERT(pwm == iotjs_pwm_instance_from_jval(jpwm));
 
-  iotjs_jval_t jconfiguration = JS_GET_ARG(0, object);
-  iotjs_jval_t jcallback = JS_GET_ARG(1, function);
+  jerry_value_t jconfiguration = JS_GET_ARG(0, object);
+  jerry_value_t jcallback = JS_GET_ARG(1, function);
 
   // Set configuration
   iotjs_pwm_set_configuration(jconfiguration, pwm);
@@ -274,7 +274,7 @@ JS_FUNCTION(SetPeriod) {
   DJS_CHECK_ARGS(1, number);
   DJS_CHECK_ARG_IF_EXIST(1, function);
 
-  iotjs_jval_t jcallback = JS_GET_ARG_IF_EXIST(1, function);
+  jerry_value_t jcallback = JS_GET_ARG_IF_EXIST(1, function);
 
   IOTJS_VALIDATED_STRUCT_METHOD(iotjs_pwm_t, pwm);
   _this->period = JS_GET_ARG(0, number);
@@ -298,7 +298,7 @@ JS_FUNCTION(SetDutyCycle) {
   DJS_CHECK_ARGS(1, number);
   DJS_CHECK_ARG_IF_EXIST(1, function);
 
-  iotjs_jval_t jcallback = JS_GET_ARG_IF_EXIST(1, function);
+  jerry_value_t jcallback = JS_GET_ARG_IF_EXIST(1, function);
 
   IOTJS_VALIDATED_STRUCT_METHOD(iotjs_pwm_t, pwm);
   _this->duty_cycle = JS_GET_ARG(0, number);
@@ -322,7 +322,7 @@ JS_FUNCTION(SetEnable) {
   DJS_CHECK_ARGS(1, boolean);
   DJS_CHECK_ARG_IF_EXIST(1, function);
 
-  iotjs_jval_t jcallback = JS_GET_ARG_IF_EXIST(1, function);
+  jerry_value_t jcallback = JS_GET_ARG_IF_EXIST(1, function);
 
   IOTJS_VALIDATED_STRUCT_METHOD(iotjs_pwm_t, pwm);
   _this->enable = JS_GET_ARG(0, boolean);
@@ -344,7 +344,7 @@ JS_FUNCTION(Close) {
   JS_DECLARE_THIS_PTR(pwm, pwm);
   DJS_CHECK_ARG_IF_EXIST(0, function);
 
-  iotjs_jval_t jcallback = JS_GET_ARG_IF_EXIST(0, function);
+  jerry_value_t jcallback = JS_GET_ARG_IF_EXIST(0, function);
 
   if (!jerry_value_is_null(jcallback)) {
     PWM_ASYNC_COMMON_WORKER(iotjs_pwm_close, pwm, jcallback, kPwmOpClose);
@@ -358,11 +358,11 @@ JS_FUNCTION(Close) {
 }
 
 
-iotjs_jval_t InitPwm() {
-  iotjs_jval_t jpwm_constructor =
+jerry_value_t InitPwm() {
+  jerry_value_t jpwm_constructor =
       jerry_create_external_function(PWMConstructor);
 
-  iotjs_jval_t jprototype = jerry_create_object();
+  jerry_value_t jprototype = jerry_create_object();
 
   iotjs_jval_set_method(jprototype, IOTJS_MAGIC_STRING_SETPERIOD, SetPeriod);
   iotjs_jval_set_method(jprototype, IOTJS_MAGIC_STRING_SETDUTYCYCLE,

--- a/src/modules/iotjs_module_spi.c
+++ b/src/modules/iotjs_module_spi.c
@@ -22,7 +22,7 @@
 
 IOTJS_DEFINE_NATIVE_HANDLE_INFO_THIS_MODULE(spi);
 
-static iotjs_spi_t* iotjs_spi_create(iotjs_jval_t jspi) {
+static iotjs_spi_t* iotjs_spi_create(jerry_value_t jspi) {
   iotjs_spi_t* spi = IOTJS_ALLOC(iotjs_spi_t);
   IOTJS_VALIDATED_STRUCT_CONSTRUCTOR(iotjs_spi_t, spi);
   iotjs_jobjectwrap_initialize(&_this->jobjectwrap, jspi,
@@ -51,7 +51,7 @@ static void iotjs_spi_destroy(iotjs_spi_t* spi) {
 #define THIS iotjs_spi_reqwrap_t* spi_reqwrap
 
 
-static iotjs_spi_reqwrap_t* iotjs_spi_reqwrap_create(iotjs_jval_t jcallback,
+static iotjs_spi_reqwrap_t* iotjs_spi_reqwrap_create(jerry_value_t jcallback,
                                                      iotjs_spi_t* spi,
                                                      SpiOp op) {
   iotjs_spi_reqwrap_t* spi_reqwrap = IOTJS_ALLOC(iotjs_spi_reqwrap_t);
@@ -85,7 +85,7 @@ static uv_work_t* iotjs_spi_reqwrap_req(THIS) {
 }
 
 
-static iotjs_jval_t iotjs_spi_reqwrap_jcallback(THIS) {
+static jerry_value_t iotjs_spi_reqwrap_jcallback(THIS) {
   IOTJS_VALIDATED_STRUCT_METHOD(iotjs_spi_reqwrap_t, spi_reqwrap);
   return iotjs_reqwrap_jcallback(&_this->reqwrap);
 }
@@ -111,8 +111,8 @@ iotjs_spi_t* iotjs_spi_instance_from_reqwrap(THIS) {
 #undef THIS
 
 
-static int iotjs_spi_get_array_data(char** buf, iotjs_jval_t jarray) {
-  iotjs_jval_t jlength =
+static int iotjs_spi_get_array_data(char** buf, jerry_value_t jarray) {
+  jerry_value_t jlength =
       iotjs_jval_get_property(jarray, IOTJS_MAGIC_STRING_LENGTH);
   IOTJS_ASSERT(!jerry_value_is_undefined(jlength));
 
@@ -121,7 +121,7 @@ static int iotjs_spi_get_array_data(char** buf, iotjs_jval_t jarray) {
   *buf = iotjs_buffer_allocate(length);
 
   for (size_t i = 0; i < length; i++) {
-    iotjs_jval_t jdata = iotjs_jval_get_property_by_index(jarray, i);
+    jerry_value_t jdata = iotjs_jval_get_property_by_index(jarray, i);
     (*buf)[i] = iotjs_jval_as_number(jdata);
     jerry_release_value(jdata);
   }
@@ -132,8 +132,8 @@ static int iotjs_spi_get_array_data(char** buf, iotjs_jval_t jarray) {
 }
 
 
-static void iotjs_spi_set_array_buffer(iotjs_spi_t* spi, iotjs_jval_t jtx_buf,
-                                       iotjs_jval_t jrx_buf) {
+static void iotjs_spi_set_array_buffer(iotjs_spi_t* spi, jerry_value_t jtx_buf,
+                                       jerry_value_t jrx_buf) {
   IOTJS_VALIDATED_STRUCT_METHOD(iotjs_spi_t, spi);
 
   int tx_buf_len = iotjs_spi_get_array_data(&_this->tx_buf_data, jtx_buf);
@@ -146,8 +146,8 @@ static void iotjs_spi_set_array_buffer(iotjs_spi_t* spi, iotjs_jval_t jtx_buf,
 }
 
 
-static void iotjs_spi_set_buffer(iotjs_spi_t* spi, iotjs_jval_t jtx_buf,
-                                 iotjs_jval_t jrx_buf) {
+static void iotjs_spi_set_buffer(iotjs_spi_t* spi, jerry_value_t jtx_buf,
+                                 jerry_value_t jrx_buf) {
   IOTJS_VALIDATED_STRUCT_METHOD(iotjs_spi_t, spi);
 
   iotjs_bufferwrap_t* tx_buf = iotjs_bufferwrap_from_jbuffer(jtx_buf);
@@ -174,45 +174,46 @@ static void iotjs_spi_release_buffer(iotjs_spi_t* spi) {
 
 
 static void iotjs_spi_set_configuration(iotjs_spi_t* spi,
-                                        iotjs_jval_t joptions) {
+                                        jerry_value_t joptions) {
   IOTJS_VALIDATED_STRUCT_METHOD(iotjs_spi_t, spi);
 
 #if defined(__linux__)
-  iotjs_jval_t jdevice =
+  jerry_value_t jdevice =
       iotjs_jval_get_property(joptions, IOTJS_MAGIC_STRING_DEVICE);
   _this->device = iotjs_jval_as_string(jdevice);
   jerry_release_value(jdevice);
 #elif defined(__NUTTX__) || defined(__TIZENRT__)
-  iotjs_jval_t jbus = iotjs_jval_get_property(joptions, IOTJS_MAGIC_STRING_BUS);
+  jerry_value_t jbus =
+      iotjs_jval_get_property(joptions, IOTJS_MAGIC_STRING_BUS);
   _this->bus = iotjs_jval_as_number(jbus);
   jerry_release_value(jbus);
 #endif
-  iotjs_jval_t jmode =
+  jerry_value_t jmode =
       iotjs_jval_get_property(joptions, IOTJS_MAGIC_STRING_MODE);
   _this->mode = (SpiMode)iotjs_jval_as_number(jmode);
   jerry_release_value(jmode);
 
-  iotjs_jval_t jchip_select =
+  jerry_value_t jchip_select =
       iotjs_jval_get_property(joptions, IOTJS_MAGIC_STRING_CHIPSELECT);
   _this->chip_select = (SpiChipSelect)iotjs_jval_as_number(jchip_select);
   jerry_release_value(jchip_select);
 
-  iotjs_jval_t jmax_speed =
+  jerry_value_t jmax_speed =
       iotjs_jval_get_property(joptions, IOTJS_MAGIC_STRING_MAXSPEED);
   _this->max_speed = iotjs_jval_as_number(jmax_speed);
   jerry_release_value(jmax_speed);
 
-  iotjs_jval_t jbits_per_word =
+  jerry_value_t jbits_per_word =
       iotjs_jval_get_property(joptions, IOTJS_MAGIC_STRING_BITSPERWORD);
   _this->bits_per_word = (SpiOrder)iotjs_jval_as_number(jbits_per_word);
   jerry_release_value(jbits_per_word);
 
-  iotjs_jval_t jbit_order =
+  jerry_value_t jbit_order =
       iotjs_jval_get_property(joptions, IOTJS_MAGIC_STRING_BITORDER);
   _this->bit_order = (SpiOrder)iotjs_jval_as_number(jbit_order);
   jerry_release_value(jbit_order);
 
-  iotjs_jval_t jloopback =
+  jerry_value_t jloopback =
       iotjs_jval_get_property(joptions, IOTJS_MAGIC_STRING_LOOPBACK);
   _this->loopback = iotjs_jval_as_boolean(jloopback);
   jerry_release_value(jloopback);
@@ -276,7 +277,7 @@ static void iotjs_spi_after_work(uv_work_t* work_req, int status) {
           IOTJS_VALIDATED_STRUCT_METHOD(iotjs_spi_t, spi);
 
           // Append read data
-          iotjs_jval_t result_data =
+          jerry_value_t result_data =
               iotjs_jval_create_byte_array(_this->buf_len, _this->rx_buf_data);
           iotjs_jargs_append_jval(&jargs, result_data);
           jerry_release_value(result_data);
@@ -300,7 +301,7 @@ static void iotjs_spi_after_work(uv_work_t* work_req, int status) {
     }
   }
 
-  iotjs_jval_t jcallback = iotjs_spi_reqwrap_jcallback(req_wrap);
+  jerry_value_t jcallback = iotjs_spi_reqwrap_jcallback(req_wrap);
   iotjs_make_callback(jcallback, jerry_create_undefined(), &jargs);
 
   iotjs_jargs_destroy(&jargs);
@@ -309,7 +310,7 @@ static void iotjs_spi_after_work(uv_work_t* work_req, int status) {
 }
 
 
-iotjs_spi_t* iotjs_spi_get_instance(iotjs_jval_t jspi) {
+iotjs_spi_t* iotjs_spi_get_instance(jerry_value_t jspi) {
   uintptr_t handle = iotjs_jval_get_object_native_handle(jspi);
   return (iotjs_spi_t*)(handle);
 }
@@ -330,15 +331,15 @@ JS_FUNCTION(SpiConstructor) {
   DJS_CHECK_ARGS(2, object, function);
 
   // Create SPI object
-  iotjs_jval_t jspi = JS_GET_THIS();
+  jerry_value_t jspi = JS_GET_THIS();
   iotjs_spi_t* spi = iotjs_spi_create(jspi);
   IOTJS_ASSERT(spi == iotjs_spi_get_instance(jspi));
 
   // Set configuration
-  iotjs_jval_t jconfiguration = JS_GET_ARG(0, object);
+  jerry_value_t jconfiguration = JS_GET_ARG(0, object);
   iotjs_spi_set_configuration(spi, jconfiguration);
 
-  iotjs_jval_t jcallback = JS_GET_ARG(1, function);
+  jerry_value_t jcallback = JS_GET_ARG(1, function);
   SPI_ASYNC(open, spi, jcallback, kSpiOpOpen);
 
   return jerry_create_undefined();
@@ -352,11 +353,11 @@ JS_FUNCTION(TransferArray) {
   DJS_CHECK_ARGS(2, array, array);
   DJS_CHECK_ARG_IF_EXIST(2, function);
 
-  iotjs_jval_t jcallback = JS_GET_ARG_IF_EXIST(2, function);
+  jerry_value_t jcallback = JS_GET_ARG_IF_EXIST(2, function);
 
   iotjs_spi_set_array_buffer(spi, JS_GET_ARG(0, array), JS_GET_ARG(1, array));
 
-  iotjs_jval_t result = jerry_create_undefined();
+  jerry_value_t result = jerry_create_undefined();
   if (!jerry_value_is_null(jcallback)) {
     SPI_ASYNC(transfer, spi, jcallback, kSpiOpTransferArray);
   } else {
@@ -381,7 +382,7 @@ JS_FUNCTION(TransferBuffer) {
   DJS_CHECK_ARGS(2, object, object);
   DJS_CHECK_ARG_IF_EXIST(2, function);
 
-  iotjs_jval_t jcallback = JS_GET_ARG_IF_EXIST(2, function);
+  jerry_value_t jcallback = JS_GET_ARG_IF_EXIST(2, function);
 
   iotjs_spi_set_buffer(spi, JS_GET_ARG(0, object), JS_GET_ARG(1, object));
 
@@ -404,7 +405,7 @@ JS_FUNCTION(Close) {
 
   DJS_CHECK_ARG_IF_EXIST(0, function);
 
-  iotjs_jval_t jcallback = JS_GET_ARG_IF_EXIST(0, function);
+  jerry_value_t jcallback = JS_GET_ARG_IF_EXIST(0, function);
 
   if (!jerry_value_is_null(jcallback)) {
     SPI_ASYNC(close, spi, jcallback, kSpiOpClose);
@@ -418,12 +419,13 @@ JS_FUNCTION(Close) {
 }
 
 
-iotjs_jval_t InitSpi() {
-  iotjs_jval_t jspi = jerry_create_object();
-  iotjs_jval_t jspiConstructor = jerry_create_external_function(SpiConstructor);
+jerry_value_t InitSpi() {
+  jerry_value_t jspi = jerry_create_object();
+  jerry_value_t jspiConstructor =
+      jerry_create_external_function(SpiConstructor);
   iotjs_jval_set_property_jval(jspi, IOTJS_MAGIC_STRING_SPI, jspiConstructor);
 
-  iotjs_jval_t prototype = jerry_create_object();
+  jerry_value_t prototype = jerry_create_object();
   iotjs_jval_set_method(prototype, IOTJS_MAGIC_STRING_TRANSFERARRAY,
                         TransferArray);
   iotjs_jval_set_method(prototype, IOTJS_MAGIC_STRING_TRANSFERBUFFER,
@@ -435,7 +437,7 @@ iotjs_jval_t InitSpi() {
   jerry_release_value(jspiConstructor);
 
   // SPI mode properties
-  iotjs_jval_t jmode = jerry_create_object();
+  jerry_value_t jmode = jerry_create_object();
   iotjs_jval_set_property_number(jmode, IOTJS_MAGIC_STRING_0, kSpiMode_0);
   iotjs_jval_set_property_number(jmode, IOTJS_MAGIC_STRING_1, kSpiMode_1);
   iotjs_jval_set_property_number(jmode, IOTJS_MAGIC_STRING_2, kSpiMode_2);
@@ -444,14 +446,14 @@ iotjs_jval_t InitSpi() {
   jerry_release_value(jmode);
 
   // SPI mode properties
-  iotjs_jval_t jcs = jerry_create_object();
+  jerry_value_t jcs = jerry_create_object();
   iotjs_jval_set_property_number(jcs, IOTJS_MAGIC_STRING_NONE, kSpiCsNone);
   iotjs_jval_set_property_number(jcs, IOTJS_MAGIC_STRING_HIGH, kSpiCsHigh);
   iotjs_jval_set_property_jval(jspi, IOTJS_MAGIC_STRING_CHIPSELECT_U, jcs);
   jerry_release_value(jcs);
 
   // SPI order properties
-  iotjs_jval_t jbit_order = jerry_create_object();
+  jerry_value_t jbit_order = jerry_create_object();
   iotjs_jval_set_property_number(jbit_order, IOTJS_MAGIC_STRING_MSB,
                                  kSpiOrderMsb);
   iotjs_jval_set_property_number(jbit_order, IOTJS_MAGIC_STRING_LSB,

--- a/src/modules/iotjs_module_stm32f4dis.c
+++ b/src/modules/iotjs_module_stm32f4dis.c
@@ -17,8 +17,8 @@
 #include "iotjs_module_stm32f4dis.h"
 
 
-iotjs_jval_t InitStm32f4dis() {
-  iotjs_jval_t stm32f4dis = jerry_create_object();
+jerry_value_t InitStm32f4dis() {
+  jerry_value_t stm32f4dis = jerry_create_object();
 
 #if defined(__NUTTX__)
 

--- a/src/modules/iotjs_module_stm32f4dis.h
+++ b/src/modules/iotjs_module_stm32f4dis.h
@@ -17,7 +17,7 @@
 #define IOTJS_MODULE_STM32F4DIS_H
 
 
-void iotjs_stm32f4dis_pin_initialize(iotjs_jval_t jobj);
+void iotjs_stm32f4dis_pin_initialize(jerry_value_t jobj);
 
 
 #endif /* IOTJS_MODULE_STM32F4DIS_H */

--- a/src/modules/iotjs_module_tcp.c
+++ b/src/modules/iotjs_module_tcp.c
@@ -25,7 +25,7 @@
 IOTJS_DEFINE_NATIVE_HANDLE_INFO_THIS_MODULE(tcpwrap);
 
 
-iotjs_tcpwrap_t* iotjs_tcpwrap_create(iotjs_jval_t jtcp) {
+iotjs_tcpwrap_t* iotjs_tcpwrap_create(jerry_value_t jtcp) {
   iotjs_tcpwrap_t* tcpwrap = IOTJS_ALLOC(iotjs_tcpwrap_t);
   IOTJS_VALIDATED_STRUCT_CONSTRUCTOR(iotjs_tcpwrap_t, tcpwrap);
 
@@ -56,7 +56,7 @@ iotjs_tcpwrap_t* iotjs_tcpwrap_from_handle(uv_tcp_t* tcp_handle) {
 }
 
 
-iotjs_tcpwrap_t* iotjs_tcpwrap_from_jobject(iotjs_jval_t jtcp) {
+iotjs_tcpwrap_t* iotjs_tcpwrap_from_jobject(jerry_value_t jtcp) {
   iotjs_handlewrap_t* handlewrap = iotjs_handlewrap_from_jobject(jtcp);
   return (iotjs_tcpwrap_t*)handlewrap;
 }
@@ -69,7 +69,7 @@ uv_tcp_t* iotjs_tcpwrap_tcp_handle(iotjs_tcpwrap_t* tcpwrap) {
 }
 
 
-iotjs_jval_t iotjs_tcpwrap_jobject(iotjs_tcpwrap_t* tcpwrap) {
+jerry_value_t iotjs_tcpwrap_jobject(iotjs_tcpwrap_t* tcpwrap) {
   IOTJS_VALIDATED_STRUCT_METHOD(iotjs_tcpwrap_t, tcpwrap);
   return iotjs_handlewrap_jobject(&_this->handlewrap);
 }
@@ -81,7 +81,7 @@ iotjs_jval_t iotjs_tcpwrap_jobject(iotjs_tcpwrap_t* tcpwrap) {
 static void iotjs_connect_reqwrap_destroy(THIS);
 
 
-iotjs_connect_reqwrap_t* iotjs_connect_reqwrap_create(iotjs_jval_t jcallback) {
+iotjs_connect_reqwrap_t* iotjs_connect_reqwrap_create(jerry_value_t jcallback) {
   iotjs_connect_reqwrap_t* connect_reqwrap =
       IOTJS_ALLOC(iotjs_connect_reqwrap_t);
   IOTJS_VALIDATED_STRUCT_CONSTRUCTOR(iotjs_connect_reqwrap_t, connect_reqwrap);
@@ -110,7 +110,7 @@ uv_connect_t* iotjs_connect_reqwrap_req(THIS) {
 }
 
 
-iotjs_jval_t iotjs_connect_reqwrap_jcallback(THIS) {
+jerry_value_t iotjs_connect_reqwrap_jcallback(THIS) {
   IOTJS_VALIDATED_STRUCT_METHOD(iotjs_connect_reqwrap_t, connect_reqwrap);
   return iotjs_reqwrap_jcallback(&_this->reqwrap);
 }
@@ -124,7 +124,7 @@ iotjs_jval_t iotjs_connect_reqwrap_jcallback(THIS) {
 static void iotjs_write_reqwrap_destroy(THIS);
 
 
-iotjs_write_reqwrap_t* iotjs_write_reqwrap_create(iotjs_jval_t jcallback) {
+iotjs_write_reqwrap_t* iotjs_write_reqwrap_create(jerry_value_t jcallback) {
   iotjs_write_reqwrap_t* write_reqwrap = IOTJS_ALLOC(iotjs_write_reqwrap_t);
   IOTJS_VALIDATED_STRUCT_CONSTRUCTOR(iotjs_write_reqwrap_t, write_reqwrap);
   iotjs_reqwrap_initialize(&_this->reqwrap, jcallback, (uv_req_t*)&_this->req);
@@ -152,7 +152,7 @@ uv_write_t* iotjs_write_reqwrap_req(THIS) {
 }
 
 
-iotjs_jval_t iotjs_write_reqwrap_jcallback(THIS) {
+jerry_value_t iotjs_write_reqwrap_jcallback(THIS) {
   IOTJS_VALIDATED_STRUCT_METHOD(iotjs_write_reqwrap_t, write_reqwrap);
   return iotjs_reqwrap_jcallback(&_this->reqwrap);
 }
@@ -167,7 +167,7 @@ static void iotjs_shutdown_reqwrap_destroy(THIS);
 
 
 iotjs_shutdown_reqwrap_t* iotjs_shutdown_reqwrap_create(
-    iotjs_jval_t jcallback) {
+    jerry_value_t jcallback) {
   iotjs_shutdown_reqwrap_t* shutdown_reqwrap =
       IOTJS_ALLOC(iotjs_shutdown_reqwrap_t);
   IOTJS_VALIDATED_STRUCT_CONSTRUCTOR(iotjs_shutdown_reqwrap_t,
@@ -197,7 +197,7 @@ uv_shutdown_t* iotjs_shutdown_reqwrap_req(THIS) {
 }
 
 
-iotjs_jval_t iotjs_shutdown_reqwrap_jcallback(THIS) {
+jerry_value_t iotjs_shutdown_reqwrap_jcallback(THIS) {
   IOTJS_VALIDATED_STRUCT_METHOD(iotjs_shutdown_reqwrap_t, shutdown_reqwrap);
   return iotjs_reqwrap_jcallback(&_this->reqwrap);
 }
@@ -208,7 +208,7 @@ iotjs_jval_t iotjs_shutdown_reqwrap_jcallback(THIS) {
 JS_FUNCTION(TCP) {
   DJS_CHECK_THIS();
 
-  iotjs_jval_t jtcp = JS_GET_THIS();
+  jerry_value_t jtcp = JS_GET_THIS();
   iotjs_tcpwrap_create(jtcp);
   return jerry_create_undefined();
 }
@@ -224,10 +224,10 @@ void AfterClose(uv_handle_t* handle) {
   iotjs_handlewrap_t* wrap = iotjs_handlewrap_from_handle(handle);
 
   // tcp object.
-  iotjs_jval_t jtcp = iotjs_handlewrap_jobject(wrap);
+  jerry_value_t jtcp = iotjs_handlewrap_jobject(wrap);
 
   // callback function.
-  iotjs_jval_t jcallback =
+  jerry_value_t jcallback =
       iotjs_jval_get_property(jtcp, IOTJS_MAGIC_STRING_ONCLOSE);
   if (jerry_value_is_function(jcallback)) {
     iotjs_make_callback(jcallback, jerry_create_undefined(),
@@ -280,7 +280,7 @@ static void AfterConnect(uv_connect_t* req, int status) {
 
   // Take callback function object.
   // function afterConnect(status)
-  iotjs_jval_t jcallback = iotjs_connect_reqwrap_jcallback(req_wrap);
+  jerry_value_t jcallback = iotjs_connect_reqwrap_jcallback(req_wrap);
   IOTJS_ASSERT(jerry_value_is_function(jcallback));
 
   // Only parameter is status code.
@@ -309,7 +309,7 @@ JS_FUNCTION(Connect) {
 
   iotjs_string_t address = JS_GET_ARG(0, string);
   int port = JS_GET_ARG(1, number);
-  iotjs_jval_t jcallback = JS_GET_ARG(2, function);
+  jerry_value_t jcallback = JS_GET_ARG(2, function);
 
   sockaddr_in addr;
   int err = uv_ip4_addr(iotjs_string_data(&address), port, &addr);
@@ -343,10 +343,10 @@ static void OnConnection(uv_stream_t* handle, int status) {
   iotjs_tcpwrap_t* tcp_wrap = iotjs_tcpwrap_from_handle((uv_tcp_t*)handle);
 
   // Tcp object
-  iotjs_jval_t jtcp = iotjs_tcpwrap_jobject(tcp_wrap);
+  jerry_value_t jtcp = iotjs_tcpwrap_jobject(tcp_wrap);
 
   // `onconnection` callback.
-  iotjs_jval_t jonconnection =
+  jerry_value_t jonconnection =
       iotjs_jval_get_property(jtcp, IOTJS_MAGIC_STRING_ONCONNECTION);
   IOTJS_ASSERT(jerry_value_is_function(jonconnection));
 
@@ -358,11 +358,11 @@ static void OnConnection(uv_stream_t* handle, int status) {
 
   if (status == 0) {
     // Create client socket handle wrapper.
-    iotjs_jval_t jcreate_tcp =
+    jerry_value_t jcreate_tcp =
         iotjs_jval_get_property(jtcp, IOTJS_MAGIC_STRING_CREATETCP);
     IOTJS_ASSERT(jerry_value_is_function(jcreate_tcp));
 
-    iotjs_jval_t jclient_tcp =
+    jerry_value_t jclient_tcp =
         iotjs_jhelper_call_ok(jcreate_tcp, jerry_create_undefined(),
                               iotjs_jargs_get_empty());
     IOTJS_ASSERT(jerry_value_is_object(jclient_tcp));
@@ -411,7 +411,7 @@ void AfterWrite(uv_write_t* req, int status) {
   IOTJS_ASSERT(tcp_wrap != NULL);
 
   // Take callback function object.
-  iotjs_jval_t jcallback = iotjs_write_reqwrap_jcallback(req_wrap);
+  jerry_value_t jcallback = iotjs_write_reqwrap_jcallback(req_wrap);
 
   // Only parameter is status code.
   iotjs_jargs_t args = iotjs_jargs_create(1);
@@ -432,7 +432,7 @@ JS_FUNCTION(Write) {
   JS_DECLARE_THIS_PTR(tcpwrap, tcp_wrap);
   DJS_CHECK_ARGS(2, object, function);
 
-  const iotjs_jval_t jbuffer = JS_GET_ARG(0, object);
+  const jerry_value_t jbuffer = JS_GET_ARG(0, object);
   iotjs_bufferwrap_t* buffer_wrap = iotjs_bufferwrap_from_jbuffer(jbuffer);
   char* buffer = iotjs_bufferwrap_buffer(buffer_wrap);
   size_t len = iotjs_bufferwrap_length(buffer_wrap);
@@ -441,7 +441,7 @@ JS_FUNCTION(Write) {
   buf.base = buffer;
   buf.len = len;
 
-  iotjs_jval_t arg1 = JS_GET_ARG(1, object);
+  jerry_value_t arg1 = JS_GET_ARG(1, object);
   iotjs_write_reqwrap_t* req_wrap = iotjs_write_reqwrap_create(arg1);
 
   int err = uv_write(iotjs_write_reqwrap_req(req_wrap),
@@ -470,15 +470,15 @@ void OnRead(uv_stream_t* handle, ssize_t nread, const uv_buf_t* buf) {
   iotjs_tcpwrap_t* tcp_wrap = iotjs_tcpwrap_from_handle((uv_tcp_t*)handle);
 
   // tcp handle
-  iotjs_jval_t jtcp = iotjs_tcpwrap_jobject(tcp_wrap);
+  jerry_value_t jtcp = iotjs_tcpwrap_jobject(tcp_wrap);
 
   // socket object
-  iotjs_jval_t jsocket =
+  jerry_value_t jsocket =
       iotjs_jval_get_property(jtcp, IOTJS_MAGIC_STRING_OWNER);
   IOTJS_ASSERT(jerry_value_is_object(jsocket));
 
   // onread callback
-  iotjs_jval_t jonread =
+  jerry_value_t jonread =
       iotjs_jval_get_property(jtcp, IOTJS_MAGIC_STRING_ONREAD);
   IOTJS_ASSERT(jerry_value_is_function(jonread));
 
@@ -499,7 +499,7 @@ void OnRead(uv_stream_t* handle, ssize_t nread, const uv_buf_t* buf) {
       iotjs_make_callback(jonread, jerry_create_undefined(), &jargs);
     }
   } else {
-    iotjs_jval_t jbuffer = iotjs_bufferwrap_create_buffer((size_t)nread);
+    jerry_value_t jbuffer = iotjs_bufferwrap_create_buffer((size_t)nread);
     iotjs_bufferwrap_t* buffer_wrap = iotjs_bufferwrap_from_jbuffer(jbuffer);
 
     iotjs_bufferwrap_copy(buffer_wrap, buf->base, (size_t)nread);
@@ -534,7 +534,7 @@ static void AfterShutdown(uv_shutdown_t* req, int status) {
   IOTJS_ASSERT(tcp_wrap != NULL);
 
   // function onShutdown(status)
-  iotjs_jval_t jonshutdown = iotjs_shutdown_reqwrap_jcallback(req_wrap);
+  jerry_value_t jonshutdown = iotjs_shutdown_reqwrap_jcallback(req_wrap);
   IOTJS_ASSERT(jerry_value_is_function(jonshutdown));
 
   iotjs_jargs_t args = iotjs_jargs_create(1);
@@ -553,7 +553,7 @@ JS_FUNCTION(Shutdown) {
 
   DJS_CHECK_ARGS(1, function);
 
-  iotjs_jval_t arg0 = JS_GET_ARG(0, object);
+  jerry_value_t arg0 = JS_GET_ARG(0, object);
   iotjs_shutdown_reqwrap_t* req_wrap = iotjs_shutdown_reqwrap_create(arg0);
 
   int err = uv_shutdown(iotjs_shutdown_reqwrap_req(req_wrap),
@@ -594,7 +594,7 @@ JS_FUNCTION(ErrName) {
 }
 
 // used in iotjs_module_udp.cpp
-void AddressToJS(iotjs_jval_t obj, const sockaddr* addr) {
+void AddressToJS(jerry_value_t obj, const sockaddr* addr) {
   char ip[INET6_ADDRSTRLEN];
   const sockaddr_in* a4;
   const sockaddr_in6* a6;
@@ -646,10 +646,10 @@ JS_FUNCTION(GetSockeName) {
   return jerry_create_number(err);
 }
 
-iotjs_jval_t InitTcp() {
-  iotjs_jval_t tcp = jerry_create_external_function(TCP);
+jerry_value_t InitTcp() {
+  jerry_value_t tcp = jerry_create_external_function(TCP);
 
-  iotjs_jval_t prototype = jerry_create_object();
+  jerry_value_t prototype = jerry_create_object();
 
   iotjs_jval_set_property_jval(tcp, IOTJS_MAGIC_STRING_PROTOTYPE, prototype);
   iotjs_jval_set_method(tcp, IOTJS_MAGIC_STRING_ERRNAME, ErrName);

--- a/src/modules/iotjs_module_tcp.h
+++ b/src/modules/iotjs_module_tcp.h
@@ -35,13 +35,13 @@ typedef struct {
 } IOTJS_VALIDATED_STRUCT(iotjs_tcpwrap_t);
 
 
-iotjs_tcpwrap_t* iotjs_tcpwrap_create(iotjs_jval_t jtcp);
+iotjs_tcpwrap_t* iotjs_tcpwrap_create(jerry_value_t jtcp);
 
 iotjs_tcpwrap_t* iotjs_tcpwrap_from_handle(uv_tcp_t* handle);
-iotjs_tcpwrap_t* iotjs_tcpwrap_from_jobject(iotjs_jval_t jtcp);
+iotjs_tcpwrap_t* iotjs_tcpwrap_from_jobject(jerry_value_t jtcp);
 
 uv_tcp_t* iotjs_tcpwrap_tcp_handle(iotjs_tcpwrap_t* tcpwrap);
-iotjs_jval_t iotjs_tcpwrap_jobject(iotjs_tcpwrap_t* tcpwrap);
+jerry_value_t iotjs_tcpwrap_jobject(iotjs_tcpwrap_t* tcpwrap);
 
 
 typedef struct {
@@ -50,10 +50,10 @@ typedef struct {
 } IOTJS_VALIDATED_STRUCT(iotjs_connect_reqwrap_t);
 
 #define THIS iotjs_connect_reqwrap_t* connect_reqwrap
-iotjs_connect_reqwrap_t* iotjs_connect_reqwrap_create(iotjs_jval_t jcallback);
+iotjs_connect_reqwrap_t* iotjs_connect_reqwrap_create(jerry_value_t jcallback);
 void iotjs_connect_reqwrap_dispatched(THIS);
 uv_connect_t* iotjs_connect_reqwrap_req(THIS);
-iotjs_jval_t iotjs_connect_reqwrap_jcallback(THIS);
+jerry_value_t iotjs_connect_reqwrap_jcallback(THIS);
 #undef THIS
 
 
@@ -63,10 +63,10 @@ typedef struct {
 } IOTJS_VALIDATED_STRUCT(iotjs_write_reqwrap_t);
 
 #define THIS iotjs_write_reqwrap_t* write_reqwrap
-iotjs_write_reqwrap_t* iotjs_write_reqwrap_create(iotjs_jval_t jcallback);
+iotjs_write_reqwrap_t* iotjs_write_reqwrap_create(jerry_value_t jcallback);
 void iotjs_write_reqwrap_dispatched(THIS);
 uv_write_t* iotjs_write_reqwrap_req(THIS);
-iotjs_jval_t iotjs_write_reqwrap_jcallback(THIS);
+jerry_value_t iotjs_write_reqwrap_jcallback(THIS);
 #undef THIS
 
 
@@ -76,14 +76,15 @@ typedef struct {
 } IOTJS_VALIDATED_STRUCT(iotjs_shutdown_reqwrap_t);
 
 #define THIS iotjs_shutdown_reqwrap_t* shutdown_reqwrap
-iotjs_shutdown_reqwrap_t* iotjs_shutdown_reqwrap_create(iotjs_jval_t jcallback);
+iotjs_shutdown_reqwrap_t* iotjs_shutdown_reqwrap_create(
+    jerry_value_t jcallback);
 void iotjs_shutdown_reqwrap_dispatched(THIS);
 uv_shutdown_t* iotjs_shutdown_reqwrap_req(THIS);
-iotjs_jval_t iotjs_shutdown_reqwrap_jcallback(THIS);
+jerry_value_t iotjs_shutdown_reqwrap_jcallback(THIS);
 #undef THIS
 
 
-void AddressToJS(iotjs_jval_t obj, const sockaddr* addr);
+void AddressToJS(jerry_value_t obj, const sockaddr* addr);
 
 
 #endif /* IOTJS_MODULE_TCP_H */

--- a/src/modules/iotjs_module_testdriver.c
+++ b/src/modules/iotjs_module_testdriver.c
@@ -30,7 +30,7 @@ JS_FUNCTION(IsAliveExceptFor) {
   } else {
     JS_CHECK(jerry_value_is_object(jargv[0]));
 
-    iotjs_jval_t jtimer =
+    jerry_value_t jtimer =
         iotjs_jval_get_property(jargv[0], IOTJS_MAGIC_STRING_HANDLER);
 
     iotjs_timerwrap_t* timer_wrap = iotjs_timerwrap_from_jobject(jtimer);
@@ -60,8 +60,8 @@ JS_FUNCTION(IsAliveExceptFor) {
 }
 
 
-iotjs_jval_t InitTestdriver() {
-  iotjs_jval_t testdriver = jerry_create_object();
+jerry_value_t InitTestdriver() {
+  jerry_value_t testdriver = jerry_create_object();
   iotjs_jval_set_method(testdriver, IOTJS_MAGIC_STRING_ISALIVEEXCEPTFOR,
                         IsAliveExceptFor);
 

--- a/src/modules/iotjs_module_timer.c
+++ b/src/modules/iotjs_module_timer.c
@@ -22,7 +22,7 @@ static void iotjs_timerwrap_on_timeout(iotjs_timerwrap_t* timerwrap);
 IOTJS_DEFINE_NATIVE_HANDLE_INFO_THIS_MODULE(timerwrap);
 
 
-iotjs_timerwrap_t* iotjs_timerwrap_create(const iotjs_jval_t jtimer) {
+iotjs_timerwrap_t* iotjs_timerwrap_create(const jerry_value_t jtimer) {
   iotjs_timerwrap_t* timerwrap = IOTJS_ALLOC(iotjs_timerwrap_t);
   uv_timer_t* uv_timer = IOTJS_ALLOC(uv_timer_t);
   IOTJS_VALIDATED_STRUCT_CONSTRUCTOR(iotjs_timerwrap_t, timerwrap);
@@ -86,8 +86,8 @@ static void iotjs_timerwrap_on_timeout(iotjs_timerwrap_t* timerwrap) {
   IOTJS_VALIDATABLE_STRUCT_METHOD_VALIDATE(iotjs_timerwrap_t, timerwrap);
 
   // Call javascript timeout handler function.
-  iotjs_jval_t jobject = iotjs_timerwrap_jobject(timerwrap);
-  iotjs_jval_t jcallback =
+  jerry_value_t jobject = iotjs_timerwrap_jobject(timerwrap);
+  jerry_value_t jcallback =
       iotjs_jval_get_property(jobject, IOTJS_MAGIC_STRING_HANDLETIMEOUT);
   iotjs_make_callback(jcallback, jobject, iotjs_jargs_get_empty());
   jerry_release_value(jcallback);
@@ -100,9 +100,9 @@ uv_timer_t* iotjs_timerwrap_handle(iotjs_timerwrap_t* timerwrap) {
 }
 
 
-iotjs_jval_t iotjs_timerwrap_jobject(iotjs_timerwrap_t* timerwrap) {
+jerry_value_t iotjs_timerwrap_jobject(iotjs_timerwrap_t* timerwrap) {
   IOTJS_VALIDATED_STRUCT_METHOD(iotjs_timerwrap_t, timerwrap);
-  iotjs_jval_t jobject = iotjs_handlewrap_jobject(&_this->handlewrap);
+  jerry_value_t jobject = iotjs_handlewrap_jobject(&_this->handlewrap);
   IOTJS_ASSERT(jerry_value_is_object(jobject));
   return jobject;
 }
@@ -117,7 +117,7 @@ iotjs_timerwrap_t* iotjs_timerwrap_from_handle(uv_timer_t* timer_handle) {
 }
 
 
-iotjs_timerwrap_t* iotjs_timerwrap_from_jobject(const iotjs_jval_t jtimer) {
+iotjs_timerwrap_t* iotjs_timerwrap_from_jobject(const jerry_value_t jtimer) {
   iotjs_handlewrap_t* handlewrap = iotjs_handlewrap_from_jobject(jtimer);
   return (iotjs_timerwrap_t*)handlewrap;
 }
@@ -151,11 +151,11 @@ JS_FUNCTION(Stop) {
 JS_FUNCTION(Timer) {
   JS_CHECK_THIS();
 
-  const iotjs_jval_t jtimer = JS_GET_THIS();
+  const jerry_value_t jtimer = JS_GET_THIS();
 
   iotjs_timerwrap_t* timer_wrap = iotjs_timerwrap_create(jtimer);
 
-  iotjs_jval_t jobject = iotjs_timerwrap_jobject(timer_wrap);
+  jerry_value_t jobject = iotjs_timerwrap_jobject(timer_wrap);
   IOTJS_ASSERT(jerry_value_is_object(jobject));
   IOTJS_ASSERT(iotjs_jval_get_object_native_handle(jtimer) != 0);
 
@@ -163,10 +163,10 @@ JS_FUNCTION(Timer) {
 }
 
 
-iotjs_jval_t InitTimer() {
-  iotjs_jval_t timer = jerry_create_external_function(Timer);
+jerry_value_t InitTimer() {
+  jerry_value_t timer = jerry_create_external_function(Timer);
 
-  iotjs_jval_t prototype = jerry_create_object();
+  jerry_value_t prototype = jerry_create_object();
   iotjs_jval_set_property_jval(timer, IOTJS_MAGIC_STRING_PROTOTYPE, prototype);
 
   iotjs_jval_set_method(prototype, IOTJS_MAGIC_STRING_START, Start);

--- a/src/modules/iotjs_module_timer.h
+++ b/src/modules/iotjs_module_timer.h
@@ -26,13 +26,13 @@ typedef struct {
 } IOTJS_VALIDATED_STRUCT(iotjs_timerwrap_t);
 
 
-iotjs_timerwrap_t* iotjs_timerwrap_create(const iotjs_jval_t jtimer);
+iotjs_timerwrap_t* iotjs_timerwrap_create(const jerry_value_t jtimer);
 
-iotjs_timerwrap_t* iotjs_timerwrap_from_jobject(const iotjs_jval_t jtimer);
+iotjs_timerwrap_t* iotjs_timerwrap_from_jobject(const jerry_value_t jtimer);
 iotjs_timerwrap_t* iotjs_timerwrap_from_handle(uv_timer_t* timer_handle);
 
 uv_timer_t* iotjs_timerwrap_handle(iotjs_timerwrap_t* timerwrap);
-iotjs_jval_t iotjs_timerwrap_jobject(iotjs_timerwrap_t* timerwrap);
+jerry_value_t iotjs_timerwrap_jobject(iotjs_timerwrap_t* timerwrap);
 
 // Start timer.
 int iotjs_timerwrap_start(iotjs_timerwrap_t* timerwrap, uint64_t timeout,

--- a/src/modules/iotjs_module_uart.h
+++ b/src/modules/iotjs_module_uart.h
@@ -34,7 +34,7 @@ typedef enum {
 
 typedef struct {
   iotjs_handlewrap_t handlewrap;
-  iotjs_jval_t jemitter_this;
+  jerry_value_t jemitter_this;
   int device_fd;
   int baud_rate;
   uint8_t data_bits;

--- a/src/modules/iotjs_module_udp.h
+++ b/src/modules/iotjs_module_udp.h
@@ -29,13 +29,13 @@ typedef struct {
 } IOTJS_VALIDATED_STRUCT(iotjs_udpwrap_t);
 
 
-iotjs_udpwrap_t* iotjs_udpwrap_create(iotjs_jval_t judp);
+iotjs_udpwrap_t* iotjs_udpwrap_create(jerry_value_t judp);
 
 iotjs_udpwrap_t* iotjs_udpwrap_from_handle(uv_udp_t* handle);
-iotjs_udpwrap_t* iotjs_udpwrap_from_jobject(iotjs_jval_t judp);
+iotjs_udpwrap_t* iotjs_udpwrap_from_jobject(jerry_value_t judp);
 
 uv_udp_t* iotjs_udpwrap_udp_handle(iotjs_udpwrap_t* udpwrap);
-iotjs_jval_t iotjs_udpwrap_jobject(iotjs_udpwrap_t* udpwrap);
+jerry_value_t iotjs_udpwrap_jobject(iotjs_udpwrap_t* udpwrap);
 
 
 typedef struct {
@@ -46,13 +46,13 @@ typedef struct {
 
 #define THIS iotjs_send_reqwrap_t* send_reqwrap
 
-iotjs_send_reqwrap_t* iotjs_send_reqwrap_create(iotjs_jval_t jcallback,
+iotjs_send_reqwrap_t* iotjs_send_reqwrap_create(jerry_value_t jcallback,
                                                 const size_t msg_size);
 
 void iotjs_send_reqwrap_dispatched(THIS);
 
 uv_udp_send_t* iotjs_send_reqwrap_req(THIS);
-iotjs_jval_t iotjs_send_reqwrap_jcallback(THIS);
+jerry_value_t iotjs_send_reqwrap_jcallback(THIS);
 
 #undef THIS
 

--- a/src/modules/linux/iotjs_module_blehcisocket-linux.c
+++ b/src/modules/linux/iotjs_module_blehcisocket-linux.c
@@ -297,14 +297,14 @@ void iotjs_blehcisocket_poll(THIS) {
       }
     }
 
-    iotjs_jval_t jhcisocket = iotjs_jobjectwrap_jobject(&_this->jobjectwrap);
-    iotjs_jval_t jemit = iotjs_jval_get_property(jhcisocket, "emit");
+    jerry_value_t jhcisocket = iotjs_jobjectwrap_jobject(&_this->jobjectwrap);
+    jerry_value_t jemit = iotjs_jval_get_property(jhcisocket, "emit");
     IOTJS_ASSERT(jerry_value_is_function(jemit));
 
     iotjs_jargs_t jargs = iotjs_jargs_create(2);
-    iotjs_jval_t str = jerry_create_string((const jerry_char_t*)"data");
+    jerry_value_t str = jerry_create_string((const jerry_char_t*)"data");
     IOTJS_ASSERT(length >= 0);
-    iotjs_jval_t jbuf = iotjs_bufferwrap_create_buffer((size_t)length);
+    jerry_value_t jbuf = iotjs_bufferwrap_create_buffer((size_t)length);
     iotjs_bufferwrap_t* buf_wrap = iotjs_bufferwrap_from_jbuffer(jbuf);
     iotjs_bufferwrap_copy(buf_wrap, data, (size_t)length);
     iotjs_jargs_append_jval(&jargs, str);
@@ -338,13 +338,13 @@ void iotjs_blehcisocket_write(THIS, char* data, size_t length) {
 void iotjs_blehcisocket_emitErrnoError(THIS) {
   IOTJS_VALIDATED_STRUCT_METHOD(iotjs_blehcisocket_t, blehcisocket);
 
-  iotjs_jval_t jhcisocket = iotjs_jobjectwrap_jobject(&_this->jobjectwrap);
-  iotjs_jval_t jemit = iotjs_jval_get_property(jhcisocket, "emit");
+  jerry_value_t jhcisocket = iotjs_jobjectwrap_jobject(&_this->jobjectwrap);
+  jerry_value_t jemit = iotjs_jval_get_property(jhcisocket, "emit");
   IOTJS_ASSERT(jerry_value_is_function(jemit));
 
   iotjs_jargs_t jargs = iotjs_jargs_create(2);
-  iotjs_jval_t str = jerry_create_string((const jerry_char_t*)"error");
-  iotjs_jval_t jerror = iotjs_jval_create_error(strerror(errno));
+  jerry_value_t str = jerry_create_string((const jerry_char_t*)"error");
+  jerry_value_t jerror = iotjs_jval_create_error(strerror(errno));
   iotjs_jargs_append_jval(&jargs, str);
   iotjs_jargs_append_jval(&jargs, jerror);
   iotjs_jhelper_call_ok(jemit, jhcisocket, &jargs);

--- a/src/modules/linux/iotjs_module_gpio-linux.c
+++ b/src/modules/linux/iotjs_module_gpio-linux.c
@@ -79,8 +79,8 @@ static void gpio_set_value_fd(iotjs_gpio_t* gpio, int fd) {
 static void gpio_emit_change_event(iotjs_gpio_t* gpio) {
   IOTJS_VALIDATED_STRUCT_METHOD(iotjs_gpio_t, gpio);
 
-  iotjs_jval_t jgpio = iotjs_jobjectwrap_jobject(&_this->jobjectwrap);
-  iotjs_jval_t jonChange = iotjs_jval_get_property(jgpio, "onChange");
+  jerry_value_t jgpio = iotjs_jobjectwrap_jobject(&_this->jobjectwrap);
+  jerry_value_t jonChange = iotjs_jval_get_property(jgpio, "onChange");
   IOTJS_ASSERT(jerry_value_is_function(jonChange));
 
   iotjs_jhelper_call_ok(jonChange, jgpio, iotjs_jargs_get_empty());

--- a/src/modules/nuttx/iotjs_module_stm32f4dis-nuttx.c
+++ b/src/modules/nuttx/iotjs_module_stm32f4dis-nuttx.c
@@ -24,7 +24,7 @@
 
 
 #if ENABLE_MODULE_ADC
-static void iotjs_pin_initialize_adc(iotjs_jval_t jobj) {
+static void iotjs_pin_initialize_adc(jerry_value_t jobj) {
   unsigned int number_bit;
 
 // ADC pin name is "ADC.(number)_(timer)".
@@ -64,7 +64,7 @@ static void iotjs_pin_initialize_adc(iotjs_jval_t jobj) {
 
 #if ENABLE_MODULE_GPIO
 
-static void iotjs_pin_initialize_gpio(iotjs_jval_t jobj) {
+static void iotjs_pin_initialize_gpio(jerry_value_t jobj) {
 // Set GPIO pin from configuration bits of nuttx.
 // GPIO pin name is "P(port)(pin)".
 #define SET_GPIO_CONSTANT(port, pin)                   \
@@ -107,7 +107,7 @@ static void iotjs_pin_initialize_gpio(iotjs_jval_t jobj) {
 
 #if ENABLE_MODULE_PWM
 
-static void iotjs_pin_initialize_pwm(iotjs_jval_t jobj) {
+static void iotjs_pin_initialize_pwm(jerry_value_t jobj) {
   unsigned int timer_bit;
 
 // Set PWM pin from configuration bits of nuttx.
@@ -122,8 +122,8 @@ static void iotjs_pin_initialize_pwm(iotjs_jval_t jobj) {
   SET_GPIO_CONSTANT(timer, channel, 1);           \
   SET_GPIO_CONSTANT(timer, channel, 2);
 
-#define SET_GPIO_CONSTANT_TIM(timer)                \
-  iotjs_jval_t jtim##timer = jerry_create_object(); \
+#define SET_GPIO_CONSTANT_TIM(timer)                 \
+  jerry_value_t jtim##timer = jerry_create_object(); \
   iotjs_jval_set_property_jval(jobj, "PWM" #timer, jtim##timer);
 
 #define SET_GPIO_CONSTANT_TIM_1(timer) \
@@ -181,8 +181,8 @@ static void iotjs_pin_initialize_pwm(iotjs_jval_t jobj) {
 #endif /* ENABLE_MODULE_PWM */
 
 
-void iotjs_stm32f4dis_pin_initialize(iotjs_jval_t jobj) {
-  iotjs_jval_t jpin = jerry_create_object();
+void iotjs_stm32f4dis_pin_initialize(jerry_value_t jobj) {
+  jerry_value_t jpin = jerry_create_object();
   iotjs_jval_set_property_jval(jobj, "pin", jpin);
 
 #if ENABLE_MODULE_ADC

--- a/test/external_modules/mymodule2/my_module.c
+++ b/test/external_modules/mymodule2/my_module.c
@@ -15,7 +15,7 @@
 
 #include "iotjs_def.h"
 
-iotjs_jval_t InitMyNativeModule() {
+jerry_value_t InitMyNativeModule() {
   jerry_value_t mymodule = jerry_create_object();
   iotjs_jval_set_property_string_raw(mymodule, "message", "Hello world!");
   return mymodule;


### PR DESCRIPTION
Related issue: #1201 

IoT.js-DCO-1.0-Signed-off-by: László Langó llango.u-szeged@partner.samsung.com