### PR TITLE
Update JerryScript submodule

### DIFF
--- a/test/run_pass/issue/issue-1557.js
+++ b/test/run_pass/issue/issue-1557.js
@@ -1,0 +1,22 @@
+/* Copyright 2018-present Samsung Electronics Co., Ltd. and other contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+var fz_globalObject = Function("return this")( )
+var prop_names = Object.getOwnPropertyNames(fz_globalObject)
+console.log(prop_names)
+for (var i = 0; i < 10; i++) {
+    var prop_name = prop_names[i]
+    console.log(prop_name)
+}

--- a/test/testsets.json
+++ b/test/testsets.json
@@ -117,7 +117,8 @@
     { "name": "issue-1348.js" },
     { "name": "issue-1351.js" },
     { "name": "issue-1485.js" },
-    { "name": "issue-1507.js" }
+    { "name": "issue-1507.js" },
+    { "name": "issue-1557.js" }
   ],
   "run_fail":  [
     { "name": "test_assert_equal.js", "expected-failure": true },

--- a/tools/js2c.py
+++ b/tools/js2c.py
@@ -55,7 +55,7 @@ def force_str(string):
 
 
 def parse_literals(code):
-    JERRY_SNAPSHOT_VERSION = 9
+    JERRY_SNAPSHOT_VERSION = 10
     JERRY_SNAPSHOT_MAGIC = 0x5952524A
 
     literals = set()


### PR DESCRIPTION
Updated snapshot version and added a test for #1557. Fixes #1557

IoT.js-DCO-1.0-Signed-off-by: László Langó llango.u-szeged@partner.samsung.com