### PR TITLE
Remove unnecessary 'jerry_acquire_value' call.

### DIFF
--- a/src/iotjs_binding.c
+++ b/src/iotjs_binding.c
@@ -230,7 +230,7 @@ jerry_value_t iotjs_jval_get_property(jerry_value_t jobj, const char* name) {
 
   if (jerry_value_has_error_flag(res)) {
     jerry_release_value(res);
-    return jerry_acquire_value(jerry_create_undefined());
+    return jerry_create_undefined();
   }
 
   return res;


### PR DESCRIPTION
IoT.js-DCO-1.0-Signed-off-by: László Langó llango.u-szeged@partner.samsung.com