### PR TITLE
Fix Tizen Build break

### DIFF
--- a/config/tizen/gbsbuild.sh
+++ b/config/tizen/gbsbuild.sh
@@ -18,11 +18,7 @@ cd ..
 
 echo "******************************************************************"
 echo "*                       Tizen GBS build                          *"
-echo "*                                                                *"
-echo "* Please input user, passwd of http://Tizen.org on '~/.gbs.conf' *"
-echo "* For more information, please read Guide Docs. folder           *"
 echo "* ~/.gbs.conf sample is at 'config/tizen/sample.gbs.conf'.       *"
-echo "*                                                                *"
 echo "******************************************************************"
 read -p "[Warning] This working folder will be copied to ../iotjs_tizen_gbs \
 Are you sure to continue? (y/n) " -n 1 -r
@@ -56,22 +52,13 @@ then
   then
     echo "========================================================"
     echo "1. GBS Build is successful."
-    echo "2. Please move to new working folder ../iotjs_tizen_gbs "
-    echo "   cd ../iotjs_tizen_gbs"
-    echo "3. From now, you can build with this command on new directory"
-    echo "   gbs build -A armv7l --include"
-    echo "4. Your new branch 'tizen_gbs' is added."
-    echo "5. 'iotjs origin' repository is added."
-    git remote add origin https://github.com/samsung/iotjs
-    echo "(You cant fetch origin repository with this command)"
-    echo "   git fetch --all"
-    echo "========================================================"
-    # git remote add origin
-    # https://review.tizen.org/git/platform/upstream/iotjs
-    git branch -a
-    git status
+    echo "2. You can find rpm packages in below folder"
+    echo "   GBS-ROOT/local/repos/tizen_unified_preview1/armv7l/RPMS"
   else
     echo "GBS Build failed!"
     exit 1
   fi
+cd ..
+rm -rf iotjs_tizen_gbs
+cd iotjs
 fi

--- a/config/tizen/packaging/iotjs.spec
+++ b/config/tizen/packaging/iotjs.spec
@@ -73,7 +73,6 @@ cp %{SOURCE1001} .
  --compile-flag=-D__TIZEN__ \
  --cmake-param=-DENABLE_MODULE_DGRAM=ON \
  --cmake-param=-DENABLE_MODULE_GPIO=ON \
- --cmake-param=-DENABLE_MODULE_I2C=ON \
  --no-init-submodule --no-parallel-build --no-check-test
 
 %install


### PR DESCRIPTION
Remove I2C module build option to fix tizen build break
Delete a folder(iotjs_tizen_gbs) after completing gbs build

IoT.js-DCO-1.0-Signed-off-by: Haesik, Jun haesik.jun@samsung.com
  
  