### PR TITLE
Revert "Remove Validated struct from the https module. (#1429)"

### DIFF
--- a/src/modules/iotjs_module_https.c
+++ b/src/modules/iotjs_module_https.c
@@ -33,90 +33,93 @@ iotjs_https_t* iotjs_https_create(const char* URL, const char* method,
                                   const bool reject_unauthorized,
                                   jerry_value_t jthis) {
   iotjs_https_t* https_data = IOTJS_ALLOC(iotjs_https_t);
+  IOTJS_VALIDATED_STRUCT_CONSTRUCTOR(iotjs_https_t, https_data);
 
   // Original Request Details
-  https_data->URL = URL;
-  https_data->header_list = NULL;
+  _this->URL = URL;
+  _this->header_list = NULL;
   if (strcmp(method, STRING_GET) == 0)
-    https_data->method = HTTPS_GET;
+    _this->method = HTTPS_GET;
   else if (strcmp(method, STRING_POST) == 0)
-    https_data->method = HTTPS_POST;
+    _this->method = HTTPS_POST;
   else if (strcmp(method, STRING_PUT) == 0)
-    https_data->method = HTTPS_PUT;
+    _this->method = HTTPS_PUT;
   else if (strcmp(method, STRING_DELETE) == 0)
-    https_data->method = HTTPS_DELETE;
+    _this->method = HTTPS_DELETE;
   else if (strcmp(method, STRING_HEAD) == 0)
-    https_data->method = HTTPS_HEAD;
+    _this->method = HTTPS_HEAD;
   else if (strcmp(method, STRING_CONNECT) == 0)
-    https_data->method = HTTPS_CONNECT;
+    _this->method = HTTPS_CONNECT;
   else if (strcmp(method, STRING_OPTIONS) == 0)
-    https_data->method = HTTPS_OPTIONS;
+    _this->method = HTTPS_OPTIONS;
   else if (strcmp(method, STRING_TRACE) == 0)
-    https_data->method = HTTPS_TRACE;
+    _this->method = HTTPS_TRACE;
   else {
     IOTJS_ASSERT(0);
   }
 
   // TLS certs stuff
-  https_data->ca = ca;
-  https_data->cert = cert;
-  https_data->key = key;
-  https_data->reject_unauthorized = reject_unauthorized;
+  _this->ca = ca;
+  _this->cert = cert;
+  _this->key = key;
+  _this->reject_unauthorized = reject_unauthorized;
   // Content Length stuff
-  https_data->content_length = -1;
+  _this->content_length = -1;
 
   // Handles
-  https_data->loop = iotjs_environment_loop(iotjs_environment_get());
-  https_data->jthis_native = jerry_acquire_value(jthis);
-  jerry_set_object_native_pointer(https_data->jthis_native, https_data,
+  _this->loop = iotjs_environment_loop(iotjs_environment_get());
+  _this->jthis_native = jerry_acquire_value(jthis);
+  jerry_set_object_native_pointer(_this->jthis_native, https_data,
                                   &this_module_native_info);
-  https_data->curl_multi_handle = curl_multi_init();
-  https_data->curl_easy_handle = curl_easy_init();
-  https_data->timeout.data = (void*)https_data;
-  uv_timer_init(https_data->loop, &(https_data->timeout));
-  https_data->request_done = false;
-  https_data->closing_handles = 3;
-  https_data->poll_data = NULL;
+  _this->curl_multi_handle = curl_multi_init();
+  _this->curl_easy_handle = curl_easy_init();
+  _this->timeout.data = (void*)https_data;
+  uv_timer_init(_this->loop, &(_this->timeout));
+  _this->request_done = false;
+  _this->closing_handles = 3;
+  _this->poll_data = NULL;
 
   // Timeout stuff
-  https_data->timeout_ms = -1;
-  https_data->last_bytes_num = -1;
-  https_data->last_bytes_time = 0;
-  https_data->socket_timeout.data = (void*)https_data;
-  uv_timer_init(https_data->loop, &(https_data->socket_timeout));
+  _this->timeout_ms = -1;
+  _this->last_bytes_num = -1;
+  _this->last_bytes_time = 0;
+  _this->socket_timeout.data = (void*)https_data;
+  uv_timer_init(_this->loop, &(_this->socket_timeout));
 
   // ReadData stuff
-  https_data->cur_read_index = 0;
-  https_data->is_stream_writable = false;
-  https_data->stream_ended = false;
-  https_data->data_to_read = false;
-  https_data->to_destroy_read_onwrite = false;
-  https_data->async_read_onwrite.data = (void*)https_data;
-  uv_timer_init(https_data->loop, &(https_data->async_read_onwrite));
+  _this->cur_read_index = 0;
+  _this->is_stream_writable = false;
+  _this->stream_ended = false;
+  _this->data_to_read = false;
+  _this->to_destroy_read_onwrite = false;
+  _this->async_read_onwrite.data = (void*)https_data;
+  uv_timer_init(_this->loop, &(_this->async_read_onwrite));
   // No Need to read data for following types of requests
-  if (https_data->method == HTTPS_GET || https_data->method == HTTPS_DELETE ||
-      https_data->method == HTTPS_HEAD || https_data->method == HTTPS_OPTIONS ||
-      https_data->method == HTTPS_TRACE)
-    https_data->stream_ended = true;
+  if (_this->method == HTTPS_GET || _this->method == HTTPS_DELETE ||
+      _this->method == HTTPS_HEAD || _this->method == HTTPS_OPTIONS ||
+      _this->method == HTTPS_TRACE)
+    _this->stream_ended = true;
 
   return https_data;
 }
 
 // Destructor
 void iotjs_https_destroy(iotjs_https_t* https_data) {
-  https_data->URL = NULL;
+  IOTJS_VALIDATED_STRUCT_DESTRUCTOR(iotjs_https_t, https_data);
+  // To shutup unused variable _this warning
+  _this->URL = NULL;
   IOTJS_RELEASE(https_data);
 }
 
 //----------------Utility Functions------------------
 void iotjs_https_check_done(iotjs_https_t* https_data) {
+  IOTJS_VALIDATED_STRUCT_METHOD(iotjs_https_t, https_data);
   char* done_url;
   CURLMsg* message;
   int pending;
   bool error = false;
 
-  while ((message =
-              curl_multi_info_read(https_data->curl_multi_handle, &pending))) {
+  while ((message = curl_multi_info_read(_this->curl_multi_handle, &pending))) {
     switch (message->msg) {
       case CURLMSG_DONE:
         curl_easy_getinfo(message->easy_handle, CURLINFO_EFFECTIVE_URL,
@@ -136,13 +139,13 @@ void iotjs_https_check_done(iotjs_https_t* https_data) {
       iotjs_string_destroy(&jresult_string);
       iotjs_jargs_destroy(&jarg);
     }
-    if (https_data->stream_ended) {
+    if (_this->stream_ended) {
       iotjs_https_cleanup(https_data);
     } else {
-      if (https_data->to_destroy_read_onwrite) {
+      if (_this->to_destroy_read_onwrite) {
         iotjs_https_call_read_onwrite_async(https_data);
       }
-      https_data->request_done = true;
+      _this->request_done = true;
     }
     break;
   }
@@ -150,13 +153,14 @@ void iotjs_https_check_done(iotjs_https_t* https_data) {
 
 // Cleanup before destructor
 void iotjs_https_cleanup(iotjs_https_t* https_data) {
-  https_data->loop = NULL;
+  IOTJS_VALIDATED_STRUCT_METHOD(iotjs_https_t, https_data);
+  _this->loop = NULL;
 
-  uv_close((uv_handle_t*)&https_data->timeout,
+  uv_close((uv_handle_t*)&_this->timeout,
            (uv_close_cb)iotjs_https_uv_close_callback);
-  uv_close((uv_handle_t*)&https_data->socket_timeout,
+  uv_close((uv_handle_t*)&_this->socket_timeout,
            (uv_close_cb)iotjs_https_uv_close_callback);
-  uv_close((uv_handle_t*)&https_data->async_read_onwrite,
+  uv_close((uv_handle_t*)&_this->async_read_onwrite,
            (uv_close_cb)iotjs_https_uv_close_callback);
 
   iotjs_https_jcallback(https_data, IOTJS_MAGIC_STRING_ONEND,
@@ -164,130 +168,137 @@ void iotjs_https_cleanup(iotjs_https_t* https_data) {
   iotjs_https_jcallback(https_data, IOTJS_MAGIC_STRING_ONCLOSED,
                         iotjs_jargs_get_empty(), false);
 
-  curl_multi_remove_handle(https_data->curl_multi_handle,
-                           https_data->curl_easy_handle);
-  curl_easy_cleanup(https_data->curl_easy_handle);
-  https_data->curl_easy_handle = NULL;
-  curl_multi_cleanup(https_data->curl_multi_handle);
-  https_data->curl_multi_handle = NULL;
-  curl_slist_free_all(https_data->header_list);
+  curl_multi_remove_handle(_this->curl_multi_handle, _this->curl_easy_handle);
+  curl_easy_cleanup(_this->curl_easy_handle);
+  _this->curl_easy_handle = NULL;
+  curl_multi_cleanup(_this->curl_multi_handle);
+  _this->curl_multi_handle = NULL;
+  curl_slist_free_all(_this->header_list);
 
-  if (https_data->poll_data != NULL)
-    iotjs_https_poll_close_all(https_data->poll_data);
+  if (_this->poll_data != NULL)
+    iotjs_https_poll_close_all(_this->poll_data);
 
-  if (https_data->to_destroy_read_onwrite) {
+  if (_this->to_destroy_read_onwrite) {
     const iotjs_jargs_t* jarg = iotjs_jargs_get_empty();
-    jerry_value_t jthis = https_data->jthis_native;
-    IOTJS_ASSERT(jerry_value_is_function((https_data->read_onwrite)));
+    jerry_value_t jthis = _this->jthis_native;
+    IOTJS_ASSERT(jerry_value_is_function((_this->read_onwrite)));
 
-    if (!jerry_value_is_undefined((https_data->read_callback)))
-      iotjs_make_callback(https_data->read_callback, jthis, jarg);
+    if (!jerry_value_is_undefined((_this->read_callback)))
+      iotjs_make_callback(_this->read_callback, jthis, jarg);
 
-    iotjs_make_callback(https_data->read_onwrite, jthis, jarg);
-    https_data->to_destroy_read_onwrite = false;
-    iotjs_string_destroy(&(https_data->read_chunk));
-    jerry_release_value((https_data->read_onwrite));
-    jerry_release_value((https_data->read_callback));
+    iotjs_make_callback(_this->read_onwrite, jthis, jarg);
+    _this->to_destroy_read_onwrite = false;
+    iotjs_string_destroy(&(_this->read_chunk));
+    jerry_release_value((_this->read_onwrite));
+    jerry_release_value((_this->read_callback));
   }
   return;
 }
 
+CURLM* iotjs_https_get_multi_handle(iotjs_https_t* https_data) {
+  IOTJS_VALIDATED_STRUCT_METHOD(iotjs_https_t, https_data);
+  return _this->curl_multi_handle;
+}
+
 // Set various parameters of curl handles
 void iotjs_https_initialize_curl_opts(iotjs_https_t* https_data) {
+  IOTJS_VALIDATED_STRUCT_METHOD(iotjs_https_t, https_data);
+
   // Setup Some parameters for multi handle
-  curl_multi_setopt(https_data->curl_multi_handle, CURLMOPT_SOCKETFUNCTION,
+  curl_multi_setopt(_this->curl_multi_handle, CURLMOPT_SOCKETFUNCTION,
                     iotjs_https_curl_socket_callback);
-  curl_multi_setopt(https_data->curl_multi_handle, CURLMOPT_SOCKETDATA,
+  curl_multi_setopt(_this->curl_multi_handle, CURLMOPT_SOCKETDATA,
                     (void*)https_data);
-  curl_multi_setopt(https_data->curl_multi_handle, CURLMOPT_TIMERFUNCTION,
+  curl_multi_setopt(_this->curl_multi_handle, CURLMOPT_TIMERFUNCTION,
                     iotjs_https_curl_start_timeout_callback);
-  curl_multi_setopt(https_data->curl_multi_handle, CURLMOPT_TIMERDATA,
+  curl_multi_setopt(_this->curl_multi_handle, CURLMOPT_TIMERDATA,
                     (void*)https_data);
 
-  curl_easy_setopt(https_data->curl_easy_handle, CURLOPT_PROXY, "");
-  curl_easy_setopt(https_data->curl_easy_handle, CURLOPT_HEADERDATA,
+  curl_easy_setopt(_this->curl_easy_handle, CURLOPT_PROXY, "");
+  curl_easy_setopt(_this->curl_easy_handle, CURLOPT_HEADERDATA,
                    (void*)https_data);
-  curl_easy_setopt(https_data->curl_easy_handle, CURLOPT_WRITEFUNCTION,
+  curl_easy_setopt(_this->curl_easy_handle, CURLOPT_WRITEFUNCTION,
                    iotjs_https_curl_write_callback);
-  curl_easy_setopt(_thttps_datahis->curl_easy_handle, CURLOPT_WRITEDATA,
+  curl_easy_setopt(_this->curl_easy_handle, CURLOPT_WRITEDATA,
                    (void*)https_data);
 
   // Read and send data to server only for some request types
-  if (https_data->method == HTTPS_POST || https_data->method == HTTPS_PUT ||
-      https_data->method == HTTPS_CONNECT) {
-    curl_easy_setopt(https_data->curl_easy_handle, CURLOPT_READFUNCTION,
+  if (_this->method == HTTPS_POST || _this->method == HTTPS_PUT ||
+      _this->method == HTTPS_CONNECT) {
+    curl_easy_setopt(_this->curl_easy_handle, CURLOPT_READFUNCTION,
                      iotjs_https_curl_read_callback);
-    curl_easy_setopt(https_data->curl_easy_handle, CURLOPT_READDATA,
+    curl_easy_setopt(_this->curl_easy_handle, CURLOPT_READDATA,
                      (void*)https_data);
   }
 
-  curl_easy_setopt(https_data->curl_easy_handle, CURLOPT_SOCKOPTFUNCTION,
+  curl_easy_setopt(_this->curl_easy_handle, CURLOPT_SOCKOPTFUNCTION,
                    iotjs_https_curl_sockopt_callback);
-  curl_easy_setopt(https_data->curl_easy_handle, CURLOPT_SOCKOPTDATA,
+  curl_easy_setopt(_this->curl_easy_handle, CURLOPT_SOCKOPTDATA,
                    (void*)https_data);
 
-  curl_easy_setopt(https_data->curl_easy_handle, CURLOPT_URL, https_data->URL);
-  https_data->URL = NULL;
-  curl_easy_setopt(https_data->curl_easy_handle, CURLOPT_PROTOCOLS,
+  curl_easy_setopt(_this->curl_easy_handle, CURLOPT_URL, _this->URL);
+  _this->URL = NULL;
+  curl_easy_setopt(_this->curl_easy_handle, CURLOPT_PROTOCOLS,
                    CURLPROTO_HTTP | CURLPROTO_HTTPS);
 
-  if (strlen(https_data->ca) > 0)
-    curl_easy_setopt(https_data->curl_easy_handle, CURLOPT_CAINFO,
-                     https_data->ca);
-  https_data->ca = NULL;
-  if (strlen(https_data->cert) > 0)
-    curl_easy_setopt(https_data->curl_easy_handle, CURLOPT_SSLCERT,
-                     https_data->cert);
-  https_data->cert = NULL;
-  if (strlen(https_data->key) > 0)
-    curl_easy_setopt(https_data->curl_easy_handle, CURLOPT_SSLKEY,
-                     https_data->key);
-  https_data->key = NULL;
-  if (!https_data->reject_unauthorized) {
-    curl_easy_setopt(https_data->curl_easy_handle, CURLOPT_SSL_VERIFYPEER, 0);
-    curl_easy_setopt(https_data->curl_easy_handle, CURLOPT_SSL_VERIFYHOST, 0);
+  if (strlen(_this->ca) > 0)
+    curl_easy_setopt(_this->curl_easy_handle, CURLOPT_CAINFO, _this->ca);
+  _this->ca = NULL;
+  if (strlen(_this->cert) > 0)
+    curl_easy_setopt(_this->curl_easy_handle, CURLOPT_SSLCERT, _this->cert);
+  _this->cert = NULL;
+  if (strlen(_this->key) > 0)
+    curl_easy_setopt(_this->curl_easy_handle, CURLOPT_SSLKEY, _this->key);
+  _this->key = NULL;
+  if (!_this->reject_unauthorized) {
+    curl_easy_setopt(_this->curl_easy_handle, CURLOPT_SSL_VERIFYPEER, 0);
+    curl_easy_setopt(_this->curl_easy_handle, CURLOPT_SSL_VERIFYHOST, 0);
   }
 
   // Various request types
-  switch (https_data->method) {
+  switch (_this->method) {
     case HTTPS_GET:
-      curl_easy_setopt(https_data->curl_easy_handle, CURLOPT_HTTPGET, 1L);
+      curl_easy_setopt(_this->curl_easy_handle, CURLOPT_HTTPGET, 1L);
       break;
     case HTTPS_POST:
-      curl_easy_setopt(https_data->curl_easy_handle, CURLOPT_POST, 1L);
+      curl_easy_setopt(_this->curl_easy_handle, CURLOPT_POST, 1L);
       break;
     case HTTPS_PUT:
-      curl_easy_setopt(https_data->curl_easy_handle, CURLOPT_UPLOAD, 1L);
+      curl_easy_setopt(_this->curl_easy_handle, CURLOPT_UPLOAD, 1L);
       break;
     case HTTPS_DELETE:
-      curl_easy_setopt(https_data->curl_easy_handle, CURLOPT_CUSTOMREQUEST,
+      curl_easy_setopt(_this->curl_easy_handle, CURLOPT_CUSTOMREQUEST,
                        "DELETE");
       break;
     case HTTPS_HEAD:
-      curl_easy_setopt(https_data->curl_easy_handle, CURLOPT_NOBODY, 1L);
+      curl_easy_setopt(_this->curl_easy_handle, CURLOPT_NOBODY, 1L);
       break;
     case HTTPS_CONNECT:
-      curl_easy_setopt(https_data->curl_easy_handle, CURLOPT_CUSTOMREQUEST,
+      curl_easy_setopt(_this->curl_easy_handle, CURLOPT_CUSTOMREQUEST,
                        "CONNECT");
       break;
     case HTTPS_OPTIONS:
-      curl_easy_setopt(https_data->curl_easy_handle, CURLOPT_CUSTOMREQUEST,
+      curl_easy_setopt(_this->curl_easy_handle, CURLOPT_CUSTOMREQUEST,
                        "OPTIONS");
       break;
     case HTTPS_TRACE:
-      curl_easy_setopt(https_data->curl_easy_handle, CURLOPT_CUSTOMREQUEST,
-                       "TRACE");
+      curl_easy_setopt(_this->curl_easy_handle, CURLOPT_CUSTOMREQUEST, "TRACE");
       break;
   }
 
-  curl_easy_setopt(https_data->curl_easy_handle, CURLOPT_HTTP_TRANSFER_DECODING,
-                   0L);
+  curl_easy_setopt(_this->curl_easy_handle, CURLOPT_HTTP_TRANSFER_DECODING, 0L);
+}
+
+// Get https.ClientRequest from struct
+jerry_value_t iotjs_https_jthis_from_https(iotjs_https_t* https_data) {
+  IOTJS_VALIDATED_STRUCT_METHOD(iotjs_https_t, https_data);
+  return _this->jthis_native;
 }
 
 // Call any property of ClientRequest._Incoming
 bool iotjs_https_jcallback(iotjs_https_t* https_data, const char* property,
                            const iotjs_jargs_t* jarg, bool resultvalue) {
-  jerry_value_t jthis = https_data->jthis_native;
+  jerry_value_t jthis = iotjs_https_jthis_from_https(https_data);
   bool retval = true;
   if (jerry_value_is_null(jthis))
     return retval;
@@ -313,37 +324,39 @@ bool iotjs_https_jcallback(iotjs_https_t* https_data, const char* property,
 // Call onWrite and callback after ClientRequest._write
 void iotjs_https_call_read_onwrite(uv_timer_t* timer) {
   iotjs_https_t* https_data = (iotjs_https_t*)(timer->data);
+  IOTJS_VALIDATED_STRUCT_METHOD(iotjs_https_t, https_data);
 
-  uv_timer_stop(&(https_data->async_read_onwrite));
-  if (jerry_value_is_null(https_data->jthis_native))
+  uv_timer_stop(&(_this->async_read_onwrite));
+  if (jerry_value_is_null(_this->jthis_native))
     return;
   const iotjs_jargs_t* jarg = iotjs_jargs_get_empty();
-  jerry_value_t jthis = https_data->jthis_native;
-  IOTJS_ASSERT(jerry_value_is_function((https_data->read_onwrite)));
+  jerry_value_t jthis = _this->jthis_native;
+  IOTJS_ASSERT(jerry_value_is_function((_this->read_onwrite)));
 
-  if (!jerry_value_is_undefined((https_data->read_callback)))
-    iotjs_make_callback(https_data->read_callback, jthis, jarg);
+  if (!jerry_value_is_undefined((_this->read_callback)))
+    iotjs_make_callback(_this->read_callback, jthis, jarg);
 
-  iotjs_make_callback(https_data->read_onwrite, jthis, jarg);
+  iotjs_make_callback(_this->read_onwrite, jthis, jarg);
 }
 
 // Call the above method Asynchronously
 void iotjs_https_call_read_onwrite_async(iotjs_https_t* https_data) {
-  uv_timer_start(&(https_data->async_read_onwrite),
-                 iotjs_https_call_read_onwrite, 0, 0);
+  IOTJS_VALIDATED_STRUCT_METHOD(iotjs_https_t, https_data);
+  uv_timer_start(&(_this->async_read_onwrite), iotjs_https_call_read_onwrite, 0,
+                 0);
 }
 
 // ------------Functions almost directly called by JS----------
 // Add a header to outgoing request
 void iotjs_https_add_header(iotjs_https_t* https_data,
                             const char* char_header) {
-  https_data->header_list =
-      curl_slist_append(https_data->header_list, char_header);
-  if (https_data->method == HTTPS_POST || https_data->method == HTTPS_PUT) {
+  IOTJS_VALIDATED_STRUCT_METHOD(iotjs_https_t, https_data);
+  _this->header_list = curl_slist_append(_this->header_list, char_header);
+  if (_this->method == HTTPS_POST || _this->method == HTTPS_PUT) {
     if (strncmp(char_header, "Content-Length: ", strlen("Content-Length: ")) ==
         0) {
       const char* numberString = char_header + strlen("Content-Length: ");
-      https_data->content_length = strtol(numberString, NULL, 10);
+      _this->content_length = strtol(numberString, NULL, 10);
     }
   }
 }
@@ -352,66 +365,68 @@ void iotjs_https_add_header(iotjs_https_t* https_data,
 void iotjs_https_data_to_write(iotjs_https_t* https_data,
                                iotjs_string_t read_chunk,
                                jerry_value_t callback, jerry_value_t onwrite) {
-  if (https_data->to_destroy_read_onwrite) {
-    https_data->to_destroy_read_onwrite = false;
-    iotjs_string_destroy(&(https_data->read_chunk));
-    jerry_release_value((https_data->read_onwrite));
-    jerry_release_value((https_data->read_callback));
+  IOTJS_VALIDATED_STRUCT_METHOD(iotjs_https_t, https_data);
+
+  if (_this->to_destroy_read_onwrite) {
+    _this->to_destroy_read_onwrite = false;
+    iotjs_string_destroy(&(_this->read_chunk));
+    jerry_release_value((_this->read_onwrite));
+    jerry_release_value((_this->read_callback));
   }
 
-  https_data->read_chunk = read_chunk;
-  https_data->data_to_read = true;
+  _this->read_chunk = read_chunk;
+  _this->data_to_read = true;
 
-  https_data->read_callback = jerry_acquire_value(callback);
-  https_data->read_onwrite = jerry_acquire_value(onwrite);
-  https_data->to_destroy_read_onwrite = true;
+  _this->read_callback = jerry_acquire_value(callback);
+  _this->read_onwrite = jerry_acquire_value(onwrite);
+  _this->to_destroy_read_onwrite = true;
 
-  if (https_data->request_done) {
+  if (_this->request_done) {
     iotjs_https_call_read_onwrite_async(https_data);
-  } else if (https_data->is_stream_writable) {
-    curl_easy_pause(https_data->curl_easy_handle, CURLPAUSE_CONT);
-    uv_timer_stop(&(https_data->timeout));
-    uv_timer_start(&(https_data->timeout), iotjs_https_uv_timeout_callback, 1,
-                   0);
+  } else if (_this->is_stream_writable) {
+    curl_easy_pause(_this->curl_easy_handle, CURLPAUSE_CONT);
+    uv_timer_stop(&(_this->timeout));
+    uv_timer_start(&(_this->timeout), iotjs_https_uv_timeout_callback, 1, 0);
   }
 }
 
 // Finish writing all data from ClientRequest Stream
 void iotjs_https_finish_request(iotjs_https_t* https_data) {
-  https_data->stream_ended = true;
-  if (https_data->request_done) {
+  IOTJS_VALIDATED_STRUCT_METHOD(iotjs_https_t, https_data);
+  _this->stream_ended = true;
+  if (_this->request_done) {
     iotjs_https_cleanup(https_data);
-  } else if (https_data->is_stream_writable) {
-    curl_easy_pause(https_data->curl_easy_handle, CURLPAUSE_CONT);
-    uv_timer_stop(&(https_data->timeout));
-    uv_timer_start(&(https_data->timeout), iotjs_https_uv_timeout_callback, 1,
-                   0);
+  } else if (_this->is_stream_writable) {
+    curl_easy_pause(_this->curl_easy_handle, CURLPAUSE_CONT);
+    uv_timer_stop(&(_this->timeout));
+    uv_timer_start(&(_this->timeout), iotjs_https_uv_timeout_callback, 1, 0);
   }
 }
 
 // Start sending the request
 void iotjs_https_send_request(iotjs_https_t* https_data) {
+  IOTJS_VALIDATED_STRUCT_METHOD(iotjs_https_t, https_data);
   // Add all the headers to the easy handle
-  curl_easy_setopt(https_data->curl_easy_handle, CURLOPT_HTTPHEADER,
-                   https_data->header_list);
+  curl_easy_setopt(_this->curl_easy_handle, CURLOPT_HTTPHEADER,
+                   _this->header_list);
 
-  if (https_data->method == HTTPS_POST && https_data->content_length != -1)
-    curl_easy_setopt(https_data->curl_easy_handle, CURLOPT_POSTFIELDSIZE,
-                     https_data->content_length);
-  else if (https_data->method == HTTPS_PUT && https_data->content_length != -1)
-    curl_easy_setopt(https_data->curl_easy_handle, CURLOPT_INFILESIZE,
-                     https_data->content_length);
+  if (_this->method == HTTPS_POST && _this->content_length != -1)
+    curl_easy_setopt(_this->curl_easy_handle, CURLOPT_POSTFIELDSIZE,
+                     _this->content_length);
+  else if (_this->method == HTTPS_PUT && _this->content_length != -1)
+    curl_easy_setopt(_this->curl_easy_handle, CURLOPT_INFILESIZE,
+                     _this->content_length);
 
-  curl_multi_add_handle(https_data->curl_multi_handle,
-                        https_data->curl_easy_handle);
+  curl_multi_add_handle(_this->curl_multi_handle, _this->curl_easy_handle);
 }
 
 // Set timeout for request.
 void iotjs_https_set_timeout(long ms, iotjs_https_t* https_data) {
+  IOTJS_VALIDATED_STRUCT_METHOD(iotjs_https_t, https_data);
   if (ms < 0)
     return;
-  https_data->timeout_ms = ms;
-  uv_timer_start(&(https_data->socket_timeout),
+  _this->timeout_ms = ms;
+  uv_timer_start(&(_this->socket_timeout),
                  iotjs_https_uv_socket_timeout_callback, 1, (uint64_t)ms);
 }
 
@@ -421,41 +436,42 @@ void iotjs_https_set_timeout(long ms, iotjs_https_t* https_data) {
 size_t iotjs_https_curl_read_callback(void* contents, size_t size, size_t nmemb,
                                       void* userp) {
   iotjs_https_t* https_data = (iotjs_https_t*)userp;
+  IOTJS_VALIDATED_STRUCT_METHOD(iotjs_https_t, https_data);
 
   // If stream wasnt made writable yet, make it so.
-  if (!https_data->is_stream_writable) {
-    https_data->is_stream_writable = true;
+  if (!_this->is_stream_writable) {
+    _this->is_stream_writable = true;
     iotjs_https_jcallback(https_data, IOTJS_MAGIC_STRING_ONWRITABLE,
                           iotjs_jargs_get_empty(), false);
   }
 
-  if (https_data->data_to_read) {
+  if (_this->data_to_read) {
     size_t real_size = size * nmemb;
-    size_t chunk_size = iotjs_string_size(&(https_data->read_chunk));
-    size_t left_to_copy_size = chunk_size - https_data->cur_read_index;
+    size_t chunk_size = iotjs_string_size(&(_this->read_chunk));
+    size_t left_to_copy_size = chunk_size - _this->cur_read_index;
 
     if (real_size < 1)
       return 0;
 
     // send some data
-    if (https_data->cur_read_index < chunk_size) {
+    if (_this->cur_read_index < chunk_size) {
       size_t num_to_copy =
           (left_to_copy_size < real_size) ? left_to_copy_size : real_size;
-      const char* buf = iotjs_string_data(&(https_data->read_chunk));
-      buf = &buf[_thttps_datahis->cur_read_index];
+      const char* buf = iotjs_string_data(&(_this->read_chunk));
+      buf = &buf[_this->cur_read_index];
       strncpy((char*)contents, buf, num_to_copy);
-      https_data->cur_read_index = https_data->cur_read_index + num_to_copy;
+      _this->cur_read_index = _this->cur_read_index + num_to_copy;
       return num_to_copy;
     }
 
     // Finished sending one chunk of data
-    https_data->cur_read_index = 0;
-    https_data->data_to_read = false;
+    _this->cur_read_index = 0;
+    _this->data_to_read = false;
     iotjs_https_call_read_onwrite_async(https_data);
   }
 
   // If the data is sent, and stream hasn't ended, wait for more data
-  if (!https_data->stream_ended) {
+  if (!_this->stream_ended) {
     return CURL_READFUNC_PAUSE;
   }
 
@@ -467,36 +483,36 @@ size_t iotjs_https_curl_read_callback(void* contents, size_t size, size_t nmemb,
 int iotjs_https_curl_socket_callback(CURL* easy, curl_socket_t sockfd,
                                      int action, void* userp, void* socketp) {
   iotjs_https_t* https_data = (iotjs_https_t*)userp;
+  IOTJS_VALIDATED_STRUCT_METHOD(iotjs_https_t, https_data);
   if (action == CURL_POLL_IN || action == CURL_POLL_OUT ||
       action == CURL_POLL_INOUT) {
     iotjs_https_poll_t* poll_data = NULL;
 
     if (!socketp) {
-      poll_data = iotjs_https_poll_create(https_data->loop, sockfd, https_data);
-      curl_multi_assign(https_data->curl_multi_handle, sockfd,
-                        (void*)poll_data);
-      https_data->closing_handles = https_data->closing_handles + 1;
-      if (https_data->poll_data == NULL)
-        https_data->poll_data = poll_data;
+      poll_data = iotjs_https_poll_create(_this->loop, sockfd, https_data);
+      curl_multi_assign(_this->curl_multi_handle, sockfd, (void*)poll_data);
+      _this->closing_handles = _this->closing_handles + 1;
+      if (_this->poll_data == NULL)
+        _this->poll_data = poll_data;
       else
-        iotjs_https_poll_append(https_data->poll_data, poll_data);
+        iotjs_https_poll_append(_this->poll_data, poll_data);
     } else
       poll_data = (iotjs_https_poll_t*)socketp;
 
     if (action == CURL_POLL_IN)
-      uv_poll_start(&poll_data->poll_handle, UV_READABLE,
+      uv_poll_start(iotjs_https_poll_get_poll_handle(poll_data), UV_READABLE,
                     iotjs_https_uv_poll_callback);
     else if (action == CURL_POLL_OUT)
-      uv_poll_start(&poll_data->poll_handle, UV_WRITABLE,
+      uv_poll_start(iotjs_https_poll_get_poll_handle(poll_data), UV_WRITABLE,
                     iotjs_https_uv_poll_callback);
     else if (action == CURL_POLL_INOUT)
-      uv_poll_start(&poll_data->poll_handle, UV_READABLE | UV_WRITABLE,
-                    iotjs_https_uv_poll_callback);
+      uv_poll_start(iotjs_https_poll_get_poll_handle(poll_data),
+                    UV_READABLE | UV_WRITABLE, iotjs_https_uv_poll_callback);
   } else {
     if (socketp) {
       iotjs_https_poll_t* poll_data = (iotjs_https_poll_t*)socketp;
       iotjs_https_poll_close(poll_data);
-      curl_multi_assign(https_data->curl_multi_handle, sockfd, NULL);
+      curl_multi_assign(_this->curl_multi_handle, sockfd, NULL);
     }
   }
   return 0;
@@ -515,14 +531,15 @@ int iotjs_https_curl_sockopt_callback(void* userp, curl_socket_t curlfd,
 int iotjs_https_curl_start_timeout_callback(CURLM* multi, long timeout_ms,
                                             void* userp) {
   iotjs_https_t* https_data = (iotjs_https_t*)userp;
+  IOTJS_VALIDATED_STRUCT_METHOD(iotjs_https_t, https_data);
   if (timeout_ms < 0)
-    uv_timer_stop(&(https_data->timeout));
+    uv_timer_stop(&(_this->timeout));
   else {
     if (timeout_ms == 0)
       timeout_ms = 1;
-    if ((https_data->timeout_ms != -1) && (timeout_ms > https_data->timeout_ms))
-      timeout_ms = https_data->timeout_ms;
-    uv_timer_start(&(https_data->timeout), iotjs_https_uv_timeout_callback,
+    if ((_this->timeout_ms != -1) && (timeout_ms > _this->timeout_ms))
+      timeout_ms = _this->timeout_ms;
+    uv_timer_start(&(_this->timeout), iotjs_https_uv_timeout_callback,
                    (uint64_t)timeout_ms, 0);
   }
   return 0;
@@ -532,8 +549,9 @@ int iotjs_https_curl_start_timeout_callback(CURLM* multi, long timeout_ms,
 size_t iotjs_https_curl_write_callback(void* contents, size_t size,
                                        size_t nmemb, void* userp) {
   iotjs_https_t* https_data = (iotjs_https_t*)userp;
+  IOTJS_VALIDATED_STRUCT_METHOD(iotjs_https_t, https_data);
   size_t real_size = size * nmemb;
-  if (jerry_value_is_null(https_data->jthis_native))
+  if (jerry_value_is_null(_this->jthis_native))
     return real_size - 1;
 
   iotjs_jargs_t jarg = iotjs_jargs_create(1);
@@ -562,18 +580,20 @@ size_t iotjs_https_curl_write_callback(void* contents, size_t size,
 // Callback called on closing handles during cleanup
 void iotjs_https_uv_close_callback(uv_handle_t* handle) {
   iotjs_https_t* https_data = (iotjs_https_t*)handle->data;
-  https_data->closing_handles = https_data->closing_handles - 1;
-  if (https_data->closing_handles <= 0) {
-    if (https_data->poll_data != NULL)
-      iotjs_https_poll_destroy(https_data->poll_data);
-    jerry_release_value(https_data->jthis_native);
+  IOTJS_VALIDATED_STRUCT_METHOD(iotjs_https_t, https_data);
+  _this->closing_handles = _this->closing_handles - 1;
+  if (_this->closing_handles <= 0) {
+    if (_this->poll_data != NULL)
+      iotjs_https_poll_destroy(_this->poll_data);
+    jerry_release_value(_this->jthis_native);
   }
 }
 
 // Callback called when poll detects actions on FD
 void iotjs_https_uv_poll_callback(uv_poll_t* poll, int status, int events) {
   iotjs_https_poll_t* poll_data = (iotjs_https_poll_t*)poll->data;
-  iotjs_https_t* https_data = (iotjs_https_t*)poll_data->https_data;
+  IOTJS_VALIDATED_STRUCT_METHOD(iotjs_https_poll_t, poll_data);
+  iotjs_https_t* https_data = (iotjs_https_t*)_this->https_data;
 
   int flags = 0;
   if (status < 0)
@@ -583,8 +603,8 @@ void iotjs_https_uv_poll_callback(uv_poll_t* poll, int status, int events) {
   if (!status && events & UV_WRITABLE)
     flags |= CURL_CSELECT_OUT;
   int running_handles;
-  curl_multi_socket_action(https_data->curl_multi_handle, poll_data->sockfd,
-                           flags, &running_handles);
+  curl_multi_socket_action(iotjs_https_get_multi_handle(https_data),
+                           _this->sockfd, flags, &running_handles);
   iotjs_https_check_done(https_data);
 }
 
@@ -592,39 +612,41 @@ void iotjs_https_uv_poll_callback(uv_poll_t* poll, int status, int events) {
 // This timeout is usually given by curl itself.
 void iotjs_https_uv_timeout_callback(uv_timer_t* timer) {
   iotjs_https_t* https_data = (iotjs_https_t*)(timer->data);
+  IOTJS_VALIDATED_STRUCT_METHOD(iotjs_https_t, https_data);
   uv_timer_stop(timer);
-  curl_multi_socket_action(https_data->curl_multi_handle, CURL_SOCKET_TIMEOUT,
-                           0, &https_data->running_handles);
+  curl_multi_socket_action(_this->curl_multi_handle, CURL_SOCKET_TIMEOUT, 0,
+                           &_this->running_handles);
   iotjs_https_check_done(https_data);
 }
 
 // Callback called to check if request has timed out
 void iotjs_https_uv_socket_timeout_callback(uv_timer_t* timer) {
   iotjs_https_t* https_data = (iotjs_https_t*)(timer->data);
+  IOTJS_VALIDATED_STRUCT_METHOD(iotjs_https_t, https_data);
   double download_bytes = 0;
   double upload_bytes = 0;
   uint64_t total_time_ms = 0;
 
-  if (https_data->timeout_ms != -1) {
-    curl_easy_getinfo(https_data->curl_easy_handle, CURLINFO_SIZE_DOWNLOAD,
+  if (_this->timeout_ms != -1) {
+    curl_easy_getinfo(_this->curl_easy_handle, CURLINFO_SIZE_DOWNLOAD,
                       &download_bytes);
-    curl_easy_getinfo(https_data->curl_easy_handle, CURLINFO_SIZE_UPLOAD,
+    curl_easy_getinfo(_this->curl_easy_handle, CURLINFO_SIZE_UPLOAD,
                       &upload_bytes);
-    total_time_ms = uv_now(https_data->loop);
+    total_time_ms = uv_now(_this->loop);
     double total_bytes = download_bytes + upload_bytes;
 
-    if (https_data->last_bytes_num == total_bytes) {
+    if (_this->last_bytes_num == total_bytes) {
       if (total_time_ms >
-          ((uint64_t)https_data->timeout_ms + https_data->last_bytes_time)) {
-        if (!https_data->request_done) {
+          ((uint64_t)_this->timeout_ms + _this->last_bytes_time)) {
+        if (!_this->request_done) {
           iotjs_https_jcallback(https_data, IOTJS_MAGIC_STRING_ONTIMEOUT,
                                 iotjs_jargs_get_empty(), false);
         }
-        uv_timer_stop(&(https_data->socket_timeout));
+        uv_timer_stop(&(_this->socket_timeout));
       }
     } else {
-      https_data->last_bytes_num = total_bytes;
-      https_data->last_bytes_time = total_time_ms;
+      _this->last_bytes_num = total_bytes;
+      _this->last_bytes_time = total_time_ms;
     }
   }
 }
@@ -634,33 +656,45 @@ iotjs_https_poll_t* iotjs_https_poll_create(uv_loop_t* loop,
                                             curl_socket_t sockfd,
                                             iotjs_https_t* https_data) {
   iotjs_https_poll_t* poll_data = IOTJS_ALLOC(iotjs_https_poll_t);
-  poll_data->sockfd = sockfd;
-  poll_data->poll_handle.data = poll_data;
-  poll_data->https_data = https_data;
-  poll_data->closing = false;
-  poll_data->next = NULL;
-  uv_poll_init_socket(loop, &poll_data->poll_handle, sockfd);
+  IOTJS_VALIDATED_STRUCT_CONSTRUCTOR(iotjs_https_poll_t, poll_data);
+  _this->sockfd = sockfd;
+  _this->poll_handle.data = poll_data;
+  _this->https_data = https_data;
+  _this->closing = false;
+  _this->next = NULL;
+  uv_poll_init_socket(loop, &_this->poll_handle, sockfd);
   return poll_data;
 }
 
 void iotjs_https_poll_append(iotjs_https_poll_t* head,
                              iotjs_https_poll_t* poll_data) {
   iotjs_https_poll_t* current = head;
-  iotjs_https_poll_t* next = current->next;
+  iotjs_https_poll_t* next = iotjs_https_poll_get_next(current);
   while (next != NULL) {
     current = next;
-    next = current->next;
+    next = iotjs_https_poll_get_next(current);
   }
-  current->next = poll_data;
+  IOTJS_VALIDATED_STRUCT_METHOD(iotjs_https_poll_t, current);
+  _this->next = poll_data;
+}
+
+iotjs_https_poll_t* iotjs_https_poll_get_next(iotjs_https_poll_t* poll_data) {
+  IOTJS_VALIDATED_STRUCT_METHOD(iotjs_https_poll_t, poll_data);
+  return _this->next;
+}
+
+uv_poll_t* iotjs_https_poll_get_poll_handle(iotjs_https_poll_t* poll_data) {
+  IOTJS_VALIDATED_STRUCT_METHOD(iotjs_https_poll_t, poll_data);
+  return &_this->poll_handle;
 }
 
 void iotjs_https_poll_close(iotjs_https_poll_t* poll_data) {
-  if (poll_data->closing == false) {
-    poll_data->closing = true;
-    uv_poll_stop(&poll_data->poll_handle);
-    poll_data->poll_handle.data = poll_data->https_data;
-    uv_close((uv_handle_t*)&poll_data->poll_handle,
-             iotjs_https_uv_close_callback);
+  IOTJS_VALIDATED_STRUCT_METHOD(iotjs_https_poll_t, poll_data);
+  if (_this->closing == false) {
+    _this->closing = true;
+    uv_poll_stop(&_this->poll_handle);
+    _this->poll_handle.data = _this->https_data;
+    uv_close((uv_handle_t*)&_this->poll_handle, iotjs_https_uv_close_callback);
   }
   return;
 }
@@ -669,13 +703,14 @@ void iotjs_https_poll_close_all(iotjs_https_poll_t* head) {
   iotjs_https_poll_t* current = head;
   while (current != NULL) {
     iotjs_https_poll_close(current);
-    current = current->next;
+    current = iotjs_https_poll_get_next(current);
   }
 }
 
 void iotjs_https_poll_destroy(iotjs_https_poll_t* poll_data) {
-  if (poll_data->next != NULL) {
-    iotjs_https_poll_destroy(poll_data->next);
+  IOTJS_VALIDATED_STRUCT_DESTRUCTOR(iotjs_https_poll_t, poll_data);
+  if (_this->next != NULL) {
+    iotjs_https_poll_destroy(_this->next);
   }
   IOTJS_RELEASE(poll_data);
 }

--- a/src/modules/iotjs_module_https.h
+++ b/src/modules/iotjs_module_https.h
@@ -83,7 +83,7 @@ typedef struct {
   jerry_value_t read_onwrite;
   uv_timer_t async_read_onwrite;
 
-} iotjs_https_t;
+} IOTJS_VALIDATED_STRUCT(iotjs_https_t);
 
 iotjs_https_t* iotjs_https_create(const char* URL, const char* method,
                                   const char* ca, const char* cert,
@@ -91,25 +91,26 @@ iotjs_https_t* iotjs_https_create(const char* URL, const char* method,
                                   const bool reject_unauthorized,
                                   jerry_value_t jthis);
 
+#define THIS iotjs_https_t* https_data
 // Some utility functions
-void iotjs_https_check_done(iotjs_https_t* https_data);
-void iotjs_https_cleanup(iotjs_https_t* https_data);
-void iotjs_https_initialize_curl_opts(iotjs_https_t* https_data);
-jerry_value_t iotjs_https_jiotjs_https_t* https_data_from_https(
-    iotjs_https_t* https_data);
-bool iotjs_https_jcallback(iotjs_https_t* https_data, const char* property,
+void iotjs_https_check_done(THIS);
+void iotjs_https_cleanup(THIS);
+CURLM* iotjs_https_get_multi_handle(THIS);
+void iotjs_https_initialize_curl_opts(THIS);
+jerry_value_t iotjs_https_jthis_from_https(THIS);
+bool iotjs_https_jcallback(THIS, const char* property,
                            const iotjs_jargs_t* jarg, bool resultvalue);
 void iotjs_https_call_read_onwrite(uv_timer_t* timer);
-void iotjs_https_call_read_onwrite_async(iotjs_https_t* https_data);
+void iotjs_https_call_read_onwrite_async(THIS);
 
 // Functions almost directly called by JS via JHANDLER
-void iotjs_https_add_header(iotjs_https_t* https_data, const char* char_header);
-void iotjs_https_data_to_write(iotjs_https_t* https_data,
-                               iotjs_string_t read_chunk,
+void iotjs_https_add_header(THIS, const char* char_header);
+void iotjs_https_data_to_write(THIS, iotjs_string_t read_chunk,
                                jerry_value_t callback, jerry_value_t onwrite);
-void iotjs_https_finish_request(iotjs_https_t* https_data);
-void iotjs_https_send_request(iotjs_https_t* https_data);
-void iotjs_https_set_timeout(long ms, iotjs_https_t* https_data);
+void iotjs_https_finish_request(THIS);
+void iotjs_https_send_request(THIS);
+void iotjs_https_set_timeout(long ms, THIS);
+#undef THIS
 
 
 // CURL callbacks
@@ -136,13 +137,15 @@ typedef struct {
   struct iotjs_https_t* https_data;
   curl_socket_t sockfd;
   bool closing;
-} iotjs_https_poll_t;
+} IOTJS_VALIDATED_STRUCT(iotjs_https_poll_t);
 
 iotjs_https_poll_t* iotjs_https_poll_create(uv_loop_t* loop,
                                             curl_socket_t sockfd,
                                             iotjs_https_t* https_data);
 void iotjs_https_poll_append(iotjs_https_poll_t* head,
                              iotjs_https_poll_t* poll_data);
+iotjs_https_poll_t* iotjs_https_poll_get_next(iotjs_https_poll_t* poll_data);
+uv_poll_t* iotjs_https_poll_get_poll_handle(iotjs_https_poll_t* poll_data);
 void iotjs_https_poll_close(iotjs_https_poll_t* poll_data);
 void iotjs_https_poll_destroy(iotjs_https_poll_t* poll_data);
 void iotjs_https_poll_close_all(iotjs_https_poll_t* head);


### PR DESCRIPTION
This reverts commit 24388e4391f2a872468efd989b3cebb4d1a5887d.

This commit should not have been merged because it does not build:

"_thttps_datahi" is a an existing symbol (replace misake?)

(Maybe the full.profile would have help to detect this).

IoT.js-DCO-1.0-Signed-off-by: Philippe Coval philippe.coval@osg.samsung.com