### PR TITLE
Minor define maintenance in 'iotjs_binding.h'

### DIFF
--- a/src/modules/iotjs_module_i2c.c
+++ b/src/modules/iotjs_module_i2c.c
@@ -170,8 +170,8 @@ JS_FUNCTION(I2cCons) {
     return res;
   }
 
-  DJS_GET_REQUIRED_CONF_VALUE(jconfig, i2c->address, IOTJS_MAGIC_STRING_ADDRESS,
-                              number);
+  JS_GET_REQUIRED_CONF_VALUE(jconfig, i2c->address, IOTJS_MAGIC_STRING_ADDRESS,
+                             number);
 
   jerry_value_t jcallback = JS_GET_ARG_IF_EXIST(1, function);
 

--- a/src/modules/iotjs_module_pwm.c
+++ b/src/modules/iotjs_module_pwm.c
@@ -144,20 +144,19 @@ static void pwm_after_worker(uv_work_t* work_req, int status) {
 
 static jerry_value_t pwm_set_configuration(iotjs_pwm_t* pwm,
                                            jerry_value_t jconfig) {
-  DJS_GET_REQUIRED_CONF_VALUE(jconfig, pwm->duty_cycle,
-                              IOTJS_MAGIC_STRING_DUTYCYCLE, number);
+  JS_GET_REQUIRED_CONF_VALUE(jconfig, pwm->duty_cycle,
+                             IOTJS_MAGIC_STRING_DUTYCYCLE, number);
   if (pwm->duty_cycle < 0.0 || pwm->duty_cycle > 1.0) {
     return JS_CREATE_ERROR(RANGE, "pwm.dutyCycle must be within 0.0 and 1.0");
   }
 
-  DJS_GET_REQUIRED_CONF_VALUE(jconfig, pwm->period, IOTJS_MAGIC_STRING_PERIOD,
-                              number);
+  JS_GET_REQUIRED_CONF_VALUE(jconfig, pwm->period, IOTJS_MAGIC_STRING_PERIOD,
+                             number);
   if (pwm->period < 0) {
     return JS_CREATE_ERROR(RANGE, "pwm.period must be a positive value");
   }
 
-  DJS_GET_REQUIRED_CONF_VALUE(jconfig, pwm->pin, IOTJS_MAGIC_STRING_PIN,
-                              number);
+  JS_GET_REQUIRED_CONF_VALUE(jconfig, pwm->pin, IOTJS_MAGIC_STRING_PIN, number);
 
   return jerry_create_undefined();
 }

--- a/src/modules/linux/iotjs_module_adc-linux.c
+++ b/src/modules/linux/iotjs_module_adc-linux.c
@@ -50,8 +50,8 @@ jerry_value_t iotjs_adc_set_platform_config(iotjs_adc_t* adc,
                                             const jerry_value_t jconfig) {
   iotjs_adc_platform_data_t* platform_data = adc->platform_data;
 
-  DJS_GET_REQUIRED_CONF_VALUE(jconfig, platform_data->device,
-                              IOTJS_MAGIC_STRING_DEVICE, string);
+  JS_GET_REQUIRED_CONF_VALUE(jconfig, platform_data->device,
+                             IOTJS_MAGIC_STRING_DEVICE, string);
 
   return jerry_create_undefined();
 }

--- a/src/modules/linux/iotjs_module_i2c-linux.c
+++ b/src/modules/linux/iotjs_module_i2c-linux.c
@@ -80,8 +80,8 @@ jerry_value_t iotjs_i2c_set_platform_config(iotjs_i2c_t* i2c,
                                             const jerry_value_t jconfig) {
   iotjs_i2c_platform_data_t* platform_data = i2c->platform_data;
 
-  DJS_GET_REQUIRED_CONF_VALUE(jconfig, platform_data->device,
-                              IOTJS_MAGIC_STRING_DEVICE, string);
+  JS_GET_REQUIRED_CONF_VALUE(jconfig, platform_data->device,
+                             IOTJS_MAGIC_STRING_DEVICE, string);
 
   return jerry_create_undefined();
 }

--- a/src/modules/linux/iotjs_module_spi-linux.c
+++ b/src/modules/linux/iotjs_module_spi-linux.c
@@ -44,8 +44,8 @@ jerry_value_t iotjs_spi_set_platform_config(iotjs_spi_t* spi,
                                             const jerry_value_t jconfig) {
   iotjs_spi_platform_data_t* platform_data = spi->platform_data;
 
-  DJS_GET_REQUIRED_CONF_VALUE(jconfig, platform_data->device,
-                              IOTJS_MAGIC_STRING_DEVICE, string);
+  JS_GET_REQUIRED_CONF_VALUE(jconfig, platform_data->device,
+                             IOTJS_MAGIC_STRING_DEVICE, string);
 
   return jerry_create_undefined();
 }

--- a/src/modules/nuttx/iotjs_module_adc-nuttx.c
+++ b/src/modules/nuttx/iotjs_module_adc-nuttx.c
@@ -48,8 +48,8 @@ jerry_value_t iotjs_adc_set_platform_config(iotjs_adc_t* adc,
                                             const jerry_value_t jconfig) {
   iotjs_adc_platform_data_t* platform_data = adc->platform_data;
 
-  DJS_GET_REQUIRED_CONF_VALUE(jconfig, platform_data->pin,
-                              IOTJS_MAGIC_STRING_PIN, number);
+  JS_GET_REQUIRED_CONF_VALUE(jconfig, platform_data->pin,
+                             IOTJS_MAGIC_STRING_PIN, number);
 
   return jerry_create_undefined();
 }

--- a/src/modules/nuttx/iotjs_module_i2c-nuttx.c
+++ b/src/modules/nuttx/iotjs_module_i2c-nuttx.c
@@ -47,8 +47,8 @@ jerry_value_t iotjs_i2c_set_platform_config(iotjs_i2c_t* i2c,
                                             const jerry_value_t jconfig) {
   iotjs_i2c_platform_data_t* platform_data = i2c->platform_data;
 
-  DJS_GET_REQUIRED_CONF_VALUE(jconfig, platform_data->bus,
-                              IOTJS_MAGIC_STRING_BUS, number);
+  JS_GET_REQUIRED_CONF_VALUE(jconfig, platform_data->bus,
+                             IOTJS_MAGIC_STRING_BUS, number);
 
   return jerry_create_undefined();
 }

--- a/src/modules/nuttx/iotjs_module_spi-nuttx.c
+++ b/src/modules/nuttx/iotjs_module_spi-nuttx.c
@@ -45,8 +45,8 @@ jerry_value_t iotjs_spi_set_platform_config(iotjs_spi_t* spi,
                                             const jerry_value_t jconfig) {
   iotjs_spi_platform_data_t* platform_data = spi->platform_data;
 
-  DJS_GET_REQUIRED_CONF_VALUE(jconfig, platform_data->bus,
-                              IOTJS_MAGIC_STRING_BUS, number);
+  JS_GET_REQUIRED_CONF_VALUE(jconfig, platform_data->bus,
+                             IOTJS_MAGIC_STRING_BUS, number);
 
   return jerry_create_undefined();
 }

--- a/src/modules/tizenrt/iotjs_module_adc-tizenrt.c
+++ b/src/modules/tizenrt/iotjs_module_adc-tizenrt.c
@@ -57,8 +57,8 @@ jerry_value_t iotjs_adc_set_platform_config(iotjs_adc_t* adc,
                                             const jerry_value_t jconfig) {
   iotjs_adc_platform_data_t* platform_data = adc->platform_data;
 
-  DJS_GET_REQUIRED_CONF_VALUE(jconfig, platform_data->pin,
-                              IOTJS_MAGIC_STRING_PIN, number);
+  JS_GET_REQUIRED_CONF_VALUE(jconfig, platform_data->pin,
+                             IOTJS_MAGIC_STRING_PIN, number);
 
   return jerry_create_undefined();
 }

--- a/src/modules/tizenrt/iotjs_module_i2c-tizenrt.c
+++ b/src/modules/tizenrt/iotjs_module_i2c-tizenrt.c
@@ -51,8 +51,8 @@ jerry_value_t iotjs_i2c_set_platform_config(iotjs_i2c_t* i2c,
                                             const jerry_value_t jconfig) {
   iotjs_i2c_platform_data_t* platform_data = i2c->platform_data;
 
-  DJS_GET_REQUIRED_CONF_VALUE(jconfig, platform_data->bus,
-                              IOTJS_MAGIC_STRING_BUS, number);
+  JS_GET_REQUIRED_CONF_VALUE(jconfig, platform_data->bus,
+                             IOTJS_MAGIC_STRING_BUS, number);
 
   return jerry_create_undefined();
 }

--- a/src/modules/tizenrt/iotjs_module_spi-tizenrt.c
+++ b/src/modules/tizenrt/iotjs_module_spi-tizenrt.c
@@ -53,8 +53,8 @@ jerry_value_t iotjs_spi_set_platform_config(iotjs_spi_t* spi,
                                             const jerry_value_t jconfig) {
   iotjs_spi_platform_data_t* platform_data = spi->platform_data;
 
-  DJS_GET_REQUIRED_CONF_VALUE(jconfig, platform_data->bus,
-                              IOTJS_MAGIC_STRING_BUS, number);
+  JS_GET_REQUIRED_CONF_VALUE(jconfig, platform_data->bus,
+                             IOTJS_MAGIC_STRING_BUS, number);
 
   return jerry_create_undefined();
 }


### PR DESCRIPTION
Eliminated code duplication and removed 'D' prefix from
'DJS_GET_REQUIRED_CONF_VALUE', because it is not for debug.

IoT.js-DCO-1.0-Signed-off-by: László Langó llango.u-szeged@partner.samsung.com