### PR TITLE
i2c: Add readBytes utility function

### DIFF
--- a/src/js/i2c.js
+++ b/src/js/i2c.js
@@ -13,15 +13,25 @@
  * limitations under the License.
  */
 
+function extendI2CBus(i2cBus) {
+  i2cBus.readBytes = function(offset, len, callback) {
+    this.writeSync([offset]);
+    this.read(len, function(err, res) {
+      callback(err, res);
+    });
+  };
+  return i2cBus;
+}
+
 var i2c = {
   open: function(config, callback) {
     var i2cBus = new native(config, function(err) {
-      callback(err, i2cBus);
+      callback(err, extendI2CBus(i2cBus));
     });
     return i2cBus;
   },
   openSync: function(config) {
-    return new native(config);
+    return extendI2CBus(new native(config));
   },
 };
 


### PR DESCRIPTION
Note this function is not critical and can be "injected" outside module.

But if inside, it will help developer to port from node to iotjs,
if API are aligned to npm's i2c module.

An alternative to consider is to create an other module (ie: compat/npm/i2c)
that wraps and fill the gap between iotjs's minimal implementation
and node/NPM one.

IoT.js-DCO-1.0-Signed-off-by: Philippe Coval <philippe.coval@osg.samsung.com>