### PR TITLE
Change the way to check test in test_fs_mkdir_rmdir.js

### DIFF
--- a/test/run_pass/test_fs_mkdir_rmdir.js
+++ b/test/run_pass/test_fs_mkdir_rmdir.js
@@ -62,27 +62,21 @@ function unlink(path) {
       assert.equal(err, null);
       assert.equal(fs.existsSync(root2), true);
 
-      fs.rmdir(root2, function(){
+      fs.rmdir(root2, function() {
         assert.equal(fs.existsSync(root2), false);
       });
 
       // Run read-only directory test only on linux and Tizen
       // NuttX does not support read-only attribute.
       if (process.platform === 'linux' || process.platform === 'tizen') {
-        // Try to create a folder in a read-only directory.
-        fs.mkdir(root, '0444', function(err) {
+        var testMode = '0444';
+        fs.mkdir(root, testMode, function(err) {
+          assert.equal(err, null);
           assert.equal(fs.existsSync(root), true);
 
-          var dirname = root + "/permission_test";
-          try {
-            fs.mkdirSync(dirname);
-            assert.assert(false);
-          } catch (e) {
-            assert.equal(e instanceof Error, true);
-            assert.equal(e instanceof assert.AssertionError, false);
-          }
+          var mode = fs.statSync(root).mode;
+          assert.strictEqual(mode.toString(8).slice(-4), testMode);
 
-          assert.equal(fs.existsSync(dirname), false);
           fs.rmdir(root, function() {
             assert.equal(fs.existsSync(root), false);
           });

--- a/test/testsets.json
+++ b/test/testsets.json
@@ -24,7 +24,7 @@
     { "name": "test_fs_exists_sync.js" },
     { "name": "test_fs_fstat.js", "skip": ["nuttx", "tizenrt"], "reason": "not implemented for nuttx/TizenRT" },
     { "name": "test_fs_fstat_sync.js", "skip": ["nuttx", "tizenrt"], "reason": "not implemented for nuttx/TizenRT" },
-    { "name": "test_fs_mkdir_rmdir.js", "skip": ["linux", "tizen", "nuttx"], "reason": "[linux/tizen]: flaky on Travis, [nuttx]: implemented, run manually in default configuration" },
+    { "name": "test_fs_mkdir_rmdir.js", "skip": ["tizen", "nuttx"], "reason": "[tizen]: flaky on Travis, [nuttx]: implemented, run manually in default configuration" },
     { "name": "test_fs_open_close.js", "skip": ["nuttx"], "reason": "not implemented for nuttx" },
     { "name": "test_fs_readdir.js" },
     { "name": "test_fs_readfile.js" },


### PR DESCRIPTION
For root user, the file can be written to the read-only directory.

IoT.js-DCO-1.0-Signed-off-by: Hosung Kim hs852.kim@samsung.com