### PR TITLE
Properly terminate the engine at the first uncaughtException

### DIFF
--- a/src/iotjs_binding_helper.c
+++ b/src/iotjs_binding_helper.c
@@ -116,6 +116,10 @@ void iotjs_make_callback(jerry_value_t jfunction, jerry_value_t jthis,
 jerry_value_t iotjs_make_callback_with_result(jerry_value_t jfunction,
                                               jerry_value_t jthis,
                                               const iotjs_jargs_t* jargs) {
+  // If the environment is already exiting just return an undefined value.
+  if (iotjs_environment_is_exiting(iotjs_environment_get())) {
+    return jerry_create_undefined();
+  }
   // Calls back the function.
   jerry_value_t jres = iotjs_jhelper_call(jfunction, jthis, jargs);
   if (jerry_value_has_error_flag(jres)) {

--- a/test/run_fail/test-issue-1349.js
+++ b/test/run_fail/test-issue-1349.js
@@ -1,0 +1,18 @@
+/* Copyright 2017-present Samsung Electronics Co., Ltd. and other contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+var dns = require( 'dns' );
+var assert = require( 'assert' );
+assert.throws(function ( ) { dns.lookup ('localhost', require) } );

--- a/test/testsets.json
+++ b/test/testsets.json
@@ -123,6 +123,7 @@
     { "name": "test_fs_callbacks_called.js", "expected-failure": true },
     { "name": "test_iotjs_runtime_error.js", "expected-failure": true },
     { "name": "test_iotjs_syntax_error.js", "expected-failure": true },
+    { "name": "test-issue-1349.js", "expected-failure": true},
     { "name": "test-issue-1360.js", "expected-failure": true},
     { "name": "test_module_require_invalid_file.js", "expected-failure": true },
     { "name": "test_module_require_path_below_root.js", "expected-failure": true },


### PR DESCRIPTION
There's a special case where if an uncaughtException is thrown, and later a callback function is evaluated it would throw another one.
The correct behaviour for this would be terminating the engine at the first one, and throwing the error.
This patch fixes #1349

IoT.js-DCO-1.0-Signed-off-by: Daniel Balla dballa@inf.u-szeged.hu