### PR TITLE
Modify tizen build config

### DIFF
--- a/config/tizen/packaging/iotjs.spec
+++ b/config/tizen/packaging/iotjs.spec
@@ -8,16 +8,17 @@ URL: https://www.iotjs.net/
 Source:     %{name}-%{version}.tar.gz
 Source1:    %{name}.pc.in
 Source1001: %{name}.manifest
+ExclusiveArch: %arm
 
 BuildRequires: python
 BuildRequires: cmake
 BuildRequires: glibc-static
-BuildRequires: aul
-BuildRequires: pkgconfig(appcore-agent)
-BuildRequires: pkgconfig(capi-appfw-service-application)
-BuildRequires: pkgconfig(capi-appfw-app-common)
-BuildRequires: pkgconfig(capi-appfw-package-manager)
-BuildRequires: pkgconfig(capi-appfw-application)
+#BuildRequires: aul
+#BuildRequires: pkgconfig(appcore-agent)
+#BuildRequires: pkgconfig(capi-appfw-service-application)
+#BuildRequires: pkgconfig(capi-appfw-app-common)
+#BuildRequires: pkgconfig(capi-appfw-package-manager)
+#BuildRequires: pkgconfig(capi-appfw-application)
 BuildRequires: pkgconfig(capi-system-peripheral-io)
 BuildRequires: pkgconfig(dlog)
 #BuildRequires: pkgconfig(st_things_sdkapi)


### PR DESCRIPTION
- Block all tizen gbs build except ARM build

IoT.js-DCO-1.0-Signed-off-by: Haesik, Jun haesik.jun@samsung.com