### PR TITLE
[WIP] Run the debugger on the forked process

### DIFF
--- a/src/iotjs_env.h
+++ b/src/iotjs_env.h
@@ -51,6 +51,12 @@ typedef struct {
   // Running state.
   State state;
 
+  // Launch method
+  bool use_fork;
+
+  // Restart app when it's terminated
+  bool auto_restart;
+
   // Run config
   Config config;
 } iotjs_environment_t;


### PR DESCRIPTION
This patch allows debugger to run on the child process. With options,
-d -a, iot.js will auto-restart even when context_reset isn't requested.
iotjs_entry won't be continuously self-called when waiting for sources
from the debug client.

IoT.js-DCO-1.0-Signed-off-by: Daeyeon Jeong daeyeon.jeong@samsung.com