### PR TITLE
Improve parsing CLI arguments

### DIFF
--- a/docs/devs/Use-JerryScript-Debugger.md
+++ b/docs/devs/Use-JerryScript-Debugger.md
@@ -14,7 +14,7 @@ intergrated into the binary of IoT.js.
 To start the debugger-server: `<iotjs binary> --start-debug-server test.js`
 
 It is important to note that optional parameters (such as `--debugger-wait-source` or
-`--jerry-debugger-port=...`) should be specified after `--start-debug-server` in order to work properly.
+`--debugger-port <PORT>`) should be specified after `--start-debug-server` in order to work properly.
 
 #### Sending source to the debugger remotely
 
@@ -26,8 +26,8 @@ thus, there's no need to restart the environment if the remote source is changed
 #### Setting the debugger port
 
 If you want to specify the port number of the debugger-server (default: 5001),
-you can do so with the `--jerry-debugger-port=<PORT>` option:
-`<iotjs binary> --start-debug-server --jerry-debugger-port=8080 test.js`
+you can do so with the `--debugger-port <PORT>` option:
+`<iotjs binary> --start-debug-server --debugger-port 8080 test.js`
 
 Two clients are included, a [python](https://github.com/jerryscript-project/jerryscript/blob/master/jerry-debugger/jerry-client-ws.py)
 and an [HTML](https://github.com/jerryscript-project/jerryscript/blob/master/jerry-debugger/jerry-client-ws.html) variant, they can be found under `deps/jerry/jerry-debugger/`.


### PR DESCRIPTION
- show option help with `--help`
- change `--jerry-debugger-port=` to `--debugger-port`

IoT.js-DCO-1.0-Signed-off-by: Daeyeon Jeong daeyeon.jeong@samsung.com