### PR TITLE
Remove iotjs_jhelper_call_ok

### DIFF
--- a/src/iotjs_binding.c
+++ b/src/iotjs_binding.c
@@ -273,14 +273,6 @@ jerry_value_t iotjs_jhelper_call(jerry_value_t jfunc, jerry_value_t jthis,
 }
 
 
-jerry_value_t iotjs_jhelper_call_ok(jerry_value_t jfunc, jerry_value_t jthis,
-                                    const iotjs_jargs_t* jargs) {
-  jerry_value_t jres = iotjs_jhelper_call(jfunc, jthis, jargs);
-  IOTJS_ASSERT(!jerry_value_has_error_flag(jres));
-  return jres;
-}
-
-
 jerry_value_t iotjs_jhelper_eval(const char* name, size_t name_len,
                                  const uint8_t* data, size_t size,
                                  bool strict_mode) {

--- a/src/iotjs_binding.h
+++ b/src/iotjs_binding.h
@@ -99,10 +99,6 @@ void iotjs_jargs_replace(iotjs_jargs_t* jargs, uint16_t index, jerry_value_t x);
 jerry_value_t iotjs_jhelper_call(jerry_value_t jfunc, jerry_value_t jthis,
                                  const iotjs_jargs_t* jargs);
 
-// Calls javascript function.
-jerry_value_t iotjs_jhelper_call_ok(jerry_value_t jfunc, jerry_value_t jthis,
-                                    const iotjs_jargs_t* jargs);
-
 // Evaluates javascript source file.
 jerry_value_t iotjs_jhelper_eval(const char* name, size_t name_len,
                                  const uint8_t* data, size_t size,

--- a/src/modules/iotjs_module_buffer.c
+++ b/src/modules/iotjs_module_buffer.c
@@ -199,7 +199,8 @@ jerry_value_t iotjs_bufferwrap_create_buffer(size_t len) {
   iotjs_jargs_append_number(&jargs, len);
 
   jerry_value_t jres =
-      iotjs_jhelper_call_ok(jbuffer, jerry_create_undefined(), &jargs);
+      iotjs_jhelper_call(jbuffer, jerry_create_undefined(), &jargs);
+  IOTJS_ASSERT(!jerry_value_has_error_flag(jres));
   IOTJS_ASSERT(jerry_value_is_object(jres));
 
   iotjs_jargs_destroy(&jargs);

--- a/src/modules/iotjs_module_tcp.c
+++ b/src/modules/iotjs_module_tcp.c
@@ -275,8 +275,9 @@ static void OnConnection(uv_stream_t* handle, int status) {
     IOTJS_ASSERT(jerry_value_is_function(jcreate_tcp));
 
     jerry_value_t jclient_tcp =
-        iotjs_jhelper_call_ok(jcreate_tcp, jerry_create_undefined(),
-                              iotjs_jargs_get_empty());
+        iotjs_jhelper_call(jcreate_tcp, jerry_create_undefined(),
+                           iotjs_jargs_get_empty());
+    IOTJS_ASSERT(!jerry_value_has_error_flag(jclient_tcp));
     IOTJS_ASSERT(jerry_value_is_object(jclient_tcp));
 
     iotjs_tcpwrap_t* tcp_wrap_client =

--- a/src/modules/iotjs_module_uart.c
+++ b/src/modules/iotjs_module_uart.c
@@ -80,9 +80,9 @@ static void iotjs_uart_read_cb(uv_poll_t* req, int status, int events) {
     iotjs_jargs_append_jval(&jargs, str);
     iotjs_jargs_append_jval(&jargs, data);
     jerry_value_t jres =
-        iotjs_jhelper_call_ok(jemit,
-                              iotjs_handlewrap_jobject(&uart->handlewrap),
-                              &jargs);
+        iotjs_jhelper_call(jemit, iotjs_handlewrap_jobject(&uart->handlewrap),
+                           &jargs);
+    IOTJS_ASSERT(!jerry_value_has_error_flag(jres));
 
     jerry_release_value(jres);
     jerry_release_value(str);

--- a/src/modules/linux/iotjs_module_blehcisocket-linux.c
+++ b/src/modules/linux/iotjs_module_blehcisocket-linux.c
@@ -289,7 +289,8 @@ void iotjs_blehcisocket_poll(iotjs_blehcisocket_t* blehcisocket) {
     iotjs_bufferwrap_copy(buf_wrap, data, (size_t)length);
     iotjs_jargs_append_jval(&jargs, str);
     iotjs_jargs_append_jval(&jargs, jbuf);
-    jerry_value_t jres = iotjs_jhelper_call_ok(jemit, jhcisocket, &jargs);
+    jerry_value_t jres = iotjs_jhelper_call(jemit, jhcisocket, &jargs);
+    IOTJS_ASSERT(!jerry_value_has_error_flag(jres));
 
     jerry_release_value(jres);
     jerry_release_value(str);
@@ -322,7 +323,8 @@ void iotjs_blehcisocket_emitErrnoError(iotjs_blehcisocket_t* blehcisocket) {
   jerry_value_t str = jerry_create_string((const jerry_char_t*)"error");
   iotjs_jargs_append_jval(&jargs, str);
   iotjs_jargs_append_error(&jargs, strerror(errno));
-  jerry_value_t jres = iotjs_jhelper_call_ok(jemit, jhcisocket, &jargs);
+  jerry_value_t jres = iotjs_jhelper_call(jemit, jhcisocket, &jargs);
+  IOTJS_ASSERT(!jerry_value_has_error_flag(jres));
 
   jerry_release_value(jres);
   jerry_release_value(str);

--- a/src/modules/linux/iotjs_module_gpio-linux.c
+++ b/src/modules/linux/iotjs_module_gpio-linux.c
@@ -79,7 +79,8 @@ static void gpio_emit_change_event(iotjs_gpio_t* gpio) {
   IOTJS_ASSERT(jerry_value_is_function(jonChange));
 
   jerry_value_t jres =
-      iotjs_jhelper_call_ok(jonChange, jgpio, iotjs_jargs_get_empty());
+      iotjs_jhelper_call(jonChange, jgpio, iotjs_jargs_get_empty());
+  IOTJS_ASSERT(!jerry_value_has_error_flag(jres));
 
   jerry_release_value(jres);
   jerry_release_value(jonChange);


### PR DESCRIPTION
Remove iotjs_jhelper_call_ok
Because it has nothing but the call of iotjs_jhelper_call.
Changed to use iotjs_jhelper_call directly

IoT.js-DCO-1.0-Signed-off-by: Minsoo Kim minnsoo.kim@samsung.com