### PR TITLE
tools: fix magic_text quote problems in js2c

### DIFF
--- a/tools/js2c.py
+++ b/tools/js2c.py
@@ -353,6 +353,7 @@ def js2c(buildtype, js_modules, snapshot_tool=None, verbose=False):
         sorted_strings = sorted(magic_string_set, key=lambda x: (len(x), x))
         for idx, magic_string in enumerate(sorted_strings):
             magic_text = repr(magic_string)[1:-1]
+            magic_text = magic_text.replace('"', '\"')
 
             fout_magic_str.write('  MAGICSTR_EX_DEF(MAGIC_STR_%d, "%s") \\\n'
                                  % (idx, magic_text))


### PR DESCRIPTION
The internal JavaScript files for js2c will be crashed for:

```js
"string"/foo/bar"
```

Just replace the double-quoted(").