### PR TITLE
Update the snapshot version in the js2c.py

### DIFF
--- a/tools/js2c.py
+++ b/tools/js2c.py
@@ -55,7 +55,7 @@ def force_str(string):
 
 
 def parse_literals(code):
-    JERRY_SNAPSHOT_VERSION = 8
+    JERRY_SNAPSHOT_VERSION = 9
     JERRY_SNAPSHOT_MAGIC = 0x5952524A
 
     literals = set()


### PR DESCRIPTION
This will fix the travis build.
This should have been in the jerry submodule update patch.

IoT.js-DCO-1.0-Signed-off-by: Imre Kiss kissi.szeged@partner.samsung.com