### PR TITLE
Merge code duplication to reduce code size of system I/O modules

### DIFF
--- a/src/modules.json
+++ b/src/modules.json
@@ -22,7 +22,8 @@
           "native_files": ["modules/iotjs_module_adc.c"]
         }
       },
-      "native_files": ["modules/iotjs_module_adc.c"],
+      "native_files": ["modules/iotjs_module_adc.c",
+                       "modules/iotjs_module_periph_common.c"],
       "init": "InitAdc",
       "js_file": "js/adc.js"
     },
@@ -158,7 +159,8 @@
           "native_files": ["modules/tizenrt/iotjs_module_gpio-tizenrt.c"]
         }
       },
-      "native_files": ["modules/iotjs_module_gpio.c"],
+      "native_files": ["modules/iotjs_module_gpio.c",
+                       "modules/iotjs_module_periph_common.c"],
       "init": "InitGpio",
       "js_file": "js/gpio.js"
     },
@@ -223,7 +225,8 @@
           "native_files": ["modules/tizenrt/iotjs_module_i2c-tizenrt.c"]
         }
       },
-      "native_files": ["modules/iotjs_module_i2c.c"],
+      "native_files": ["modules/iotjs_module_i2c.c",
+                       "modules/iotjs_module_periph_common.c"],
       "init": "InitI2c",
       "js_file": "js/i2c.js"
     },
@@ -251,7 +254,8 @@
           "native_files": ["modules/tizenrt/iotjs_module_pwm-tizenrt.c"]
         }
       },
-      "native_files": ["modules/iotjs_module_pwm.c"],
+      "native_files": ["modules/iotjs_module_pwm.c",
+                       "modules/iotjs_module_periph_common.c"],
       "init": "InitPwm",
       "js_file": "js/pwm.js"
     },
@@ -267,7 +271,8 @@
           "native_files": ["modules/tizenrt/iotjs_module_spi-tizenrt.c"]
         }
       },
-      "native_files": ["modules/iotjs_module_spi.c"],
+      "native_files": ["modules/iotjs_module_spi.c",
+                       "modules/iotjs_module_periph_common.c"],
       "init": "InitSpi",
       "js_file": "js/spi.js"
     },
@@ -324,7 +329,8 @@
           "native_files": ["modules/tizenrt/iotjs_module_uart-tizenrt.c"]
         }
       },
-      "native_files": ["modules/iotjs_module_uart.c"],
+      "native_files": ["modules/iotjs_module_uart.c",
+                       "modules/iotjs_module_periph_common.c"],
       "init": "InitUart",
       "js_file": "js/uart.js",
       "require": ["events"]

--- a/src/modules/iotjs_module_adc.c
+++ b/src/modules/iotjs_module_adc.c
@@ -17,138 +17,35 @@
 #include "iotjs_module_adc.h"
 
 
-static JNativeInfoType this_module_native_info = {.free_cb = NULL };
+IOTJS_DEFINE_NATIVE_HANDLE_INFO_THIS_MODULE(adc);
 
+IOTJS_DEFINE_PERIPH_CREATE_FUNCTION(adc);
 
-static iotjs_adc_t* adc_create(const jerry_value_t jadc) {
-  iotjs_adc_t* adc = IOTJS_ALLOC(iotjs_adc_t);
-  iotjs_adc_create_platform_data(adc);
-  adc->jobject = jadc;
-  jerry_set_object_native_pointer(jadc, adc, &this_module_native_info);
-
-  return adc;
-}
-
-
-static void adc_destroy(iotjs_adc_t* adc) {
+static void iotjs_adc_destroy(iotjs_adc_t* adc) {
   iotjs_adc_destroy_platform_data(adc->platform_data);
   IOTJS_RELEASE(adc);
 }
 
-
-static iotjs_adc_reqwrap_t* adc_reqwrap_create(const jerry_value_t jcallback,
-                                               iotjs_adc_t* adc, AdcOp op) {
-  iotjs_adc_reqwrap_t* adc_reqwrap = IOTJS_ALLOC(iotjs_adc_reqwrap_t);
-
-  iotjs_reqwrap_initialize(&adc_reqwrap->reqwrap, jcallback,
-                           (uv_req_t*)&adc_reqwrap->req);
-
-  adc_reqwrap->req_data.op = op;
-  adc_reqwrap->adc_data = adc;
-  return adc_reqwrap;
-}
-
-static void adc_reqwrap_destroy(iotjs_adc_reqwrap_t* adc_reqwrap) {
-  iotjs_reqwrap_destroy(&adc_reqwrap->reqwrap);
-  IOTJS_RELEASE(adc_reqwrap);
-}
-
-
 static void adc_worker(uv_work_t* work_req) {
-  iotjs_adc_reqwrap_t* req_wrap =
-      (iotjs_adc_reqwrap_t*)(iotjs_reqwrap_from_request((uv_req_t*)work_req));
-  iotjs_adc_reqdata_t* req_data = &req_wrap->req_data;
-  iotjs_adc_t* adc = req_wrap->adc_data;
+  iotjs_periph_reqwrap_t* req_wrap =
+      (iotjs_periph_reqwrap_t*)(iotjs_reqwrap_from_request(
+          (uv_req_t*)work_req));
+  iotjs_adc_t* adc = (iotjs_adc_t*)req_wrap->data;
 
-  switch (req_data->op) {
+  switch (req_wrap->op) {
     case kAdcOpOpen:
-      req_data->result = iotjs_adc_open(adc);
+      req_wrap->result = iotjs_adc_open(adc);
       break;
     case kAdcOpRead:
-      req_data->result = iotjs_adc_read(adc);
+      req_wrap->result = iotjs_adc_read(adc);
       break;
     case kAdcOpClose:
-      req_data->result = iotjs_adc_close(adc);
+      req_wrap->result = iotjs_adc_close(adc);
       break;
     default:
       IOTJS_ASSERT(!"Invalid Adc Operation");
   }
 }
-
-
-static const char* adc_error_string(uint8_t op) {
-  switch (op) {
-    case kAdcOpClose:
-      return "Close error, cannot close ADC";
-    case kAdcOpOpen:
-      return "Open error, cannot open ADC";
-    case kAdcOpRead:
-      return "Read error, cannot read ADC";
-    default:
-      return "Unknown ADC error";
-  }
-}
-
-
-static void adc_after_worker(uv_work_t* work_req, int status) {
-  iotjs_adc_reqwrap_t* req_wrap =
-      (iotjs_adc_reqwrap_t*)(iotjs_reqwrap_from_request((uv_req_t*)work_req));
-  iotjs_adc_reqdata_t* req_data = &req_wrap->req_data;
-
-  iotjs_jargs_t jargs = iotjs_jargs_create(2);
-  bool result = req_data->result;
-
-  if (status) {
-    iotjs_jargs_append_error(&jargs, "ADC System Error");
-  } else {
-    switch (req_data->op) {
-      case kAdcOpRead:
-        if (!result) {
-          iotjs_jargs_append_error(&jargs, adc_error_string(req_data->op));
-        } else {
-          iotjs_adc_t* adc = req_wrap->adc_data;
-
-          iotjs_jargs_append_null(&jargs);
-          iotjs_jargs_append_number(&jargs, adc->value);
-        }
-        break;
-      case kAdcOpOpen:
-      case kAdcOpClose:
-        if (!result) {
-          iotjs_jargs_append_error(&jargs, adc_error_string(req_data->op));
-        } else {
-          iotjs_jargs_append_null(&jargs);
-        }
-        break;
-      default: {
-        IOTJS_ASSERT(!"ADC after worker failed");
-        break;
-      }
-    }
-  }
-
-  const jerry_value_t jcallback = iotjs_reqwrap_jcallback(&req_wrap->reqwrap);
-  if (jerry_value_is_function(jcallback)) {
-    iotjs_make_callback(jcallback, jerry_create_undefined(), &jargs);
-  }
-
-  if (req_data->op == kAdcOpClose) {
-    adc_destroy(req_wrap->adc_data);
-  }
-
-  iotjs_jargs_destroy(&jargs);
-  adc_reqwrap_destroy(req_wrap);
-}
-
-
-#define ADC_CALL_ASYNC(op, jcallback)                                       \
-  do {                                                                      \
-    uv_loop_t* loop = iotjs_environment_loop(iotjs_environment_get());      \
-    iotjs_adc_reqwrap_t* req_wrap = adc_reqwrap_create(jcallback, adc, op); \
-    uv_work_t* req = &req_wrap->req;                                        \
-    uv_queue_work(loop, req, adc_worker, adc_after_worker);                 \
-  } while (0)
-
 
 JS_FUNCTION(AdcCons) {
   DJS_CHECK_THIS();
@@ -175,9 +72,9 @@ JS_FUNCTION(AdcCons) {
   // If the callback doesn't exist, it is completed synchronously.
   // Otherwise, it will be executed asynchronously.
   if (!jerry_value_is_null(jcallback)) {
-    ADC_CALL_ASYNC(kAdcOpOpen, jcallback);
+    iotjs_periph_call_async(adc, jcallback, kAdcOpOpen, adc_worker);
   } else if (!iotjs_adc_open(adc)) {
-    return JS_CREATE_ERROR(COMMON, adc_error_string(kAdcOpOpen));
+    return JS_CREATE_ERROR(COMMON, iotjs_periph_error_str(kAdcOpOpen));
   }
 
   return jerry_create_undefined();
@@ -188,7 +85,8 @@ JS_FUNCTION(Read) {
   JS_DECLARE_THIS_PTR(adc, adc);
   DJS_CHECK_ARG_IF_EXIST(0, function);
 
-  ADC_CALL_ASYNC(kAdcOpRead, JS_GET_ARG_IF_EXIST(0, function));
+  iotjs_periph_call_async(adc, JS_GET_ARG_IF_EXIST(0, function), kAdcOpRead,
+                          adc_worker);
 
   return jerry_create_undefined();
 }
@@ -197,7 +95,7 @@ JS_FUNCTION(ReadSync) {
   JS_DECLARE_THIS_PTR(adc, adc);
 
   if (!iotjs_adc_read(adc)) {
-    return JS_CREATE_ERROR(COMMON, adc_error_string(kAdcOpRead));
+    return JS_CREATE_ERROR(COMMON, iotjs_periph_error_str(kAdcOpRead));
   }
 
   return jerry_create_number(adc->value);
@@ -207,7 +105,8 @@ JS_FUNCTION(Close) {
   JS_DECLARE_THIS_PTR(adc, adc);
   DJS_CHECK_ARG_IF_EXIST(0, function);
 
-  ADC_CALL_ASYNC(kAdcOpClose, JS_GET_ARG_IF_EXIST(0, function));
+  iotjs_periph_call_async(adc, JS_GET_ARG_IF_EXIST(0, function), kAdcOpClose,
+                          adc_worker);
 
   return jerry_create_undefined();
 }
@@ -216,9 +115,8 @@ JS_FUNCTION(CloseSync) {
   JS_DECLARE_THIS_PTR(adc, adc);
 
   bool ret = iotjs_adc_close(adc);
-  adc_destroy(adc);
   if (!ret) {
-    return JS_CREATE_ERROR(COMMON, adc_error_string(kAdcOpClose));
+    return JS_CREATE_ERROR(COMMON, iotjs_periph_error_str(kAdcOpClose));
   }
 
   return jerry_create_undefined();

--- a/src/modules/iotjs_module_adc.h
+++ b/src/modules/iotjs_module_adc.h
@@ -18,14 +18,8 @@
 #define IOTJS_MODULE_ADC_H
 
 #include "iotjs_def.h"
+#include "iotjs_module_periph_common.h"
 #include "iotjs_reqwrap.h"
-
-
-typedef enum {
-  kAdcOpOpen,
-  kAdcOpRead,
-  kAdcOpClose,
-} AdcOp;
 
 // Forward declaration of platform data. These are only used by platform code.
 // Generic ADC module never dereferences platform data pointer.
@@ -36,21 +30,6 @@ typedef struct {
   iotjs_adc_platform_data_t* platform_data;
   int32_t value;
 } iotjs_adc_t;
-
-
-typedef struct {
-  bool result;
-  AdcOp op;
-} iotjs_adc_reqdata_t;
-
-
-typedef struct {
-  iotjs_reqwrap_t reqwrap;
-  uv_work_t req;
-  iotjs_adc_reqdata_t req_data;
-  iotjs_adc_t* adc_data;
-} iotjs_adc_reqwrap_t;
-
 
 bool iotjs_adc_read(iotjs_adc_t* adc);
 bool iotjs_adc_close(iotjs_adc_t* adc);

--- a/src/modules/iotjs_module_gpio.c
+++ b/src/modules/iotjs_module_gpio.c
@@ -19,166 +19,36 @@
 
 IOTJS_DEFINE_NATIVE_HANDLE_INFO_THIS_MODULE(gpio);
 
-static iotjs_gpio_t* gpio_create(jerry_value_t jgpio) {
-  iotjs_gpio_t* gpio = IOTJS_ALLOC(iotjs_gpio_t);
-  iotjs_gpio_create_platform_data(gpio);
-  gpio->jobject = jgpio;
-  jerry_set_object_native_pointer(jgpio, gpio, &this_module_native_info);
-
-  return gpio;
-}
-
-
-static iotjs_gpio_reqwrap_t* gpio_reqwrap_create(jerry_value_t jcallback,
-                                                 iotjs_gpio_t* gpio,
-                                                 GpioOp op) {
-  iotjs_gpio_reqwrap_t* gpio_reqwrap = IOTJS_ALLOC(iotjs_gpio_reqwrap_t);
-
-  iotjs_reqwrap_initialize(&gpio_reqwrap->reqwrap, jcallback,
-                           (uv_req_t*)&gpio_reqwrap->req);
-
-  gpio_reqwrap->req_data.op = op;
-  gpio_reqwrap->gpio_data = gpio;
-  return gpio_reqwrap;
-}
-
-
-static void gpio_reqwrap_destroy(iotjs_gpio_reqwrap_t* gpio_reqwrap) {
-  iotjs_reqwrap_destroy(&gpio_reqwrap->reqwrap);
-  IOTJS_RELEASE(gpio_reqwrap);
-}
-
-
-static void gpio_reqwrap_dispatched(iotjs_gpio_reqwrap_t* gpio_reqwrap) {
-  gpio_reqwrap_destroy(gpio_reqwrap);
-}
-
-
-static uv_work_t* gpio_reqwrap_req(iotjs_gpio_reqwrap_t* gpio_reqwrap) {
-  return &gpio_reqwrap->req;
-}
-
-
-static jerry_value_t gpio_reqwrap_jcallback(
-    iotjs_gpio_reqwrap_t* gpio_reqwrap) {
-  return iotjs_reqwrap_jcallback(&gpio_reqwrap->reqwrap);
-}
-
-
-static iotjs_gpio_reqwrap_t* gpio_reqwrap_from_request(uv_work_t* req) {
-  return (iotjs_gpio_reqwrap_t*)(iotjs_reqwrap_from_request((uv_req_t*)req));
-}
-
-
-static iotjs_gpio_reqdata_t* gpio_reqwrap_data(
-    iotjs_gpio_reqwrap_t* gpio_reqwrap) {
-  return &gpio_reqwrap->req_data;
-}
-
-
-static iotjs_gpio_t* gpio_instance_from_reqwrap(
-    iotjs_gpio_reqwrap_t* gpio_reqwrap) {
-  return gpio_reqwrap->gpio_data;
-}
-
+IOTJS_DEFINE_PERIPH_CREATE_FUNCTION(gpio);
 
 static void iotjs_gpio_destroy(iotjs_gpio_t* gpio) {
   iotjs_gpio_destroy_platform_data(gpio->platform_data);
   IOTJS_RELEASE(gpio);
 }
 
-
-static iotjs_gpio_t* gpio_instance_from_jval(const jerry_value_t jgpio) {
-  uintptr_t handle = iotjs_jval_get_object_native_handle(jgpio);
-  return (iotjs_gpio_t*)handle;
-}
-
-
 static void gpio_worker(uv_work_t* work_req) {
-  iotjs_gpio_reqwrap_t* req_wrap = gpio_reqwrap_from_request(work_req);
-  iotjs_gpio_reqdata_t* req_data = gpio_reqwrap_data(req_wrap);
-  iotjs_gpio_t* gpio = gpio_instance_from_reqwrap(req_wrap);
+  iotjs_periph_reqwrap_t* req_wrap =
+      (iotjs_periph_reqwrap_t*)(iotjs_reqwrap_from_request(
+          (uv_req_t*)work_req));
+  iotjs_gpio_t* gpio = (iotjs_gpio_t*)req_wrap->data;
 
-  switch (req_data->op) {
+  switch (req_wrap->op) {
     case kGpioOpOpen:
-      req_data->result = iotjs_gpio_open(gpio);
+      req_wrap->result = iotjs_gpio_open(gpio);
       break;
     case kGpioOpWrite:
-      req_data->result = iotjs_gpio_write(gpio);
+      req_wrap->result = iotjs_gpio_write(gpio);
       break;
     case kGpioOpRead:
-      req_data->result = iotjs_gpio_read(gpio);
+      req_wrap->result = iotjs_gpio_read(gpio);
       break;
     case kGpioOpClose:
-      req_data->result = iotjs_gpio_close(gpio);
+      req_wrap->result = iotjs_gpio_close(gpio);
       break;
     default:
-      IOTJS_ASSERT(!"Invalid Gpio Operation");
+      IOTJS_ASSERT(!"Invalid Operation");
   }
 }
-
-
-static const char* gpio_error_string(uint8_t op) {
-  switch (op) {
-    case kGpioOpClose:
-      return "Close error, cannot close GPIO";
-    case kGpioOpOpen:
-      return "Open error, cannot open GPIO";
-    case kGpioOpRead:
-      return "Read error, cannot read GPIO";
-    case kGpioOpWrite:
-      return "Write error, cannot read GPIO";
-    default:
-      return "Unknown GPIO error";
-  }
-}
-
-
-static void gpio_after_worker(uv_work_t* work_req, int status) {
-  iotjs_gpio_reqwrap_t* req_wrap = gpio_reqwrap_from_request(work_req);
-  iotjs_gpio_reqdata_t* req_data = gpio_reqwrap_data(req_wrap);
-
-  iotjs_jargs_t jargs = iotjs_jargs_create(2);
-  bool result = req_data->result;
-
-  if (status) {
-    iotjs_jargs_append_error(&jargs, "GPIO System Error");
-  } else {
-    switch (req_data->op) {
-      case kGpioOpRead:
-        if (!result) {
-          iotjs_jargs_append_error(&jargs, gpio_error_string(req_data->op));
-        } else {
-          iotjs_gpio_t* gpio = gpio_instance_from_reqwrap(req_wrap);
-
-          iotjs_jargs_append_null(&jargs);
-          iotjs_jargs_append_bool(&jargs, gpio->value);
-        }
-        break;
-      case kGpioOpOpen:
-      case kGpioOpWrite:
-      case kGpioOpClose:
-        if (!result) {
-          iotjs_jargs_append_error(&jargs, gpio_error_string(req_data->op));
-        } else {
-          iotjs_jargs_append_null(&jargs);
-        }
-        break;
-      default:
-        IOTJS_ASSERT(!"Unreachable");
-        break;
-    }
-  }
-
-  const jerry_value_t jcallback = gpio_reqwrap_jcallback(req_wrap);
-  if (jerry_value_is_function(jcallback)) {
-    iotjs_make_callback(jcallback, jerry_create_undefined(), &jargs);
-  }
-
-  iotjs_jargs_destroy(&jargs);
-  gpio_reqwrap_dispatched(req_wrap);
-}
-
 
 static jerry_value_t gpio_set_configuration(iotjs_gpio_t* gpio,
                                             jerry_value_t jconfigurable) {
@@ -264,16 +134,6 @@ static jerry_value_t gpio_set_configuration(iotjs_gpio_t* gpio,
   return jerry_create_undefined();
 }
 
-
-#define GPIO_CALL_ASYNC(op, jcallback)                                         \
-  do {                                                                         \
-    uv_loop_t* loop = iotjs_environment_loop(iotjs_environment_get());         \
-    iotjs_gpio_reqwrap_t* req_wrap = gpio_reqwrap_create(jcallback, gpio, op); \
-    uv_work_t* req = gpio_reqwrap_req(req_wrap);                               \
-    uv_queue_work(loop, req, gpio_worker, gpio_after_worker);                  \
-  } while (0)
-
-
 JS_FUNCTION(GpioCons) {
   DJS_CHECK_THIS();
   DJS_CHECK_ARGS(1, object);
@@ -282,7 +142,6 @@ JS_FUNCTION(GpioCons) {
   // Create GPIO object
   const jerry_value_t jgpio = JS_GET_THIS();
   iotjs_gpio_t* gpio = gpio_create(jgpio);
-  IOTJS_ASSERT(gpio == gpio_instance_from_jval(jgpio));
 
   jerry_value_t config_res =
       gpio_set_configuration(gpio, JS_GET_ARG(0, object));
@@ -296,35 +155,33 @@ JS_FUNCTION(GpioCons) {
   // If the callback doesn't exist, it is completed synchronously.
   // Otherwise, it will be executed asynchronously.
   if (!jerry_value_is_null(jcallback)) {
-    GPIO_CALL_ASYNC(kGpioOpOpen, jcallback);
+    iotjs_periph_call_async(gpio, jcallback, kGpioOpOpen, gpio_worker);
   } else if (!iotjs_gpio_open(gpio)) {
-    return JS_CREATE_ERROR(COMMON, gpio_error_string(kGpioOpOpen));
+    return JS_CREATE_ERROR(COMMON, iotjs_periph_error_str(kGpioOpOpen));
   }
 
   return jerry_create_undefined();
 }
-
 
 JS_FUNCTION(Close) {
   JS_DECLARE_THIS_PTR(gpio, gpio);
   DJS_CHECK_ARG_IF_EXIST(0, function);
 
-  GPIO_CALL_ASYNC(kGpioOpClose, JS_GET_ARG_IF_EXIST(0, function));
+  iotjs_periph_call_async(gpio, JS_GET_ARG_IF_EXIST(0, function), kGpioOpClose,
+                          gpio_worker);
 
   return jerry_create_undefined();
 }
-
 
 JS_FUNCTION(CloseSync) {
   JS_DECLARE_THIS_PTR(gpio, gpio);
 
   if (!iotjs_gpio_close(gpio)) {
-    return JS_CREATE_ERROR(COMMON, gpio_error_string(kGpioOpClose));
+    return JS_CREATE_ERROR(COMMON, iotjs_periph_error_str(kGpioOpClose));
   }
 
   return jerry_create_undefined();
 }
-
 
 JS_FUNCTION(Write) {
   JS_DECLARE_THIS_PTR(gpio, gpio);
@@ -335,18 +192,18 @@ JS_FUNCTION(Write) {
   } else if (jerry_value_is_boolean(jargv[0])) {
     value = jerry_get_boolean_value(jargv[0]);
   } else {
-    return JS_CREATE_ERROR(COMMON, "GPIO Write Error - Wrong argument type");
+    return JS_CREATE_ERROR(COMMON, iotjs_periph_error_str(kGpioOpWrite));
   }
 
   DJS_CHECK_ARG_IF_EXIST(1, function);
 
   gpio->value = value;
 
-  GPIO_CALL_ASYNC(kGpioOpWrite, JS_GET_ARG_IF_EXIST(1, function));
+  iotjs_periph_call_async(gpio, JS_GET_ARG_IF_EXIST(1, function), kGpioOpWrite,
+                          gpio_worker);
 
   return jerry_create_undefined();
 }
-
 
 JS_FUNCTION(WriteSync) {
   JS_DECLARE_THIS_PTR(gpio, gpio);
@@ -364,33 +221,31 @@ JS_FUNCTION(WriteSync) {
   gpio->value = value;
 
   if (!iotjs_gpio_write(gpio)) {
-    return JS_CREATE_ERROR(COMMON, gpio_error_string(kGpioOpWrite));
+    return JS_CREATE_ERROR(COMMON, iotjs_periph_error_str(kGpioOpWrite));
   }
 
   return jerry_create_undefined();
 }
-
 
 JS_FUNCTION(Read) {
   JS_DECLARE_THIS_PTR(gpio, gpio);
   DJS_CHECK_ARG_IF_EXIST(0, function);
 
-  GPIO_CALL_ASYNC(kGpioOpRead, JS_GET_ARG_IF_EXIST(0, function));
+  iotjs_periph_call_async(gpio, JS_GET_ARG_IF_EXIST(0, function), kGpioOpRead,
+                          gpio_worker);
 
   return jerry_create_undefined();
 }
-
 
 JS_FUNCTION(ReadSync) {
   JS_DECLARE_THIS_PTR(gpio, gpio);
 
   if (!iotjs_gpio_read(gpio)) {
-    return JS_CREATE_ERROR(COMMON, gpio_error_string(kGpioOpRead));
+    return JS_CREATE_ERROR(COMMON, iotjs_periph_error_str(kGpioOpRead));
   }
 
   return jerry_create_boolean(gpio->value);
 }
-
 
 jerry_value_t InitGpio() {
   jerry_value_t jgpioConstructor = jerry_create_external_function(GpioCons);

--- a/src/modules/iotjs_module_gpio.h
+++ b/src/modules/iotjs_module_gpio.h
@@ -19,6 +19,7 @@
 
 
 #include "iotjs_def.h"
+#include "iotjs_module_periph_common.h"
 #include "iotjs_reqwrap.h"
 
 
@@ -27,7 +28,6 @@ typedef enum {
   kGpioDirectionOut,
   __kGpioDirectionMax
 } GpioDirection;
-
 
 typedef enum {
   kGpioModeNone = 0,
@@ -39,7 +39,6 @@ typedef enum {
   __kGpioModeMax
 } GpioMode;
 
-
 typedef enum {
   kGpioEdgeNone = 0,
   kGpioEdgeRising,
@@ -47,20 +46,6 @@ typedef enum {
   kGpioEdgeBoth,
   __kGpioEdgeMax
 } GpioEdge;
-
-
-typedef enum {
-  kGpioOpOpen,
-  kGpioOpWrite,
-  kGpioOpRead,
-  kGpioOpClose,
-} GpioOp;
-
-
-typedef struct {
-  GpioOp op;
-  bool result;
-} iotjs_gpio_reqdata_t;
 
 typedef struct iotjs_gpio_platform_data_s iotjs_gpio_platform_data_t;
 
@@ -75,15 +60,6 @@ typedef struct {
   GpioMode mode;
   GpioEdge edge;
 } iotjs_gpio_t;
-
-
-typedef struct {
-  iotjs_reqwrap_t reqwrap;
-  uv_work_t req;
-  iotjs_gpio_reqdata_t req_data;
-  iotjs_gpio_t* gpio_data;
-} iotjs_gpio_reqwrap_t;
-
 
 bool iotjs_gpio_open(iotjs_gpio_t* gpio);
 bool iotjs_gpio_write(iotjs_gpio_t* gpio);

--- a/src/modules/iotjs_module_i2c.c
+++ b/src/modules/iotjs_module_i2c.c
@@ -20,31 +20,7 @@
 
 IOTJS_DEFINE_NATIVE_HANDLE_INFO_THIS_MODULE(i2c);
 
-static iotjs_i2c_t* i2c_create(const jerry_value_t ji2c) {
-  iotjs_i2c_t* i2c = IOTJS_ALLOC(iotjs_i2c_t);
-  iotjs_i2c_create_platform_data(i2c);
-  i2c->jobject = ji2c;
-  jerry_set_object_native_pointer(ji2c, i2c, &this_module_native_info);
-
-  return i2c;
-}
-
-static iotjs_i2c_reqwrap_t* i2c_reqwrap_create(const jerry_value_t jcallback,
-                                               iotjs_i2c_t* i2c, I2cOp op) {
-  iotjs_i2c_reqwrap_t* i2c_reqwrap = IOTJS_ALLOC(iotjs_i2c_reqwrap_t);
-
-  iotjs_reqwrap_initialize(&i2c_reqwrap->reqwrap, jcallback,
-                           (uv_req_t*)&i2c_reqwrap->req);
-
-  i2c_reqwrap->req_data.op = op;
-  i2c_reqwrap->i2c_data = i2c;
-  return i2c_reqwrap;
-}
-
-static void i2c_reqwrap_destroy(iotjs_i2c_reqwrap_t* i2c_reqwrap) {
-  iotjs_reqwrap_destroy(&i2c_reqwrap->reqwrap);
-  IOTJS_RELEASE(i2c_reqwrap);
-}
+IOTJS_DEFINE_PERIPH_CREATE_FUNCTION(i2c);
 
 static void iotjs_i2c_destroy(iotjs_i2c_t* i2c) {
   iotjs_i2c_destroy_platform_data(i2c->platform_data);
@@ -52,106 +28,28 @@ static void iotjs_i2c_destroy(iotjs_i2c_t* i2c) {
 }
 
 static void i2c_worker(uv_work_t* work_req) {
-  iotjs_i2c_reqwrap_t* req_wrap =
-      (iotjs_i2c_reqwrap_t*)(iotjs_reqwrap_from_request((uv_req_t*)work_req));
-  iotjs_i2c_reqdata_t* req_data = &req_wrap->req_data;
-  iotjs_i2c_t* i2c = req_wrap->i2c_data;
+  iotjs_periph_reqwrap_t* req_wrap =
+      (iotjs_periph_reqwrap_t*)(iotjs_reqwrap_from_request(
+          (uv_req_t*)work_req));
+  iotjs_i2c_t* i2c = (iotjs_i2c_t*)req_wrap->data;
 
-  switch (req_data->op) {
+  switch (req_wrap->op) {
     case kI2cOpOpen:
-      req_data->result = iotjs_i2c_open(i2c);
+      req_wrap->result = iotjs_i2c_open(i2c);
       break;
     case kI2cOpWrite:
-      req_data->result = iotjs_i2c_write(i2c);
+      req_wrap->result = iotjs_i2c_write(i2c);
       break;
     case kI2cOpRead:
-      req_data->result = iotjs_i2c_read(i2c);
+      req_wrap->result = iotjs_i2c_read(i2c);
       break;
     case kI2cOpClose:
-      req_data->result = iotjs_i2c_close(i2c);
+      req_wrap->result = iotjs_i2c_close(i2c);
       break;
     default:
       IOTJS_ASSERT(!"Invalid Operation");
   }
 }
-
-static const char* i2c_error_str(int op) {
-  switch (op) {
-    case kI2cOpOpen:
-      return "Open error, cannot open I2C";
-    case kI2cOpWrite:
-      return "Write error, cannot write I2C";
-    case kI2cOpRead:
-      return "Read error, cannot read I2C";
-    case kI2cOpClose:
-      return "Close error, cannot close I2C";
-    default:
-      return "Unknown error";
-  }
-}
-
-static void i2c_after_worker(uv_work_t* work_req, int status) {
-  iotjs_i2c_reqwrap_t* req_wrap =
-      (iotjs_i2c_reqwrap_t*)(iotjs_reqwrap_from_request((uv_req_t*)work_req));
-  iotjs_i2c_reqdata_t* req_data = &req_wrap->req_data;
-
-  iotjs_jargs_t jargs = iotjs_jargs_create(2);
-
-  if (status) {
-    iotjs_jargs_append_error(&jargs, "System error");
-  } else {
-    switch (req_data->op) {
-      case kI2cOpOpen:
-      case kI2cOpWrite:
-      case kI2cOpClose: {
-        if (!req_data->result) {
-          iotjs_jargs_append_error(&jargs, i2c_error_str(req_data->op));
-        } else {
-          iotjs_jargs_append_null(&jargs);
-        }
-        break;
-      }
-      case kI2cOpRead: {
-        if (!req_data->result) {
-          iotjs_jargs_append_error(&jargs, i2c_error_str(req_data->op));
-        } else {
-          iotjs_i2c_t* i2c = req_wrap->i2c_data;
-
-          iotjs_jargs_append_null(&jargs);
-          jerry_value_t result =
-              iotjs_jval_create_byte_array(i2c->buf_len, i2c->buf_data);
-          iotjs_jargs_append_jval(&jargs, result);
-          jerry_release_value(result);
-
-          if (i2c->buf_data != NULL) {
-            iotjs_buffer_release(i2c->buf_data);
-          }
-        }
-        break;
-      }
-      default: {
-        IOTJS_ASSERT(!"Unreachable");
-        break;
-      }
-    }
-  }
-
-  const jerry_value_t jcallback = iotjs_reqwrap_jcallback(&req_wrap->reqwrap);
-  if (jerry_value_is_function(jcallback)) {
-    iotjs_make_callback(jcallback, jerry_create_undefined(), &jargs);
-  }
-
-  iotjs_jargs_destroy(&jargs);
-  i2c_reqwrap_destroy(req_wrap);
-}
-
-#define I2C_CALL_ASYNC(op, jcallback)                                       \
-  do {                                                                      \
-    uv_loop_t* loop = iotjs_environment_loop(iotjs_environment_get());      \
-    iotjs_i2c_reqwrap_t* req_wrap = i2c_reqwrap_create(jcallback, i2c, op); \
-    uv_work_t* req = &req_wrap->req;                                        \
-    uv_queue_work(loop, req, i2c_worker, i2c_after_worker);                 \
-  } while (0)
 
 JS_FUNCTION(I2cCons) {
   DJS_CHECK_THIS();
@@ -178,9 +76,9 @@ JS_FUNCTION(I2cCons) {
   // If the callback doesn't exist, it is completed synchronously.
   // Otherwise, it will be executed asynchronously.
   if (!jerry_value_is_null(jcallback)) {
-    I2C_CALL_ASYNC(kI2cOpOpen, jcallback);
+    iotjs_periph_call_async(i2c, jcallback, kI2cOpOpen, i2c_worker);
   } else if (!iotjs_i2c_open(i2c)) {
-    return JS_CREATE_ERROR(COMMON, "I2C Error: cannot open I2C");
+    return JS_CREATE_ERROR(COMMON, iotjs_periph_error_str(kI2cOpOpen));
   }
 
   return jerry_create_undefined();
@@ -190,7 +88,8 @@ JS_FUNCTION(Close) {
   JS_DECLARE_THIS_PTR(i2c, i2c);
   DJS_CHECK_ARG_IF_EXIST(1, function);
 
-  I2C_CALL_ASYNC(kI2cOpClose, JS_GET_ARG_IF_EXIST(0, function));
+  iotjs_periph_call_async(i2c, JS_GET_ARG_IF_EXIST(0, function), kI2cOpClose,
+                          i2c_worker);
 
   return jerry_create_undefined();
 }
@@ -199,7 +98,7 @@ JS_FUNCTION(CloseSync) {
   JS_DECLARE_THIS_PTR(i2c, i2c);
 
   if (!iotjs_i2c_close(i2c)) {
-    return JS_CREATE_ERROR(COMMON, "I2C Error: cannot close");
+    return JS_CREATE_ERROR(COMMON, iotjs_periph_error_str(kI2cOpClose));
   }
 
   return jerry_create_undefined();
@@ -215,10 +114,11 @@ static jerry_value_t i2c_write(iotjs_i2c_t* i2c, const jerry_value_t jargv[],
   i2c->buf_data = iotjs_buffer_allocate_from_number_array(i2c->buf_len, jarray);
 
   if (async) {
-    I2C_CALL_ASYNC(kI2cOpWrite, JS_GET_ARG_IF_EXIST(1, function));
+    iotjs_periph_call_async(i2c, JS_GET_ARG_IF_EXIST(1, function), kI2cOpWrite,
+                            i2c_worker);
   } else {
     if (!iotjs_i2c_write(i2c)) {
-      return JS_CREATE_ERROR(COMMON, "I2C Error: writeSync");
+      return JS_CREATE_ERROR(COMMON, iotjs_periph_error_str(kI2cOpWrite));
     }
   }
 
@@ -247,8 +147,8 @@ JS_FUNCTION(Read) {
 
   JS_GET_REQUIRED_ARG_VALUE(0, i2c->buf_len, IOTJS_MAGIC_STRING_LENGTH, number);
 
-  jerry_value_t jcallback = JS_GET_ARG_IF_EXIST(1, function);
-  I2C_CALL_ASYNC(kI2cOpRead, jcallback);
+  iotjs_periph_call_async(i2c, JS_GET_ARG_IF_EXIST(1, function), kI2cOpRead,
+                          i2c_worker);
 
   return jerry_create_undefined();
 }
@@ -260,7 +160,7 @@ JS_FUNCTION(ReadSync) {
   JS_GET_REQUIRED_ARG_VALUE(0, i2c->buf_len, IOTJS_MAGIC_STRING_LENGTH, number);
 
   if (!iotjs_i2c_read(i2c)) {
-    return JS_CREATE_ERROR(COMMON, "I2C Error: readSync");
+    return JS_CREATE_ERROR(COMMON, iotjs_periph_error_str(kI2cOpRead));
   }
 
   return iotjs_jval_create_byte_array(i2c->buf_len, i2c->buf_data);

--- a/src/modules/iotjs_module_i2c.h
+++ b/src/modules/iotjs_module_i2c.h
@@ -18,20 +18,8 @@
 #define IOTJS_MODULE_I2C_H
 
 #include "iotjs_def.h"
+#include "iotjs_module_periph_common.h"
 #include "iotjs_reqwrap.h"
-
-typedef enum {
-  kI2cOpOpen,
-  kI2cOpClose,
-  kI2cOpWrite,
-  kI2cOpRead,
-} I2cOp;
-
-
-typedef struct {
-  I2cOp op;
-  bool result;
-} iotjs_i2c_reqdata_t;
 
 // Forward declaration of platform data. These are only used by platform code.
 // Generic I2C module never dereferences platform data pointer.
@@ -47,13 +35,6 @@ typedef struct {
   uint8_t cmd;
   uint8_t address;
 } iotjs_i2c_t;
-
-typedef struct {
-  iotjs_reqwrap_t reqwrap;
-  uv_work_t req;
-  iotjs_i2c_reqdata_t req_data;
-  iotjs_i2c_t* i2c_data;
-} iotjs_i2c_reqwrap_t;
 
 jerry_value_t iotjs_i2c_set_platform_config(iotjs_i2c_t* i2c,
                                             const jerry_value_t jconfig);

--- a/src/modules/iotjs_module_periph_common.c
+++ b/src/modules/iotjs_module_periph_common.c
@@ -1,0 +1,221 @@
+/* Copyright 2018-present Samsung Electronics Co., Ltd. and other contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "iotjs_module_periph_common.h"
+#include "iotjs_module_adc.h"
+#include "iotjs_module_gpio.h"
+#include "iotjs_module_i2c.h"
+#include "iotjs_module_pwm.h"
+#include "iotjs_module_spi.h"
+#include "iotjs_module_uart.h"
+
+const char* iotjs_periph_error_str(uint8_t op) {
+  switch (op) {
+#if ENABLE_MODULE_ADC
+    case kAdcOpClose:
+      return "Close error, cannot close ADC";
+    case kAdcOpOpen:
+      return "Open error, cannot open ADC";
+    case kAdcOpRead:
+      return "Read error, cannot read ADC";
+#endif /* ENABLE_MODULE_ADC */
+#if ENABLE_MODULE_GPIO
+    case kGpioOpOpen:
+      return "Open error, cannot open GPIO";
+    case kGpioOpWrite:
+      return "Write error, cannot write GPIO";
+    case kGpioOpRead:
+      return "Read error, cannot read GPIO";
+    case kGpioOpClose:
+      return "Close error, cannot close GPIO";
+#endif /* ENABLE_MODULE_GPIO */
+#if ENABLE_MODULE_I2C
+    case kI2cOpOpen:
+      return "Open error, cannot open I2C";
+    case kI2cOpWrite:
+      return "Write error, cannot write I2C";
+    case kI2cOpRead:
+      return "Read error, cannot read I2C";
+    case kI2cOpClose:
+      return "Close error, cannot close I2C";
+#endif /* ENABLE_MODULE_I2C */
+#if ENABLE_MODULE_PWM
+    case kPwmOpClose:
+      return "Cannot close PWM device";
+    case kPwmOpOpen:
+      return "Failed to open PWM device";
+    case kPwmOpSetDutyCycle:
+      return "Failed to set duty-cycle";
+    case kPwmOpSetEnable:
+      return "Failed to set enable";
+    case kPwmOpSetFrequency:
+      return "Failed to set frequency";
+    case kPwmOpSetPeriod:
+      return "Failed to set period";
+#endif /* ENABLE_MODULE_PWM */
+#if ENABLE_MODULE_SPI
+    case kSpiOpClose:
+      return "Close error, cannot close SPI";
+    case kSpiOpOpen:
+      return "Open error, cannot open SPI";
+    case kSpiOpTransferArray:
+    case kSpiOpTransferBuffer:
+      return "Transfer error, cannot transfer from SPI device";
+#endif /* ENABLE_MODULE_SPI */
+#if ENABLE_MODULE_UART
+    case kUartOpClose:
+      return "Close error, failed to close UART device";
+    case kUartOpOpen:
+      return "Open error, failed to open UART device";
+    case kUartOpWrite:
+      return "Write error, cannot write to UART device";
+#endif /* ENABLE_MODULE_UART */
+    default:
+      return "Unknown error";
+  }
+}
+
+static void after_worker(uv_work_t* work_req, int status) {
+  iotjs_periph_reqwrap_t* reqwrap =
+      (iotjs_periph_reqwrap_t*)iotjs_reqwrap_from_request((uv_req_t*)work_req);
+
+  iotjs_jargs_t jargs = iotjs_jargs_create(2);
+
+  if (status) {
+    iotjs_jargs_append_error(&jargs, "System error");
+  } else {
+    if (!reqwrap->result) {
+      iotjs_jargs_append_error(&jargs, iotjs_periph_error_str(reqwrap->op));
+    } else {
+      switch (reqwrap->op) {
+        case kAdcOpClose:
+        case kAdcOpOpen:
+        case kGpioOpClose:
+        case kGpioOpOpen:
+        case kGpioOpWrite:
+        case kI2cOpClose:
+        case kI2cOpOpen:
+        case kI2cOpWrite:
+        case kSpiOpClose:
+        case kSpiOpOpen:
+        case kPwmOpClose:
+        case kPwmOpOpen:
+        case kPwmOpSetDutyCycle:
+        case kPwmOpSetEnable:
+        case kPwmOpSetFrequency:
+        case kPwmOpSetPeriod:
+        case kUartOpClose:
+        case kUartOpOpen:
+        case kUartOpWrite: {
+          iotjs_jargs_append_null(&jargs);
+          break;
+        }
+        case kAdcOpRead: {
+#if ENABLE_MODULE_ADC
+          iotjs_adc_t* adc = (iotjs_adc_t*)reqwrap->data;
+
+          iotjs_jargs_append_null(&jargs);
+          iotjs_jargs_append_number(&jargs, adc->value);
+#endif /* ENABLE_MODULE_ADC */
+          break;
+        }
+        case kGpioOpRead: {
+#if ENABLE_MODULE_GPIO
+          iotjs_gpio_t* gpio = (iotjs_gpio_t*)reqwrap->data;
+
+          iotjs_jargs_append_null(&jargs);
+          iotjs_jargs_append_bool(&jargs, gpio->value);
+#endif /* ENABLE_MODULE_GPIO */
+          break;
+        }
+        case kI2cOpRead: {
+#if ENABLE_MODULE_I2C
+          iotjs_i2c_t* i2c = (iotjs_i2c_t*)reqwrap->data;
+
+          iotjs_jargs_append_null(&jargs);
+          jerry_value_t result =
+              iotjs_jval_create_byte_array(i2c->buf_len, i2c->buf_data);
+          iotjs_jargs_append_jval(&jargs, result);
+          jerry_release_value(result);
+
+          if (i2c->buf_data != NULL) {
+            iotjs_buffer_release(i2c->buf_data);
+          }
+#endif /* ENABLE_MODULE_I2C */
+          break;
+        }
+        case kSpiOpTransferArray:
+        case kSpiOpTransferBuffer: {
+#if ENABLE_MODULE_SPI
+          iotjs_spi_t* spi = (iotjs_spi_t*)reqwrap->data;
+
+          iotjs_jargs_append_null(&jargs);
+
+          // Append read data
+          jerry_value_t result =
+              iotjs_jval_create_byte_array(spi->buf_len, spi->rx_buf_data);
+          iotjs_jargs_append_jval(&jargs, result);
+          jerry_release_value(result);
+
+          iotjs_buffer_release(spi->rx_buf_data);
+#endif /* ENABLE_MODULE_SPI */
+          break;
+        }
+        default: {
+          IOTJS_ASSERT(!"Unreachable");
+          break;
+        }
+      }
+    }
+#if ENABLE_MODULE_SPI
+    if (reqwrap->op == kSpiOpTransferArray) {
+      iotjs_spi_t* spi = (iotjs_spi_t*)reqwrap->data;
+      iotjs_buffer_release(spi->tx_buf_data);
+    }
+#endif /* ENABLE_MODULE_SPI */
+#if ENABLE_MODULE_UART
+    if (reqwrap->op == kUartOpWrite) {
+      iotjs_uart_t* uart = (iotjs_uart_t*)reqwrap->data;
+      iotjs_string_destroy(&uart->buf_data);
+    }
+#endif /* ENABLE_MODULE_UART */
+  }
+
+  jerry_value_t jcallback = iotjs_reqwrap_jcallback(&reqwrap->reqwrap);
+  if (jerry_value_is_function(jcallback)) {
+    iotjs_make_callback(jcallback, jerry_create_undefined(), &jargs);
+  }
+
+  iotjs_jargs_destroy(&jargs);
+  iotjs_reqwrap_destroy(&reqwrap->reqwrap);
+  IOTJS_RELEASE(reqwrap);
+}
+
+static iotjs_periph_reqwrap_t* reqwrap_create(const jerry_value_t jcallback,
+                                              void* data, uint8_t op) {
+  iotjs_periph_reqwrap_t* reqwrap = IOTJS_ALLOC(iotjs_periph_reqwrap_t);
+  iotjs_reqwrap_initialize((iotjs_reqwrap_t*)reqwrap, jcallback,
+                           (uv_req_t*)&reqwrap->req);
+  reqwrap->op = op;
+  reqwrap->data = data;
+  return (iotjs_periph_reqwrap_t*)reqwrap;
+}
+
+void iotjs_periph_call_async(void* data, jerry_value_t jcallback, uint8_t op,
+                             uv_work_cb worker) {
+  uv_loop_t* loop = iotjs_environment_loop(iotjs_environment_get());
+  iotjs_periph_reqwrap_t* req_wrap = reqwrap_create(jcallback, data, op);
+  uv_queue_work(loop, &req_wrap->req, worker, after_worker);
+}

--- a/src/modules/iotjs_module_periph_common.h
+++ b/src/modules/iotjs_module_periph_common.h
@@ -1,0 +1,70 @@
+/* Copyright 2018-present Samsung Electronics Co., Ltd. and other contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef IOTJS_MODULE_PERIPH_COMMON_H
+#define IOTJS_MODULE_PERIPH_COMMON_H
+
+#include "iotjs_def.h"
+#include "iotjs_reqwrap.h"
+
+typedef enum {
+  kAdcOpOpen,
+  kAdcOpRead,
+  kAdcOpClose,
+  kGpioOpOpen,
+  kGpioOpWrite,
+  kGpioOpRead,
+  kGpioOpClose,
+  kI2cOpOpen,
+  kI2cOpClose,
+  kI2cOpWrite,
+  kI2cOpRead,
+  kPwmOpClose,
+  kPwmOpOpen,
+  kPwmOpSetDutyCycle,
+  kPwmOpSetEnable,
+  kPwmOpSetFrequency,
+  kPwmOpSetPeriod,
+  kSpiOpClose,
+  kSpiOpOpen,
+  kSpiOpTransferArray,
+  kSpiOpTransferBuffer,
+  kUartOpClose,
+  kUartOpOpen,
+  kUartOpWrite
+} iotjs_periph_op_t;
+
+typedef struct {
+  iotjs_reqwrap_t reqwrap; /* Note: must be the first */
+  uv_work_t req;
+  uint8_t op;
+  bool result;
+  void* data;
+} iotjs_periph_reqwrap_t;
+
+const char* iotjs_periph_error_str(uint8_t op);
+void iotjs_periph_call_async(void* type_p, jerry_value_t jcallback, uint8_t op,
+                             uv_work_cb worker);
+
+#define IOTJS_DEFINE_PERIPH_CREATE_FUNCTION(name)                             \
+  static iotjs_##name##_t* name##_create(const jerry_value_t jobject) {       \
+    iotjs_##name##_t* data = IOTJS_ALLOC(iotjs_##name##_t);                   \
+    iotjs_##name##_create_platform_data(data);                                \
+    data->jobject = jobject;                                                  \
+    jerry_set_object_native_pointer(jobject, data, &this_module_native_info); \
+    return data;                                                              \
+  }
+
+#endif /* IOTJS_MODULE_PERIPH_COMMON_H */

--- a/src/modules/iotjs_module_pwm.c
+++ b/src/modules/iotjs_module_pwm.c
@@ -20,35 +20,7 @@
 
 IOTJS_DEFINE_NATIVE_HANDLE_INFO_THIS_MODULE(pwm);
 
-static iotjs_pwm_t* pwm_create(jerry_value_t jpwm) {
-  iotjs_pwm_t* pwm = IOTJS_ALLOC(iotjs_pwm_t);
-  iotjs_pwm_create_platform_data(pwm);
-  pwm->jobject = jpwm;
-  pwm->period = -1;
-  pwm->duty_cycle = 0;
-  jerry_set_object_native_pointer(jpwm, pwm, &this_module_native_info);
-
-  return pwm;
-}
-
-static iotjs_pwm_reqwrap_t* iotjs_pwm_reqwrap_create(jerry_value_t jcallback,
-                                                     iotjs_pwm_t* pwm,
-                                                     PwmOp op) {
-  iotjs_pwm_reqwrap_t* pwm_reqwrap = IOTJS_ALLOC(iotjs_pwm_reqwrap_t);
-
-  iotjs_reqwrap_initialize(&pwm_reqwrap->reqwrap, jcallback,
-                           (uv_req_t*)&pwm_reqwrap->req);
-
-  pwm_reqwrap->req_data.op = op;
-  pwm_reqwrap->pwm_data = pwm;
-
-  return pwm_reqwrap;
-}
-
-static void pwm_reqwrap_destroy(iotjs_pwm_reqwrap_t* pwm_reqwrap) {
-  iotjs_reqwrap_destroy(&pwm_reqwrap->reqwrap);
-  IOTJS_RELEASE(pwm_reqwrap);
-}
+IOTJS_DEFINE_PERIPH_CREATE_FUNCTION(pwm);
 
 static void iotjs_pwm_destroy(iotjs_pwm_t* pwm) {
   iotjs_pwm_destroy_platform_data(pwm->platform_data);
@@ -56,90 +28,31 @@ static void iotjs_pwm_destroy(iotjs_pwm_t* pwm) {
 }
 
 static void pwm_worker(uv_work_t* work_req) {
-  iotjs_pwm_reqwrap_t* req_wrap =
-      (iotjs_pwm_reqwrap_t*)(iotjs_reqwrap_from_request((uv_req_t*)work_req));
-  iotjs_pwm_reqdata_t* req_data = &req_wrap->req_data;
-  iotjs_pwm_t* pwm = req_wrap->pwm_data;
+  iotjs_periph_reqwrap_t* req_wrap =
+      (iotjs_periph_reqwrap_t*)(iotjs_reqwrap_from_request(
+          (uv_req_t*)work_req));
+  iotjs_pwm_t* pwm = (iotjs_pwm_t*)req_wrap->data;
 
-  switch (req_data->op) {
+  switch (req_wrap->op) {
     case kPwmOpClose:
-      req_data->result = iotjs_pwm_close(pwm);
+      req_wrap->result = iotjs_pwm_close(pwm);
       break;
     case kPwmOpOpen:
-      req_data->result = iotjs_pwm_open(pwm);
+      req_wrap->result = iotjs_pwm_open(pwm);
       break;
     case kPwmOpSetDutyCycle:
-      req_data->result = iotjs_pwm_set_dutycycle(pwm);
+      req_wrap->result = iotjs_pwm_set_dutycycle(pwm);
       break;
     case kPwmOpSetEnable:
-      req_data->result = iotjs_pwm_set_enable(pwm);
+      req_wrap->result = iotjs_pwm_set_enable(pwm);
       break;
     case kPwmOpSetFrequency: /* update the period */
     case kPwmOpSetPeriod:
-      req_data->result = iotjs_pwm_set_period(pwm);
+      req_wrap->result = iotjs_pwm_set_period(pwm);
       break;
     default:
       IOTJS_ASSERT(!"Invalid Operation");
   }
-}
-
-static const char* pwm_error_str(int op) {
-  switch (op) {
-    case kPwmOpClose:
-      return "Cannot close PWM device";
-    case kPwmOpOpen:
-      return "Failed to open PWM device";
-    case kPwmOpSetDutyCycle:
-      return "Failed to set duty-cycle";
-    case kPwmOpSetEnable:
-      return "Failed to set enable";
-    case kPwmOpSetFrequency:
-      return "Failed to set frequency";
-    case kPwmOpSetPeriod:
-      return "Failed to set period";
-    default:
-      return "Unknown error";
-  }
-}
-
-static void pwm_after_worker(uv_work_t* work_req, int status) {
-  iotjs_pwm_reqwrap_t* req_wrap =
-      (iotjs_pwm_reqwrap_t*)(iotjs_reqwrap_from_request((uv_req_t*)work_req));
-  iotjs_pwm_reqdata_t* req_data = &req_wrap->req_data;
-
-  iotjs_jargs_t jargs = iotjs_jargs_create(1);
-
-  if (status) {
-    iotjs_jargs_append_error(&jargs, "System error");
-  } else {
-    switch (req_data->op) {
-      case kPwmOpClose:
-      case kPwmOpOpen:
-      case kPwmOpSetDutyCycle:
-      case kPwmOpSetEnable:
-      case kPwmOpSetFrequency:
-      case kPwmOpSetPeriod: {
-        if (!req_data->result) {
-          iotjs_jargs_append_error(&jargs, pwm_error_str(req_data->op));
-        } else {
-          iotjs_jargs_append_null(&jargs);
-        }
-        break;
-      }
-      default: {
-        IOTJS_ASSERT(!"Unreachable");
-        break;
-      }
-    }
-  }
-
-  jerry_value_t jcallback = iotjs_reqwrap_jcallback(&req_wrap->reqwrap);
-  if (jerry_value_is_function(jcallback)) {
-    iotjs_make_callback(jcallback, jerry_create_undefined(), &jargs);
-  }
-
-  iotjs_jargs_destroy(&jargs);
-  pwm_reqwrap_destroy(req_wrap);
 }
 
 static jerry_value_t pwm_set_configuration(iotjs_pwm_t* pwm,
@@ -161,15 +74,6 @@ static jerry_value_t pwm_set_configuration(iotjs_pwm_t* pwm,
 
   return jerry_create_undefined();
 }
-
-#define PWM_CALL_ASYNC(op, jcallback)                                  \
-  do {                                                                 \
-    uv_loop_t* loop = iotjs_environment_loop(iotjs_environment_get()); \
-    iotjs_pwm_reqwrap_t* req_wrap =                                    \
-        iotjs_pwm_reqwrap_create(jcallback, pwm, op);                  \
-    uv_work_t* req = &req_wrap->req;                                   \
-    uv_queue_work(loop, req, pwm_worker, pwm_after_worker);            \
-  } while (0)
 
 JS_FUNCTION(PwmCons) {
   DJS_CHECK_THIS();
@@ -200,9 +104,9 @@ JS_FUNCTION(PwmCons) {
   // If the callback doesn't exist, it is completed synchronously.
   // Otherwise, it will be executed asynchronously.
   if (!jerry_value_is_null(jcallback)) {
-    PWM_CALL_ASYNC(kPwmOpOpen, jcallback);
+    iotjs_periph_call_async(pwm, jcallback, kPwmOpOpen, pwm_worker);
   } else if (!iotjs_pwm_open(pwm)) {
-    return JS_CREATE_ERROR(COMMON, pwm_error_str(kPwmOpOpen));
+    return JS_CREATE_ERROR(COMMON, iotjs_periph_error_str(kPwmOpOpen));
   }
 
   return jerry_create_undefined();
@@ -212,7 +116,8 @@ JS_FUNCTION(Close) {
   JS_DECLARE_THIS_PTR(pwm, pwm);
   DJS_CHECK_ARG_IF_EXIST(1, function);
 
-  PWM_CALL_ASYNC(kPwmOpClose, JS_GET_ARG_IF_EXIST(0, function));
+  iotjs_periph_call_async(pwm, JS_GET_ARG_IF_EXIST(0, function), kPwmOpClose,
+                          pwm_worker);
 
   return jerry_create_undefined();
 }
@@ -221,7 +126,7 @@ JS_FUNCTION(CloseSync) {
   JS_DECLARE_THIS_PTR(pwm, pwm);
 
   if (!iotjs_pwm_close(pwm)) {
-    return JS_CREATE_ERROR(COMMON, pwm_error_str(kPwmOpClose));
+    return JS_CREATE_ERROR(COMMON, iotjs_periph_error_str(kPwmOpClose));
   }
 
   return jerry_create_undefined();
@@ -239,7 +144,7 @@ JS_FUNCTION(SetDutyCycle) {
     return JS_CREATE_ERROR(RANGE, "pwm.dutyCycle must be within 0.0 and 1.0");
   }
 
-  PWM_CALL_ASYNC(kPwmOpSetDutyCycle, jcallback);
+  iotjs_periph_call_async(pwm, jcallback, kPwmOpSetDutyCycle, pwm_worker);
 
   return jerry_create_undefined();
 }
@@ -254,7 +159,7 @@ JS_FUNCTION(SetDutyCycleSync) {
   }
 
   if (!iotjs_pwm_set_dutycycle(pwm)) {
-    return JS_CREATE_ERROR(COMMON, pwm_error_str(kPwmOpSetDutyCycle));
+    return JS_CREATE_ERROR(COMMON, iotjs_periph_error_str(kPwmOpSetDutyCycle));
   }
 
   return jerry_create_undefined();
@@ -269,7 +174,7 @@ JS_FUNCTION(SetEnable) {
 
   pwm->enable = JS_GET_ARG(0, boolean);
 
-  PWM_CALL_ASYNC(kPwmOpSetEnable, jcallback);
+  iotjs_periph_call_async(pwm, jcallback, kPwmOpSetEnable, pwm_worker);
 
   return jerry_create_undefined();
 }
@@ -281,7 +186,7 @@ JS_FUNCTION(SetEnableSync) {
   pwm->enable = JS_GET_ARG(0, boolean);
 
   if (!iotjs_pwm_set_enable(pwm)) {
-    return JS_CREATE_ERROR(COMMON, pwm_error_str(kPwmOpSetEnable));
+    return JS_CREATE_ERROR(COMMON, iotjs_periph_error_str(kPwmOpSetEnable));
   }
 
   return jerry_create_undefined();
@@ -307,10 +212,11 @@ static jerry_value_t pwm_set_period_or_frequency(iotjs_pwm_t* pwm,
   }
 
   if (async) {
-    PWM_CALL_ASYNC(op, JS_GET_ARG_IF_EXIST(1, function));
+    iotjs_periph_call_async(pwm, JS_GET_ARG_IF_EXIST(1, function), op,
+                            pwm_worker);
   } else {
     if (!iotjs_pwm_set_period(pwm)) {
-      return JS_CREATE_ERROR(COMMON, pwm_error_str(op));
+      return JS_CREATE_ERROR(COMMON, iotjs_periph_error_str(op));
     }
   }
 

--- a/src/modules/iotjs_module_pwm.h
+++ b/src/modules/iotjs_module_pwm.h
@@ -18,28 +18,13 @@
 #define IOTJS_MODULE_PWM_H
 
 #include "iotjs_def.h"
+#include "iotjs_module_periph_common.h"
 #include "iotjs_reqwrap.h"
 
 #if defined(__TIZENRT__)
 #include <iotbus_pwm.h>
 #include <stdint.h>
 #endif
-
-
-typedef enum {
-  kPwmOpClose,
-  kPwmOpOpen,
-  kPwmOpSetDutyCycle,
-  kPwmOpSetEnable,
-  kPwmOpSetFrequency,
-  kPwmOpSetPeriod
-} PwmOp;
-
-
-typedef struct {
-  bool result;
-  PwmOp op;
-} iotjs_pwm_reqdata_t;
 
 // Forward declaration of platform data. These are only used by platform code.
 // Generic PWM module never dereferences platform data pointer.
@@ -54,14 +39,6 @@ typedef struct {
   double period;
   bool enable;
 } iotjs_pwm_t;
-
-
-typedef struct {
-  iotjs_reqwrap_t reqwrap;
-  uv_work_t req;
-  iotjs_pwm_reqdata_t req_data;
-  iotjs_pwm_t* pwm_data;
-} iotjs_pwm_reqwrap_t;
 
 jerry_value_t iotjs_pwm_set_platform_config(iotjs_pwm_t* pwm,
                                             const jerry_value_t jconfig);

--- a/src/modules/iotjs_module_spi.h
+++ b/src/modules/iotjs_module_spi.h
@@ -19,6 +19,7 @@
 
 #include "iotjs_def.h"
 #include "iotjs_module_buffer.h"
+#include "iotjs_module_periph_common.h"
 #include "iotjs_reqwrap.h"
 
 #if defined(__TIZENRT__)
@@ -30,13 +31,6 @@
 #if defined(__NUTTX__)
 #include <nuttx/spi/spi.h>
 #endif
-
-typedef enum {
-  kSpiOpClose,
-  kSpiOpOpen,
-  kSpiOpTransferArray,
-  kSpiOpTransferBuffer
-} SpiOp;
 
 typedef enum {
   kSpiMode_0,
@@ -71,19 +65,6 @@ typedef struct {
   char* rx_buf_data;
   uint8_t buf_len;
 } iotjs_spi_t;
-
-typedef struct {
-  bool result;
-  SpiOp op;
-} iotjs_spi_reqdata_t;
-
-typedef struct {
-  iotjs_reqwrap_t reqwrap;
-  uv_work_t req;
-  iotjs_spi_reqdata_t req_data;
-  iotjs_spi_t* spi_data;
-} iotjs_spi_reqwrap_t;
-
 
 jerry_value_t iotjs_spi_set_platform_config(iotjs_spi_t* spi,
                                             const jerry_value_t jconfig);

--- a/src/modules/iotjs_module_uart.h
+++ b/src/modules/iotjs_module_uart.h
@@ -19,22 +19,11 @@
 
 #include "iotjs_def.h"
 #include "iotjs_handlewrap.h"
+#include "iotjs_module_periph_common.h"
 #include "iotjs_reqwrap.h"
 
 
 #define UART_WRITE_BUFFER_SIZE 512
-
-
-typedef enum {
-  kUartOpOpen,
-  kUartOpClose,
-  kUartOpWrite,
-} UartOp;
-
-typedef struct {
-  UartOp op;
-  bool result;
-} iotjs_uart_reqdata_t;
 
 typedef struct {
   iotjs_handlewrap_t handlewrap;
@@ -46,13 +35,6 @@ typedef struct {
   unsigned buf_len;
   uv_poll_t poll_handle;
 } iotjs_uart_t;
-
-typedef struct {
-  iotjs_reqwrap_t reqwrap;
-  uv_work_t req;
-  iotjs_uart_reqdata_t req_data;
-  iotjs_uart_t* uart_data;
-} iotjs_uart_reqwrap_t;
 
 void iotjs_uart_register_read_cb(iotjs_uart_t* uart);
 bool iotjs_uart_open(iotjs_uart_t* uart);


### PR DESCRIPTION
Binary size is reduced by ~1 Kbyte when all six modules are enabled (ADC, I2C, GPIO, PWM, SPI, UART)
The code maintainability is also improved by the elimination of code duplication.

IoT.js-DCO-1.0-Signed-off-by: László Langó llango.u-szeged@partner.samsung.com