### PR TITLE
Fix failure detection in the Python testrunner

### DIFF
--- a/test/testsets.json
+++ b/test/testsets.json
@@ -25,7 +25,7 @@
     { "name": "test_fs_exists_sync.js" },
     { "name": "test_fs_fstat.js", "skip": ["nuttx", "tizenrt"], "reason": "not implemented for nuttx/TizenRT" },
     { "name": "test_fs_fstat_sync.js", "skip": ["nuttx", "tizenrt"], "reason": "not implemented for nuttx/TizenRT" },
-    { "name": "test_fs_mkdir_rmdir.js", "skip": ["tizen", "nuttx"], "reason": "[tizen]: flaky on Travis, [nuttx]: implemented, run manually in default configuration" },
+    { "name": "test_fs_mkdir_rmdir.js", "skip": ["linux", "tizen", "nuttx"], "reason": "[linux/tizen]: flaky on Travis, [nuttx]: implemented, run manually in default configuration" },
     { "name": "test_fs_open_close.js", "skip": ["nuttx"], "reason": "not implemented for nuttx" },
     { "name": "test_fs_readdir.js" },
     { "name": "test_fs_readfile.js" },

--- a/tools/testrunner.py
+++ b/tools/testrunner.py
@@ -210,7 +210,9 @@ class TestRunner(object):
             if not self.quiet:
                 print(output, end="")
 
-            if not expected_failure or (expected_failure and exitcode <= 2):
+            is_normal_run = (not expected_failure and exitcode == 0)
+            is_expected_fail = (expected_failure and exitcode <= 2)
+            if is_normal_run or is_expected_fail:
                 Reporter.report_pass(test["name"], runtime)
                 self.results["pass"] += 1
             else:


### PR DESCRIPTION
During the test execution the exit code was not always
checked. This made the testrunner to report PASS status for
a test even if it did not returned zero as the exit code.