### PR TITLE
Change the lint style and remove lint monitoring

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,14 +2,12 @@
   "name": "IoT.js",
   "description": "Platform for Internet of Things with JavaScript",
   "scripts": {
-    "lint": "eslint src ./*.js -f table --ext .js > eslint.log",
-    "lint-autofix": "eslint src ./*.js -f table --ext .js --fix > eslint.log",
-    "lint-server": "nodemon --watch .eslintrc.js --watch ./src --ext js --exec \"npm run lint\""
+    "lint": "eslint src -f codeframe || true",
+    "lint-autofix": "eslint src -f codeframe --fix || true"
   },
   "author": "Samsung Electronics Co., Ltd.",
   "license": "Apache-2.0",
   "devDependencies": {
-    "eslint": "^4.7.2",
-    "nodemon": "^1.12.1"
+    "eslint": "^4.7.2"
   }
 }


### PR DESCRIPTION
This patch changes the output style to [codeframe](https://eslint.org/docs/user-guide/formatters/#codeframe) which looks similar to the clang output format.

IoT.js-DCO-1.0-Signed-off-by: Daeyeon Jeong daeyeon.jeong@samsung.com