### PR TITLE
Remove module.wrap and module.wrapper from module.js

### DIFF
--- a/src/js/module.js
+++ b/src/js/module.js
@@ -28,8 +28,6 @@ module.exports = iotjs_module_t;
 
 
 iotjs_module_t.cache = {};
-iotjs_module_t.wrapper = Native.wrapper;
-iotjs_module_t.wrap = Native.wrap;
 
 
 var cwd;


### PR DESCRIPTION
module.wrap and module.wrapper are not used any more.
They were removed about 2.5 years ago by commit ed5e309.

IoT.js-DCO-1.0-Signed-off-by: Sanggyu Lee sg5.lee@samsung.com
  