### PR TITLE
Fix mismatching member type in DebuggerConfig

### DIFF
--- a/src/iotjs_env.c
+++ b/src/iotjs_env.c
@@ -122,7 +122,7 @@ bool iotjs_environment_parse_command_line_arguments(iotjs_environment_t* env,
       size_t port_length = sizeof(strlen(argv[i] - port_arg_len - 1));
       char port[port_length];
       memcpy(&port, argv[i] + port_arg_len, port_length);
-      sscanf(port, "%d", &(_this->config.debugger->port));
+      sscanf(port, "%hu", &(_this->config.debugger->port));
     } else if (!strcmp(argv[i], "--debugger-wait-source") &&
                _this->config.debugger) {
       _this->config.debugger->wait_source = true;

--- a/src/iotjs_env.h
+++ b/src/iotjs_env.h
@@ -21,7 +21,7 @@
 typedef struct {
   bool wait_source;
   bool context_reset;
-  int port;
+  uint16_t port;
 } DebuggerConfig;
 
 typedef struct {


### PR DESCRIPTION
`jerry_debugger_init` expects `uint16` as port, but it is defined
as a regular `int` in `DebuggerConfig`.

IoT.js-DCO-1.0-Signed-off-by: Mátyás Mustoha mmatyas@inf.u-szeged.hu
