### PR TITLE
Allow passing output level for testrunners

### DIFF
--- a/tools/build.py
+++ b/tools/build.py
@@ -176,8 +176,9 @@ def init_options():
         action='store_true', default=False,
         help='Disable test execution with valgrind after build')
     parser.add_argument('--run-test',
-        action='store_true', default=False,
-        help='Execute tests after build')
+        nargs='?', default=False, const="quiet", choices=["full", "quiet"],
+        help='Execute tests after build, optional argument specifies '
+             'the level of output for the testrunner')
     parser.add_argument('--test-driver',
         choices=['js', 'py'], default='py',
         help='Specify the test driver for IoT.js: %(choices)s'
@@ -371,10 +372,6 @@ def build_iotjs(options):
 
 
 def run_checktest(options):
-    checktest_quiet = 'yes'
-    if os.getenv('TRAVIS') == "true":
-        checktest_quiet = 'no'
-
     # IoT.js executable
     iotjs = fs.join(options.build_root, 'bin', 'iotjs')
 
@@ -382,14 +379,17 @@ def run_checktest(options):
     args = []
     if options.test_driver == "js":
         cmd = iotjs
-        args = [path.CHECKTEST_PATH, 'quiet=' + checktest_quiet]
+        args = [path.CHECKTEST_PATH]
+        if options.run_test == "quiet":
+            args.append('quiet=yes')
+
         # experimental
         if options.experimental:
-            cmd.append('experimental=' + 'yes');
+            args.append('experimental=yes');
     else:
         cmd = fs.join(path.TOOLS_ROOT, 'testrunner.py')
         args = [iotjs]
-        if checktest_quiet:
+        if options.run_test == "quiet":
             args.append('--quiet')
 
 

--- a/tools/travis_script.py
+++ b/tools/travis_script.py
@@ -52,7 +52,7 @@ BUILDOPTIONS_SANITIZER = [
     '--no-check-valgrind',
     '--no-snapshot',
     '--profile=test/profiles/host-linux.profile',
-    '--run-test',
+    '--run-test=full',
     '--target-arch=i686'
 ]
 
@@ -89,7 +89,7 @@ if __name__ == '__main__':
 
         for buildtype in BUILDTYPES:
             build_iotjs(buildtype, [
-                        '--run-test',
+                        '--run-test=full',
                         '--profile=test/profiles/host-linux.profile'])
 
     elif test == 'rpi2':
@@ -148,7 +148,7 @@ if __name__ == '__main__':
     elif test == "external-modules":
         for buildtype in BUILDTYPES:
             build_iotjs(buildtype, [
-                        '--run-test',
+                        '--run-test=full',
                         '--profile=test/profiles/host-linux.profile',
                         '--external-modules=test/external_modules/'
                         'mymodule1,test/external_modules/mymodule2',
@@ -166,13 +166,13 @@ if __name__ == '__main__':
 
     elif test == "no-snapshot":
         for buildtype in BUILDTYPES:
-            build_iotjs(buildtype, ['--run-test', '--no-snapshot',
+            build_iotjs(buildtype, ['--run-test=full', '--no-snapshot',
                                     '--jerry-lto'])
 
     elif test == "host-darwin":
         for buildtype in BUILDTYPES:
             ex.check_run_cmd('./tools/build.py', [
-                             '--run-test',
+                             '--run-test=full',
                              '--buildtype=' + buildtype,
                              '--clean',
                              '--profile=test/profiles/host-darwin.profile'])


### PR DESCRIPTION
The option 'run-test' was made to a tri-state option:
* without the '--run-test' option the build script does not run tests
* with the '--run-test=full', testing will be done and all test output will be shown
* with the '--run-test=quiet', testing will be done and only PASS/FAIL will be shown
* and the '--run-test' option will behave as the '--run-test=quiet' option

Also fixes Travis testrun output to show every information.
During Travis testing the output for each test was not visible.