### PR TITLE
tizenrt: Import Kconfig.runtime from TizenRT sources

### DIFF
--- a/Kconfig.runtime
+++ b/Kconfig.runtime
@@ -1,0 +1,28 @@
+#
+# For a description of the syntax of this configuration file,
+# see kconfig-language at https://www.kernel.org/doc/Documentation/kbuild/kconfig-language.txt
+#
+
+config ENABLE_IOTJS
+	bool "IoT.js"
+	default n
+	select SPI_EXCHANGE
+	---help---
+		Enable IoT.js framework
+
+if ENABLE_IOTJS
+
+config IOTJS_PRIORITY
+        int "IoT.js task priority"
+        default 100
+
+config IOTJS_STACKSIZE
+        int "IoT.js stack size"
+        default 32768
+
+config IOTJS_JERRY_HEAP
+        int "Jerryscript Heaplimit"
+        default 128
+
+endif #ENABLE_IOTJS
+


### PR DESCRIPTION
If this file is merged in upstream,
then iotjs can be updated on TizenRT very easly by just cloning into:

TizenRT/external/iotjs/ (Kconfig.runtime is expected there)

For the record, here is history of file in TizenRT's master branch:

  commit 09cb6a6a9cc68598dcbd9abe12fcdb44e478bb16
  Author: sunghan <sh924.chang@samsung.com>
  Date:   Fri Sep 22 21:13:24 2017 +0900

    IoT.js: modify Kconfig to be called with Runtime Environment title

    1. Split Kconfig from external's
    2. Call it from os/Kconfig.runtime to get "Runtime Environment" title
       at 1st depth of menuconfig

  commit d9d52392ab5d8411eb5a24a58e123f01aa984b5f
  Author: Philippe Coval <philippe.coval@osg.samsung.com>
  Date:   Thu Jan 4 17:11:06 2018 +0100

    iotjs: Select SPI in KConfig

    Observed issue was:

      iotjs_module_spi-tizenrt.c:23:2: \
      error: #error "\n\nTizenRT CONFIG_SPI_EXCHANGE flag required for SPI module\n\n"

    Change-Id: I8ec289c680973f7949d48b64a459524dab2083e0
    Signed-off-by: Philippe Coval <philippe.coval@osg.samsung.com>

IoT.js-DCO-1.0-Signed-off-by: Philippe Coval philippe.coval@osg.samsung.com