### PR TITLE
Fix wrong behaviour of iotjs_process_exitcode

### DIFF
--- a/src/iotjs_binding_helper.c
+++ b/src/iotjs_binding_helper.c
@@ -142,12 +142,17 @@ int iotjs_process_exitcode() {
 
   jerry_value_t jexitcode =
       iotjs_jval_get_property(process, IOTJS_MAGIC_STRING_EXITCODE);
-  IOTJS_ASSERT(jerry_value_is_number(jexitcode));
-
-  const int exitcode = (int)iotjs_jval_as_number(jexitcode);
+  uint8_t exitcode = 0;
+  jerry_value_t num_val = jerry_value_to_number(jexitcode);
+  if (jerry_value_has_error_flag(num_val)) {
+    exitcode = 1;
+    jerry_value_clear_error_flag(&num_val);
+  } else {
+    exitcode = (uint8_t)iotjs_jval_as_number(num_val);
+  }
+  jerry_release_value(num_val);
   jerry_release_value(jexitcode);
-
-  return exitcode;
+  return (int)exitcode;
 }
 
 

--- a/test/run_pass/issue/issue-1507.js
+++ b/test/run_pass/issue/issue-1507.js
@@ -1,0 +1,17 @@
+/* Copyright 2018-present Samsung Electronics Co., Ltd. and other contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+var x = require("console");
+process.exitCode = x.id_0;

--- a/test/testsets.json
+++ b/test/testsets.json
@@ -114,7 +114,8 @@
     { "name": "issue-1101.js", "skip": ["all"], "reason": "need to setup test environment" },
     { "name": "issue-1348.js" },
     { "name": "issue-1351.js" },
-    { "name": "issue-1485.js" }
+    { "name": "issue-1485.js" },
+    { "name": "issue-1507.js" }
   ],
   "run_fail":  [
     { "name": "test_assert_equal.js", "expected-failure": true },


### PR DESCRIPTION
process.exitCode can be overwritten by anything.
when it's not a number type, just let iotjs_process_exitcode() returns default number.

fixes #1507

IoT.js-DCO-1.0-Signed-off-by: Minsoo Kim minnsoo.kim@samsung.com