### PR TITLE
Change iotjs_buffer_release with IOTJS_RELEASE

### DIFF
--- a/src/iotjs_binding.c
+++ b/src/iotjs_binding.c
@@ -318,7 +318,7 @@ void iotjs_jargs_destroy(iotjs_jargs_t* jargs) {
     for (unsigned i = 0; i < jargs->argc; ++i) {
       jerry_release_value(jargs->argv[i]);
     }
-    iotjs_buffer_release((char*)jargs->argv);
+    IOTJS_RELEASE(jargs->argv);
   } else {
     IOTJS_ASSERT(jargs->argv == NULL);
   }

--- a/src/iotjs_string.c
+++ b/src/iotjs_string.c
@@ -65,26 +65,14 @@ iotjs_string_t iotjs_string_create_with_buffer(char* buffer, size_t size) {
 
 
 void iotjs_string_destroy(iotjs_string_t* str) {
-  if (str->data != NULL) {
-    iotjs_buffer_release(str->data);
-    str->size = 0;
-  }
+  IOTJS_RELEASE(str->data);
+  str->size = 0;
 }
 
 
 bool iotjs_string_is_empty(const iotjs_string_t* str) {
   return str->size == 0;
 }
-
-
-void iotjs_string_make_empty(iotjs_string_t* str) {
-  if (str->data != NULL) {
-    iotjs_buffer_release(str->data);
-    str->size = 0;
-    str->data = NULL;
-  }
-}
-
 
 void iotjs_string_append(iotjs_string_t* str, const char* data, size_t size) {
   IOTJS_ASSERT(data != NULL);

--- a/src/iotjs_string.h
+++ b/src/iotjs_string.h
@@ -33,9 +33,6 @@ void iotjs_string_destroy(iotjs_string_t* str);
 // Check if string is empty
 bool iotjs_string_is_empty(const iotjs_string_t* str);
 
-// Make string empty
-void iotjs_string_make_empty(iotjs_string_t* str);
-
 // Append `data` to tail of the string.
 void iotjs_string_append(iotjs_string_t* str, const char* data, size_t size);
 

--- a/src/modules/iotjs_module_buffer.c
+++ b/src/modules/iotjs_module_buffer.c
@@ -506,7 +506,7 @@ static jerry_value_t to_hex_string(const uint8_t* data, size_t length) {
   }
 
   jerry_value_t ret_value = jerry_create_string_sz(str, buffer_length);
-  iotjs_buffer_release((char*)str);
+  IOTJS_RELEASE(str);
 
   return ret_value;
 }
@@ -564,7 +564,7 @@ static jerry_value_t to_base64_string(const uint8_t* data, size_t length) {
   }
 
   jerry_value_t ret_value = jerry_create_string_sz(str, buffer_length);
-  iotjs_buffer_release((char*)str);
+  IOTJS_RELEASE(str);
 
   return ret_value;
 }

--- a/src/modules/iotjs_module_httpparser.c
+++ b/src/modules/iotjs_module_httpparser.c
@@ -60,8 +60,8 @@ typedef enum http_parser_type http_parser_type;
 static void iotjs_httpparserwrap_initialize(
     iotjs_httpparserwrap_t* httpparserwrap, http_parser_type type) {
   http_parser_init(&httpparserwrap->parser, type);
-  iotjs_string_make_empty(&httpparserwrap->url);
-  iotjs_string_make_empty(&httpparserwrap->status_msg);
+  iotjs_string_destroy(&httpparserwrap->url);
+  iotjs_string_destroy(&httpparserwrap->status_msg);
   httpparserwrap->n_fields = 0;
   httpparserwrap->n_values = 0;
   httpparserwrap->flushed = false;
@@ -140,7 +140,7 @@ static void iotjs_httpparserwrap_flush(iotjs_httpparserwrap_t* httpparserwrap) {
 
   iotjs_make_callback(func, jobj, &argv);
 
-  iotjs_string_make_empty(&httpparserwrap->url);
+  iotjs_string_destroy(&httpparserwrap->url);
   iotjs_jargs_destroy(&argv);
   jerry_release_value(func);
   httpparserwrap->flushed = true;
@@ -160,8 +160,8 @@ static void iotjs_httpparserwrap_set_buf(iotjs_httpparserwrap_t* httpparserwrap,
 static int iotjs_httpparserwrap_on_message_begin(http_parser* parser) {
   iotjs_httpparserwrap_t* httpparserwrap =
       (iotjs_httpparserwrap_t*)(parser->data);
-  iotjs_string_make_empty(&httpparserwrap->url);
-  iotjs_string_make_empty(&httpparserwrap->status_msg);
+  iotjs_string_destroy(&httpparserwrap->url);
+  iotjs_string_destroy(&httpparserwrap->status_msg);
   return 0;
 }
 
@@ -197,8 +197,7 @@ static int iotjs_httpparserwrap_on_header_field(http_parser* parser,
       httpparserwrap->n_fields = 1;
       httpparserwrap->n_values = 0;
     }
-    iotjs_string_make_empty(
-        &httpparserwrap->fields[httpparserwrap->n_fields - 1]);
+    iotjs_string_destroy(&httpparserwrap->fields[httpparserwrap->n_fields - 1]);
   }
   IOTJS_ASSERT(httpparserwrap->n_fields == httpparserwrap->n_values + 1);
   iotjs_string_append(&httpparserwrap->fields[httpparserwrap->n_fields - 1], at,
@@ -214,8 +213,7 @@ static int iotjs_httpparserwrap_on_header_value(http_parser* parser,
       (iotjs_httpparserwrap_t*)(parser->data);
   if (httpparserwrap->n_fields != httpparserwrap->n_values) {
     httpparserwrap->n_values++;
-    iotjs_string_make_empty(
-        &httpparserwrap->values[httpparserwrap->n_values - 1]);
+    iotjs_string_destroy(&httpparserwrap->values[httpparserwrap->n_values - 1]);
   }
 
   IOTJS_ASSERT(httpparserwrap->n_fields == httpparserwrap->n_values);

--- a/src/modules/iotjs_module_periph_common.c
+++ b/src/modules/iotjs_module_periph_common.c
@@ -150,9 +150,7 @@ static void after_worker(uv_work_t* work_req, int status) {
           iotjs_jargs_append_jval(&jargs, result);
           jerry_release_value(result);
 
-          if (i2c->buf_data != NULL) {
-            iotjs_buffer_release(i2c->buf_data);
-          }
+          IOTJS_RELEASE(i2c->buf_data);
 #endif /* ENABLE_MODULE_I2C */
           break;
         }
@@ -169,7 +167,7 @@ static void after_worker(uv_work_t* work_req, int status) {
           iotjs_jargs_append_jval(&jargs, result);
           jerry_release_value(result);
 
-          iotjs_buffer_release(spi->rx_buf_data);
+          IOTJS_RELEASE(spi->rx_buf_data);
 #endif /* ENABLE_MODULE_SPI */
           break;
         }
@@ -182,7 +180,7 @@ static void after_worker(uv_work_t* work_req, int status) {
 #if ENABLE_MODULE_SPI
     if (reqwrap->op == kSpiOpTransferArray) {
       iotjs_spi_t* spi = (iotjs_spi_t*)reqwrap->data;
-      iotjs_buffer_release(spi->tx_buf_data);
+      IOTJS_RELEASE(spi->tx_buf_data);
     }
 #endif /* ENABLE_MODULE_SPI */
 #if ENABLE_MODULE_UART

--- a/src/modules/iotjs_module_spi.c
+++ b/src/modules/iotjs_module_spi.c
@@ -269,10 +269,10 @@ JS_FUNCTION(TransferSync) {
   }
 
   if (op == kSpiOpTransferArray) {
-    iotjs_buffer_release(spi->tx_buf_data);
+    IOTJS_RELEASE(spi->tx_buf_data);
   }
 
-  iotjs_buffer_release(spi->rx_buf_data);
+  IOTJS_RELEASE(spi->rx_buf_data);
 
   return result;
 }

--- a/src/modules/iotjs_module_tcp.c
+++ b/src/modules/iotjs_module_tcp.c
@@ -400,9 +400,8 @@ void OnRead(uv_stream_t* handle, ssize_t nread, const uv_buf_t* buf) {
   iotjs_jargs_append_bool(&jargs, false);
 
   if (nread <= 0) {
-    if (buf->base != NULL) {
-      iotjs_buffer_release(buf->base);
-    }
+    iotjs_buffer_release(buf->base);
+
     if (nread < 0) {
       if (nread == UV__EOF) {
         iotjs_jargs_replace(&jargs, 2, jerry_create_boolean(true));

--- a/src/modules/iotjs_module_tls.c
+++ b/src/modules/iotjs_module_tls.c
@@ -79,7 +79,7 @@ static jerry_value_t tls_connect_error(iotjs_string_t* h, iotjs_string_t* p,
   iotjs_string_destroy(hn);
 
   jerry_value_t ret_val = JS_CREATE_ERROR(COMMON, (const jerry_char_t*)buf);
-  iotjs_buffer_release(buf);
+  IOTJS_RELEASE(buf);
 
   return ret_val;
 }

--- a/src/modules/iotjs_module_udp.c
+++ b/src/modules/iotjs_module_udp.c
@@ -141,8 +141,7 @@ static void OnAlloc(uv_handle_t* handle, size_t suggested_size, uv_buf_t* buf) {
 static void OnRecv(uv_udp_t* handle, ssize_t nread, const uv_buf_t* buf,
                    const struct sockaddr* addr, unsigned int flags) {
   if (nread == 0 && addr == NULL) {
-    if (buf->base != NULL)
-      iotjs_buffer_release(buf->base);
+    iotjs_buffer_release(buf->base);
     return;
   }
 
@@ -162,8 +161,7 @@ static void OnRecv(uv_udp_t* handle, ssize_t nread, const uv_buf_t* buf,
   iotjs_jargs_append_jval(&jargs, judp);
 
   if (nread < 0) {
-    if (buf->base != NULL)
-      iotjs_buffer_release(buf->base);
+    iotjs_buffer_release(buf->base);
     iotjs_make_callback(jonmessage, jerry_create_undefined(), &jargs);
     jerry_release_value(jonmessage);
     iotjs_jargs_destroy(&jargs);

--- a/src/modules/linux/iotjs_module_i2c-linux.c
+++ b/src/modules/linux/iotjs_module_i2c-linux.c
@@ -134,9 +134,8 @@ bool iotjs_i2c_write(iotjs_i2c_t* i2c) {
   char* data = i2c->buf_data;
 
   int ret = write(platform_data->device_fd, data, len);
-  if (i2c->buf_data != NULL) {
-    iotjs_buffer_release(i2c->buf_data);
-  }
+
+  IOTJS_RELEASE(i2c->buf_data);
 
   return ret == len;
 }

--- a/src/modules/linux/iotjs_module_pwm-linux.c
+++ b/src/modules/linux/iotjs_module_pwm-linux.c
@@ -168,7 +168,7 @@ bool iotjs_pwm_set_period(iotjs_pwm_t* pwm) {
       if (snprintf(buf, sizeof(buf), "%d", value) > 0) {
         result = iotjs_systemio_open_write_close(devicePath, buf);
       }
-      iotjs_buffer_release(devicePath);
+      IOTJS_RELEASE(devicePath);
     }
   }
   return result;
@@ -197,7 +197,7 @@ bool iotjs_pwm_set_dutycycle(iotjs_pwm_t* pwm) {
       }
 
       result = iotjs_systemio_open_write_close(devicePath, buf);
-      iotjs_buffer_release(devicePath);
+      IOTJS_RELEASE(devicePath);
     }
   }
   return result;
@@ -223,7 +223,7 @@ bool iotjs_pwm_set_enable(iotjs_pwm_t* pwm) {
     }
 
     result = iotjs_systemio_open_write_close(devicePath, buf);
-    iotjs_buffer_release(devicePath);
+    IOTJS_RELEASE(devicePath);
   }
   return result;
 }

--- a/src/modules/nuttx/iotjs_module_i2c-nuttx.c
+++ b/src/modules/nuttx/iotjs_module_i2c-nuttx.c
@@ -100,9 +100,7 @@ bool iotjs_i2c_write(iotjs_i2c_t* i2c) {
   int ret =
       i2c_write(platform_data->i2c_master, &platform_data->config, data, len);
 
-  if (i2c->buf_data != NULL) {
-    iotjs_buffer_release(i2c->buf_data);
-  }
+  IOTJS_RELEASE(i2c->buf_data);
 
   if (ret < 0) {
     DLOG("%s : cannot write - %d", __func__, ret);

--- a/src/modules/tizen/iotjs_module_i2c-tizen.c
+++ b/src/modules/tizen/iotjs_module_i2c-tizen.c
@@ -89,9 +89,7 @@ bool iotjs_i2c_write(iotjs_i2c_t* i2c) {
   int ret = peripheral_i2c_write(platform_data->i2c_h, (uint8_t*)i2c->buf_data,
                                  i2c->buf_len);
 
-  if (i2c->buf_data != NULL) {
-    iotjs_buffer_release(i2c->buf_data);
-  }
+  IOTJS_RELEASE(i2c->buf_data);
 
   if (ret != PERIPHERAL_ERROR_NONE) {
     DLOG("%s : cannot write(%d)", __func__, ret);

--- a/src/modules/tizenrt/iotjs_module_i2c-tizenrt.c
+++ b/src/modules/tizenrt/iotjs_module_i2c-tizenrt.c
@@ -116,9 +116,7 @@ bool iotjs_i2c_write(iotjs_i2c_t* i2c) {
 
   int ret = iotbus_i2c_write(platform_data->i2c_context, data, len);
 
-  if (i2c->buf_data != NULL) {
-    iotjs_buffer_release(i2c->buf_data);
-  }
+  IOTJS_RELEASE(i2c->buf_data);
 
   if (ret < 0) {
     DLOG("%s: cannot write data", __func__);


### PR DESCRIPTION
This patch is related to #1523.

- `iotjs_string_make_empty` is removed.
- Since `buf` in `iotjs_module_tcp/udp.c` is given as read-only,
  so IOTJS_RELEASE isn't used there.

IoT.js-DCO-1.0-Signed-off-by: Daeyeon Jeong daeyeon.jeong@samsung.com