### PR TITLE
Add custom config file for mbedtls build

### DIFF
--- a/cmake/mbedtls.cmake
+++ b/cmake/mbedtls.cmake
@@ -21,6 +21,11 @@ set(MODULE_NAME "tls")
 set(MODULE_BINARY_DIR ${DEPS_MBEDTLS_BUILD_DIR})
 
 set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wno-sign-conversion")
+set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -I${ROOT_DIR}/config/mbedtls")
+set(CMAKE_C_FLAGS
+    "${CMAKE_C_FLAGS} -DMBEDTLS_CONFIG_FILE='<config-for-iotjs.h>'")
+
+#message(FATAL_ERROR "${CMAKE_C_FLAGS}")
 
 ExternalProject_Add(mbedtls
   PREFIX ${DEPS_MBEDTLS}

--- a/config/mbedtls/config-for-iotjs.h
+++ b/config/mbedtls/config-for-iotjs.h
@@ -1,0 +1,89 @@
+/* Copyright 2018-present Samsung Electronics Co., Ltd. and other contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/*
+ *  Minimal configuration for TLS 1.1 (RFC 4346)
+ *
+ *  Copyright (C) 2006-2015, ARM Limited, All Rights Reserved
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License"); you may
+ *  not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ *  WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *  This file is part of mbed TLS (https://tls.mbed.org)
+ */
+
+/*
+ * Minimal configuration for TLS 1.1 (RFC 4346), implementing only the
+ * required ciphersuite: MBEDTLS_TLS_RSA_WITH_3DES_EDE_CBC_SHA
+ */
+
+#ifndef MBEDTLS_CONFIG_H
+#define MBEDTLS_CONFIG_H
+
+/* System support */
+#define MBEDTLS_HAVE_ASM
+#define MBEDTLS_HAVE_TIME
+
+/* mbed TLS feature support */
+#define MBEDTLS_CIPHER_MODE_CBC
+#define MBEDTLS_PKCS1_V15
+#define MBEDTLS_KEY_EXCHANGE_RSA_ENABLED
+#define MBEDTLS_SSL_PROTO_TLS1_1
+#define MBEDTLS_SSL_PROTO_TLS1_2
+
+/* mbed TLS modules */
+#define MBEDTLS_AES_C
+#define MBEDTLS_ASN1_PARSE_C
+#define MBEDTLS_ASN1_WRITE_C
+#define MBEDTLS_BIGNUM_C
+#define MBEDTLS_CIPHER_C
+#define MBEDTLS_CTR_DRBG_C
+#define MBEDTLS_DES_C
+#define MBEDTLS_ENTROPY_C
+#define MBEDTLS_MD_C
+#define MBEDTLS_MD5_C
+#define MBEDTLS_NET_C
+#define MBEDTLS_OID_C
+#define MBEDTLS_PK_C
+#define MBEDTLS_PK_PARSE_C
+#define MBEDTLS_RSA_C
+#define MBEDTLS_SHA1_C
+#define MBEDTLS_SHA256_C
+#define MBEDTLS_SSL_CLI_C
+#define MBEDTLS_SSL_SRV_C
+#define MBEDTLS_SSL_TLS_C
+#define MBEDTLS_X509_CRT_PARSE_C
+#define MBEDTLS_X509_USE_C
+
+/* For test certificates */
+#define MBEDTLS_BASE64_C
+#define MBEDTLS_CERTS_C
+#define MBEDTLS_PEM_PARSE_C
+
+/* For testing with compat.sh */
+#define MBEDTLS_FS_IO
+
+#include "mbedtls/check_config.h"
+
+#endif /* MBEDTLS_CONFIG_H */


### PR DESCRIPTION
**Build command:**
`tools/build.py --cmake-param=-DENABLE_MODULE_TLS=ON --buildtype=release --target-board=rpi2 --target-arch=arm`

**Binary size**

| | Size (bytes) |
| - | - |
| master | 567 532 |
| b2183bf | 391 304 |


IoT.js-DCO-1.0-Signed-off-by: László Langó llango.u-szeged@partner.samsung.com