### PR TITLE
Add curl into link libraries for iotjs build.

### DIFF
--- a/cmake/iotjs.cmake
+++ b/cmake/iotjs.cmake
@@ -427,6 +427,7 @@ target_include_directories(${TARGET_LIB_IOTJS} PRIVATE ${IOTJS_INCLUDE_DIRS})
 target_link_libraries(${TARGET_LIB_IOTJS}
   ${JERRY_LIBS}
   ${TUV_LIBS}
+  curl
   libhttp-parser
   ${MBEDTLS_LIBS}
   ${EXTERNAL_LIBS}


### PR DESCRIPTION
curl library is not automatically added while building
iotjs for rpi zero natively. This library is required
for http module.

IoT.js-DCO-1.0-Signed-off-by:Ziran Sun <ziran.sun@samsung.com>