### PR TITLE
Rename iotjs_module_objects_t to iotjs_module_rw_data_t

### DIFF
--- a/cmake/iotjs.cmake
+++ b/cmake/iotjs.cmake
@@ -277,11 +277,14 @@ list(LENGTH IOTJS_NATIVE_MODULES IOTJS_MODULE_COUNT)
 set(IOTJS_MODULE_INL_H "/* File generated via iotjs.cmake */
 ${IOTJS_MODULE_INITIALIZERS}
 
+const unsigned iotjs_module_count = ${IOTJS_MODULE_COUNT};
+
 const
-iotjs_module_t iotjs_modules[${IOTJS_MODULE_COUNT}] = {${IOTJS_MODULE_ENTRIES}
+iotjs_module_ro_data_t iotjs_module_ro_data[${IOTJS_MODULE_COUNT}] = {
+${IOTJS_MODULE_ENTRIES}
 };
 
-iotjs_module_objects_t iotjs_module_objects[${IOTJS_MODULE_COUNT}] = {
+iotjs_module_rw_data_t iotjs_module_rw_data[${IOTJS_MODULE_COUNT}] = {
 ${IOTJS_MODULE_OBJECTS}
 };
 ")

--- a/src/iotjs_module.c
+++ b/src/iotjs_module.c
@@ -16,36 +16,34 @@
 #include "iotjs_def.h"
 #include "iotjs_module.h"
 
-typedef struct { jerry_value_t jmodule; } iotjs_module_objects_t;
+typedef struct { jerry_value_t jmodule; } iotjs_module_rw_data_t;
 
 #include "iotjs_module_inl.h"
 
 /**
  * iotjs_module_inl.h provides:
- *  - iotjs_modules[]
- *  - iotjs_module_objects[]
+ *  - iotjs_module_count
+ *  - iotjs_module_ro_data[]
+ *  - iotjs_module_rw_data[]
  */
 
-const unsigned iotjs_modules_count =
-    sizeof(iotjs_modules) / sizeof(iotjs_module_t);
-
 void iotjs_module_list_cleanup() {
-  for (unsigned i = 0; i < iotjs_modules_count; i++) {
-    if (iotjs_module_objects[i].jmodule != 0) {
-      jerry_release_value(iotjs_module_objects[i].jmodule);
-      iotjs_module_objects[i].jmodule = 0;
+  for (unsigned i = 0; i < iotjs_module_count; i++) {
+    if (iotjs_module_rw_data[i].jmodule != 0) {
+      jerry_release_value(iotjs_module_rw_data[i].jmodule);
+      iotjs_module_rw_data[i].jmodule = 0;
     }
   }
 }
 
 jerry_value_t iotjs_module_get(const char* name) {
-  for (unsigned i = 0; i < iotjs_modules_count; i++) {
-    if (!strcmp(name, iotjs_modules[i].name)) {
-      if (iotjs_module_objects[i].jmodule == 0) {
-        iotjs_module_objects[i].jmodule = iotjs_modules[i].fn_register();
+  for (unsigned i = 0; i < iotjs_module_count; i++) {
+    if (!strcmp(name, iotjs_module_ro_data[i].name)) {
+      if (iotjs_module_rw_data[i].jmodule == 0) {
+        iotjs_module_rw_data[i].jmodule = iotjs_module_ro_data[i].fn_register();
       }
 
-      return iotjs_module_objects[i].jmodule;
+      return iotjs_module_rw_data[i].jmodule;
     }
   }
 

--- a/src/iotjs_module.h
+++ b/src/iotjs_module.h
@@ -23,10 +23,10 @@ typedef jerry_value_t (*register_func)();
 typedef struct {
   const char* name;
   register_func fn_register;
-} iotjs_module_t;
+} iotjs_module_ro_data_t;
 
-extern const unsigned iotjs_modules_count;
-extern const iotjs_module_t iotjs_modules[];
+extern const unsigned iotjs_module_count;
+extern const iotjs_module_ro_data_t iotjs_module_ro_data[];
 
 void iotjs_module_list_cleanup();
 

--- a/src/modules/iotjs_module_process.c
+++ b/src/modules/iotjs_module_process.c
@@ -288,8 +288,8 @@ static void SetBuiltinModules(jerry_value_t builtin_modules) {
     iotjs_jval_set_property_jval(builtin_modules, js_modules[i].name,
                                  jerry_create_boolean(true));
   }
-  for (unsigned i = 0; i < iotjs_modules_count; i++) {
-    iotjs_jval_set_property_jval(builtin_modules, iotjs_modules[i].name,
+  for (unsigned i = 0; i < iotjs_module_count; i++) {
+    iotjs_jval_set_property_jval(builtin_modules, iotjs_module_ro_data[i].name,
                                  jerry_create_boolean(true));
   }
 }


### PR DESCRIPTION
Previously, module was composed of iotjs_module_t (const data)
and iotjs_module_objects_t (read/write data). iotjs_module_objects_t
was introduced to put more data into readonly partition.

I change the names to iotjs_module_ro_data (read-only) and
iotjs_module_rw_data (read-write) to specify it more clearly.

IoT.js-DCO-1.0-Signed-off-by: Sanggyu Lee sg5.lee@samsung.com