### PR TITLE
Enable build mode on tizen 

### DIFF
--- a/config/tizen/gbsbuild.sh
+++ b/config/tizen/gbsbuild.sh
@@ -42,6 +42,7 @@ fi
 
 echo -e "\n(3) Calling core gbs build command"
 gbsconf="config/tizen/sample.gbs.conf"
+#if you want to change build_mode you can add --define='build_mode debug' option
 gbscommand="gbs -c $gbsconf build -A armv7l --include-all --clean"
 ret=0
 echo $gbscommand

--- a/config/tizen/packaging/iotjs.spec
+++ b/config/tizen/packaging/iotjs.spec
@@ -33,18 +33,8 @@ Requires(post): /sbin/ldconfig
 %description
 Platform for Internet of Things with JavaScript
 
-# default is RELEASE mode.
-# If DEBUG mode is needed, please use tizen_build_devel_mode
-%define RELEASE False
-# For Example
-%if %{RELEASE} == "True"
-%define build_mode release
-%else
-%define build_mode debug
-%endif
-
-# Default values to be eventually overiden BEFORE or as gbs params:
-%{!?RELEASE: %define RELEASE 0}
+# default is release mode
+%{!?build_mode: %define build_mode release}
 
 %package service
 Summary: Development files for %{name}


### PR DESCRIPTION
Default build_mode is release, if you want to build as debug mode
you can use --define='build_mode debug' option in gbs command

IoT.js-DCO-1.0-Signed-off-by: Haesik, Jun haesik.jun@samsung.com