### PR TITLE
Multiple source file sending

### DIFF
--- a/src/iotjs.c
+++ b/src/iotjs.c
@@ -182,10 +182,6 @@ static void iotjs_uv_walk_to_close_callback(uv_handle_t* handle, void* arg) {
   iotjs_handlewrap_close(handle_wrap, NULL);
 }
 
-static jerry_value_t dummy_wait_for_client_source_cb() {
-  return jerry_create_undefined();
-}
-
 int iotjs_entry(int argc, char** argv) {
   int ret_code = 0;
 
@@ -221,19 +217,6 @@ int iotjs_entry(int argc, char** argv) {
   int res = uv_loop_close(iotjs_environment_loop(env));
   IOTJS_ASSERT(res == 0);
 
-  // Check whether context reset was sent or not.
-  if (iotjs_environment_config(env)->debugger != NULL) {
-    jerry_value_t res;
-    jerry_debugger_wait_for_source_status_t receive_status;
-    receive_status =
-        jerry_debugger_wait_for_client_source(dummy_wait_for_client_source_cb,
-                                              NULL, &res);
-
-    if (receive_status == JERRY_DEBUGGER_CONTEXT_RESET_RECEIVED) {
-      iotjs_environment_config(env)->debugger->context_reset = true;
-    }
-    jerry_release_value(res);
-  }
 
   iotjs_jerry_release(env);
 

--- a/src/js/module.js
+++ b/src/js/module.js
@@ -28,6 +28,7 @@ module.exports = iotjs_module_t;
 
 
 iotjs_module_t.cache = {};
+iotjs_module_t.remoteCache = {};
 
 
 var cwd;
@@ -210,7 +211,7 @@ iotjs_module_t.loadRemote = function(filename, source) {
 
   module.filename = filename;
   module.compile(filename, source);
-  iotjs_module_t.cache[filename] = module;
+  iotjs_module_t.remoteCache[filename] = module;
 
   return module.exports;
 };
@@ -225,7 +226,9 @@ iotjs_module_t.prototype.compile = function(filename, source) {
 iotjs_module_t.runMain = function() {
   if (process.debuggerWaitSource) {
     var fn = process.debuggerGetSource();
-    iotjs_module_t.loadRemote(fn[0], fn[1]);
+    fn.forEach(function (e) {
+      iotjs_module_t.loadRemote(e[0], e[1]);
+    });
   } else {
     iotjs_module_t.load(process.argv[1], null);
   }


### PR DESCRIPTION
This patch makes iot.js capable of receiving multiple sources from the debugger client.
These sources can also require each other.

IoT.js-DCO-1.0-Signed-off-by: Daniel Balla dballa@inf.u-szeged.hu