### PR TITLE
Allow cmake files for external modules

### DIFF
--- a/cmake/jerry.cmake
+++ b/cmake/jerry.cmake
@@ -168,4 +168,4 @@ if(NOT "${TARGET_OS}" MATCHES "NUTTX")
   set(JERRY_PORT_DIR ${DEPS_LIB_JERRY_SRC}/jerry-port/default)
 endif()
 
-set(JERRY_INCLUDE_DIR ${DEPS_LIB_JERRY}/jerry-core/include)
+set(JERRY_INCLUDE_DIR ${DEPS_LIB_JERRY_SRC}/jerry-core/include)

--- a/tools/iotjs-create-module.py
+++ b/tools/iotjs-create-module.py
@@ -1,0 +1,92 @@
+#!/usr/bin/env python
+
+# Copyright 2018-present Samsung Electronics Co., Ltd. and other contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import print_function
+
+import os
+import re
+
+TEMPLATE_DIR = os.path.join(os.path.dirname(__file__), 'module_template')
+MODULE_NAME_RE = "^[a-z0-9][a-z0-9\._]*$"
+
+def load_templates(template_dir):
+    for root, dirs, files in os.walk(template_dir):
+        for fp in files:
+            yield os.path.relpath(os.path.join(root, fp), template_dir)
+
+
+def replace_contents(input_file, module_name):
+    with open(input_file) as fp:
+        data = fp.read().replace("$MODULE_NAME$", module_name)
+
+    return data
+
+def create_module(output_dir, module_name, template_dir, template_files):
+    module_path = os.path.join(output_dir, module_name)
+    print("Creating module in {}".format(module_path))
+
+    if os.path.exists(module_path):
+        print("Module path ({}) already exists! Exiting".format(module_path))
+        return False
+
+    for file_name in template_files:
+        file_path = os.path.join(template_dir, file_name)
+        print("loading template file: {}".format(file_path))
+        contents = replace_contents(file_path, module_name)
+        output_path = os.path.join(module_path, file_name)
+
+        # create sub-dir if required
+        base_dir = os.path.dirname(output_path)
+        if not os.path.exists(base_dir):
+            os.mkdir(base_dir)
+
+        with open(output_path, "w") as fp:
+            fp.write(contents)
+
+    return True
+
+def valid_module_name(value):
+    if not re.match(MODULE_NAME_RE, value):
+        msg = "Invalid module name, should match regexp: %s" % MODULE_NAME_RE
+        raise argparse.ArgumentTypeError(msg)
+    return value
+
+if __name__ == "__main__":
+    import argparse
+    import sys
+
+    desc = "Create an IoT.js external module using a template"
+    parser = argparse.ArgumentParser(description=desc)
+    parser.add_argument("module_name", metavar="<MODULE NAME>", nargs=1,
+                        type=valid_module_name,
+                        help="name of the new module ((must be in lowercase " +
+                             "and should match regexp: %s)" % MODULE_NAME_RE)
+    parser.add_argument("--path", default=".",
+                        help="directory where the module will be created " +
+                             "(default: %(default)s)")
+    parser.add_argument("--template", default=TEMPLATE_DIR,
+                        help="directory where the template files are located "
+                        "(default: %(default)s)")
+    args = parser.parse_args()
+
+    template_files = load_templates(args.template)
+    created = create_module(args.path,
+                            args.module_name[0],
+                            args.template,
+                            template_files)
+    if created:
+        module_path = os.path.join(args.path, args.module_name[0])
+        print("Module created in: {}".format(os.path.abspath(module_path)))

--- a/tools/module_template/js/module.js
+++ b/tools/module_template/js/module.js
@@ -1,0 +1,29 @@
+/* Copyright 2018-present Samsung Electronics Co., Ltd. and other contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * To export an object/value use the 'module.exports' object.
+ */
+var demo_value = "Hello";
+
+/* Export an object with two properties. */
+module.exports = {
+    /* the 'native' means the object returned by the C init method. */
+    demo2: function() { return native.message; },
+    add: native.add
+}
+
+/* Export a local variable. */
+module.exports.demo_value = demo_value;

--- a/tools/module_template/module.cmake
+++ b/tools/module_template/module.cmake
@@ -1,0 +1,41 @@
+# Copyright 2018-present Samsung Electronics Co., Ltd. and other contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# General variables usable from IoT.js cmake:
+# - TARGET_ARCH - the target architecture (as specified during cmake step)
+# - TARGET_BOARD - the target board(/device)
+# - TARGET_OS - the target operating system
+#
+# Module related variables usable from IoT.js cmake:
+# - MODULE_DIR - the modules root directory
+# - MODULE_BINARY_DIR - the build directory for the current module
+# - MODULE_LIBS - list of libraries to use during linking (set this)
+set(MODULE_NAME "$MODULE_NAME$")
+
+# DO NOT include the source files which are already in the modules.json file.
+
+# If the module builds its own files into a lib please use the line below.
+# Note: the subdir 'lib' should contain the CMakeLists.txt describing how the
+#  module should be built.
+#add_subdirectory(${MODULE_DIR}/lib/ ${MODULE_BINARY_DIR}/${MODULE_NAME})
+
+# If you wish to link external libraries please add it to
+# the MODULE_LIBS list.
+#
+# IMPORTANT!
+#  if the module builds its own library that should also be specified!
+#
+# Example (to add the 'demo' library for linking):
+#
+#  list(APPEND MODULE_LIBS demo)

--- a/tools/module_template/modules.json
+++ b/tools/module_template/modules.json
@@ -1,0 +1,10 @@
+{
+  "modules": {
+    "$MODULE_NAME$": {
+      "js_file": "js/module.js",
+      "native_files": ["src/module.c"],
+      "init": "Init$MODULE_NAME$",
+      "cmakefile": "module.cmake"
+    }
+  }
+}

--- a/tools/module_template/src/module.c
+++ b/tools/module_template/src/module.c
@@ -1,0 +1,53 @@
+/* Copyright 2018-present Samsung Electronics Co., Ltd. and other contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "iotjs_def.h"
+
+/**
+ * Demo method
+ */
+static jerry_value_t demo_method(
+    const jerry_value_t func_value, /**< function object */
+    const jerry_value_t this_value, /**< this arg */
+    const jerry_value_t *args_p,    /**< function arguments */
+    const jerry_length_t args_cnt)  /**< number of function arguments */
+{
+  if (args_cnt < 2) {
+    static char *error_msg = "Incorrect parameter count";
+    return jerry_create_error(JERRY_ERROR_TYPE,
+                              (const jerry_char_t *)error_msg);
+  }
+
+  if (!jerry_value_is_number(args_p[0]) || !jerry_value_is_number(args_p[1])) {
+    static char *error_msg = "Incorrect parameter type(s)";
+    return jerry_create_error(JERRY_ERROR_TYPE,
+                              (const jerry_char_t *)error_msg);
+  }
+
+  int arg_a = jerry_get_number_value(args_p[0]);
+  int arg_b = jerry_get_number_value(args_p[1]);
+
+  return jerry_create_number(arg_a + arg_b);
+}
+
+/**
+ * Init method called by IoT.js
+ */
+jerry_value_t Init$MODULE_NAME$() {
+  jerry_value_t mymodule = jerry_create_object();
+  iotjs_jval_set_property_string_raw(mymodule, "message", "Hello world!");
+  iotjs_jval_set_method(mymodule, "add", demo_method);
+  return mymodule;
+}


### PR DESCRIPTION
Adding processing of the 'cmakefile' key in the
module(s) json files. By specifying a CMake file
for this key the IoT.js build will also process
that given CMake file and compiles/links any
modules it specifies.

Additionally an external module generator script is
added which creates a module directory based on a template.
This is the 'tools/iotjs-create-module.py' tool.

IoT.js-DCO-1.0-Signed-off-by: Peter Gal pgal.u-szeged@partner.samsung.com