### PR TITLE
Add bridge module

### DIFF
--- a/docs/devs/Writing-New-Module.md
+++ b/docs/devs/Writing-New-Module.md
@@ -348,6 +348,29 @@ Where `native` is the JS object returned by the native `InitConsole` function in
 
 **Note**: `native` is undefined if there is no native part of the module.
 
+
+### Using bridge module to communicate between C and JavaScript module
+Bridge module provides two interfaces for sending synchronous and asynchronous message from Javascript to the native module. The Native module simply rersponds back to the requst using a simple inteface that can create return message. Of course you can use the IoT.js and JerryScript APIs to respond directly to the request of JavaScript module, but sometimes using a simpliffied method is more efficient in providing simple functionality in a short time.
+
+For example, JavaScript module can request resource path synchronously,
+and native module can simply return a resource path by just calling a function.
+
+in the bridge_sample.js of bridge_sample module
+```javascript
+bridge_sample.prototype.getResPath = function(){
+    return this.bridge.sendSync("getResPath", "");
+};
+```
+
+in the iotjs_bridge_sample.c of bridge_sample module
+```c
+if (strncmp(command, "getResPath", strlen("getResPath")) == 0) {
+    iotjs_bridge_set_return(return_message, "res/");
+    return 0;
+}
+```
+For the complete sample code, please see the bridge_sample in samples/bridge_sample folder.
+
 ## Advanced usage
 
 ### Module specific CMake file

--- a/samples/bridge_sample/README.md
+++ b/samples/bridge_sample/README.md
@@ -1,0 +1,21 @@
+# Sample bridge module
+
+See also:
+* [Writing-new-module](Writing-New-Module.md)
+* [Native Module vs. JS module](Native-Module-vs-JS-Module.md)
+* [Inside IoT.js](Inside-IoT.js.md)
+* [Developer Tutorial](Developer-Tutorial.md)
+
+
+## Description
+This sample show you how you can create a 'mixed' module using brige module that has some interfaces to support communicattion between JS and Native code. This sample created using tools/iotjs-create-module.py script.
+You can see how you could reduce your effor to create native module using simple methods provided bridge module.
+
+
+## Build
+
+$ ./tools/build.py --external-modules=./samples/bridge_sample --cmake-param=-DENABLE_MODULE_BRIDGE_SAMPLE=ON
+
+## Testing
+
+$ iotjs samples/bridge_sample/test.js

--- a/samples/bridge_sample/js/bridge_sample.js
+++ b/samples/bridge_sample/js/bridge_sample.js
@@ -1,0 +1,32 @@
+/* Copyright 2018-present Samsung Electronics Co., Ltd. and other contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+var Bridge = require('bridge');
+
+function bridge_sample(){
+    this.bridge = new Bridge(native.MODULE_NAME);
+}
+
+bridge_sample.prototype.getResPath = function(){
+    return this.bridge.sendSync("getResPath", "");
+};
+
+bridge_sample.prototype.getSystemInfo = function(callback){
+    this.bridge.send("getSystemInfo", "", function(err, msg){
+        callback(err, msg);
+    });
+};
+
+module.exports = new bridge_sample();

--- a/samples/bridge_sample/module.cmake
+++ b/samples/bridge_sample/module.cmake
@@ -1,0 +1,41 @@
+# Copyright 2018-present Samsung Electronics Co., Ltd. and other contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# General variables usable from IoT.js cmake:
+# - TARGET_ARCH - the target architecture (as specified during cmake step)
+# - TARGET_BOARD - the target board(/device)
+# - TARGET_OS - the target operating system
+#
+# Module related variables usable from IoT.js cmake:
+# - MODULE_DIR - the modules root directory
+# - MODULE_BINARY_DIR - the build directory for the current module
+# - MODULE_LIBS - list of libraries to use during linking (set this)
+set(MODULE_NAME "bridge_sample")
+
+# DO NOT include the source files which are already in the modules.json file.
+
+# If the module builds its own files into a lib please use the line below.
+# Note: the subdir 'lib' should contain the CMakeLists.txt describing how the
+#  module should be built.
+#add_subdirectory(${MODULE_DIR}/lib/ ${MODULE_BINARY_DIR}/${MODULE_NAME})
+
+# If you wish to link external libraries please add it to
+# the MODULE_LIBS list.
+#
+# IMPORTANT!
+#  if the module builds its own library that should also be specified!
+#
+# Example (to add the 'demo' library for linking):
+#
+#  list(APPEND MODULE_LIBS demo)

--- a/samples/bridge_sample/modules.json
+++ b/samples/bridge_sample/modules.json
@@ -1,0 +1,11 @@
+{
+  "modules": {
+    "bridge_sample": {
+      "js_file": "js/bridge_sample.js",
+      "native_files": ["src/iotjs_bridge_sample.c"],
+      "init": "InitBridgeSample",
+      "cmakefile": "module.cmake",
+      "require": ["bridge"]
+    }
+  }
+}

--- a/samples/bridge_sample/src/iotjs_bridge_sample.c
+++ b/samples/bridge_sample/src/iotjs_bridge_sample.c
@@ -1,0 +1,60 @@
+/* Copyright 2018-present Samsung Electronics Co., Ltd. and other contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "iotjs_def.h"
+#include "modules/iotjs_module_bridge.h"
+
+
+char* iotjs_bridge_sample_getSystemInfo(const char* message) {
+  return "{'OS':'tizen'}";
+}
+
+/*
+ * return value
+ *  0: success
+ * <0: error (return_message will be used as an error message)
+ */
+int iotjs_bridge_sample_func(const char* command, const char* message,
+                             char** return_message) {
+  char* result = 0;
+  if (strncmp(command, "getSystemInfo", strlen("getSystemInfo")) == 0) {
+    result = iotjs_bridge_sample_getSystemInfo(message);
+    if (result == 0) {
+      iotjs_bridge_set_return(return_message, "Can't get the resource path");
+      return -1;
+    } else {
+      iotjs_bridge_set_return(return_message, result);
+    }
+  } else if (strncmp(command, "getResPath", strlen("getResPath")) == 0) {
+    iotjs_bridge_set_return(return_message, "res/");
+    return 0;
+  } else {
+    iotjs_bridge_set_return(return_message, "Can't find command");
+    return -1;
+  }
+
+  return 0;
+}
+
+/**
+ * Init method called by IoT.js
+ */
+jerry_value_t InitBridgeSample() {
+  char* module_name = "bridge_sample";
+  jerry_value_t mymodule = jerry_create_object();
+  iotjs_jval_set_property_string_raw(mymodule, "MODULE_NAME", module_name);
+  iotjs_bridge_register(module_name, iotjs_bridge_sample_func);
+  return mymodule;
+}

--- a/samples/bridge_sample/test.js
+++ b/samples/bridge_sample/test.js
@@ -1,0 +1,23 @@
+/* Copyright 2018-present Samsung Electronics Co., Ltd. and other contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+var bridgeSample = require('bridge_sample');
+
+console.log("TestApp: getResPath(): " + bridgeSample.getResPath());
+
+bridgeSample.getSystemInfo(function(err, msg) {
+    console.log("TestApp: getSystemInfo(): err: " + err + "  msg: " + msg);
+});
+

--- a/src/js/bridge.js
+++ b/src/js/bridge.js
@@ -1,0 +1,30 @@
+/* Copyright 2018-present Samsung Electronics Co., Ltd. and other contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+function Bridge(moduleName) {
+    this.moduleName = moduleName;
+}
+
+Bridge.prototype.send = function(command, message, callback) {
+    native.send(this.moduleName, command, message, function(err, results) {
+        callback(err, results);
+    });
+};
+
+Bridge.prototype.sendSync = function(command, message) {
+    return native.send(this.moduleName, command, message);
+};
+
+module.exports = Bridge;

--- a/src/modules.json
+++ b/src/modules.json
@@ -361,6 +361,11 @@
     },
     "util": {
       "js_file": "js/util.js"
+    },
+    "bridge": {
+      "js_file": "js/bridge.js",
+      "native_files": ["modules/iotjs_module_bridge.c"],
+      "init": "InitBridge"
     }
   }
 }

--- a/src/modules/iotjs_module_bridge.c
+++ b/src/modules/iotjs_module_bridge.c
@@ -1,0 +1,248 @@
+/* Copyright 2018-present Samsung Electronics Co., Ltd. and other contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "iotjs_def.h"
+#include "iotjs_module_bridge.h"
+#include "iotjs_reqwrap.h"
+#include <stdio.h>
+
+
+typedef struct {
+  iotjs_reqwrap_t reqwrap;
+  uv_work_t req;
+  iotjs_string_t module;
+  iotjs_string_t command;
+  iotjs_string_t message;
+  iotjs_string_t ret_msg;
+  int err_flag;
+} iotjs_module_msg_reqwrap_t;
+
+typedef struct {
+  char* module_name;
+  iotjs_bridge_func callback;
+} relation_info_t;
+
+static relation_info_t* g_module_list = 0;
+static unsigned int g_module_count = 0;
+
+unsigned int iotjs_bridge_init() {
+  if (g_module_list == 0) {
+    // printf("__FUNCTION___ : %s(%d) module_count: %d \n",
+    //     __FUNCTION__, __LINE__, iotjs_module_count);
+    g_module_list = (relation_info_t*)iotjs_buffer_allocate(
+        sizeof(relation_info_t) * iotjs_module_count);
+    IOTJS_ASSERT(g_module_list);
+  }
+  return iotjs_module_count;
+}
+
+int iotjs_bridge_register(char* module_name, iotjs_bridge_func callback) {
+  int empty_slot = -1;
+  iotjs_bridge_init();
+  for (int i = 0; i < (int)iotjs_module_count; i++) {
+    if (g_module_list[i].module_name == 0) {
+      if (empty_slot == -1)
+        empty_slot = i;
+    } else {
+      if (strncmp(g_module_list[i].module_name, module_name,
+                  strlen(module_name)) == 0) {
+        return i;
+      }
+    }
+  }
+  if (empty_slot != -1) {
+    g_module_list[empty_slot].module_name =
+        iotjs_buffer_allocate(strlen(module_name) + 1);
+    IOTJS_ASSERT(g_module_list[empty_slot].module_name);
+    strncpy(g_module_list[empty_slot].module_name, module_name,
+            strlen(module_name));
+    g_module_list[empty_slot].callback = callback;
+    g_module_count++;
+  }
+  return empty_slot;
+}
+
+int iotjs_bridge_call(const char* module_name, const char* command,
+                      const char* message, char** return_message) {
+  int ret = -1;
+  for (int i = 0; i < (int)iotjs_module_count; i++) {
+    if (g_module_list[i].module_name != 0) {
+      if (strncmp(g_module_list[i].module_name, module_name,
+                  strlen(module_name) + 1) == 0) {
+        ret = g_module_list[i].callback(command, message, return_message);
+        break;
+      }
+    }
+  }
+  return ret;
+}
+
+int iotjs_bridge_set_return(char** return_message, char* result) {
+  if (result == NULL) {
+    *return_message = NULL;
+  } else {
+    *return_message =
+        iotjs_buffer_allocate(sizeof(char) * (strlen(result) + 1));
+    IOTJS_ASSERT(*return_message);
+    strncpy(*return_message, result, strlen(result) + 1);
+  }
+  return 0;
+}
+
+static iotjs_module_msg_reqwrap_t* iotjs_module_msg_reqwrap_create(
+    const jerry_value_t jcallback, iotjs_string_t module,
+    iotjs_string_t command, iotjs_string_t message) {
+  iotjs_module_msg_reqwrap_t* module_msg_reqwrap =
+      IOTJS_ALLOC(iotjs_module_msg_reqwrap_t);
+
+  iotjs_reqwrap_initialize(&module_msg_reqwrap->reqwrap, jcallback,
+                           (uv_req_t*)&module_msg_reqwrap->req);
+
+  module_msg_reqwrap->module = module;
+  module_msg_reqwrap->command = command;
+  module_msg_reqwrap->message = message;
+  module_msg_reqwrap->ret_msg = iotjs_string_create();
+  module_msg_reqwrap->err_flag = 0;
+  return module_msg_reqwrap;
+}
+
+static void after_worker(uv_work_t* work_req, int status) {
+  iotjs_module_msg_reqwrap_t* req_wrap =
+      (iotjs_module_msg_reqwrap_t*)iotjs_reqwrap_from_request(
+          (uv_req_t*)work_req);
+  iotjs_jargs_t jargs = iotjs_jargs_create(2);
+
+  if (status) {
+    iotjs_jargs_append_error(&jargs, "System error");
+  } else {
+    // internal error
+    if (req_wrap->err_flag) {
+      iotjs_jargs_append_error(&jargs, iotjs_string_data(&req_wrap->ret_msg));
+      iotjs_jargs_append_null(&jargs);
+    } else {
+      iotjs_jargs_append_null(&jargs);
+      iotjs_jargs_append_string_raw(&jargs,
+                                    iotjs_string_data(&req_wrap->ret_msg));
+    }
+  }
+
+  jerry_value_t jcallback = iotjs_reqwrap_jcallback(&req_wrap->reqwrap);
+  if (jerry_value_is_function(jcallback)) {
+    iotjs_make_callback(jcallback, jerry_create_undefined(), &jargs);
+  }
+
+  iotjs_string_destroy(&req_wrap->ret_msg);
+  iotjs_jargs_destroy(&jargs);
+  iotjs_reqwrap_destroy(&req_wrap->reqwrap);
+  IOTJS_RELEASE(req_wrap);
+}
+
+static void module_msg_worker(uv_work_t* work_req) {
+  iotjs_module_msg_reqwrap_t* req_wrap =
+      (iotjs_module_msg_reqwrap_t*)iotjs_reqwrap_from_request(
+          (uv_req_t*)work_req);
+
+  char* return_message = NULL;
+  int return_value = -1;
+
+  return_value =
+      iotjs_bridge_call(iotjs_string_data(&req_wrap->module),
+                        iotjs_string_data(&req_wrap->command),
+                        iotjs_string_data(&req_wrap->message), &return_message);
+
+  if (return_value < 0) { // error..
+    req_wrap->err_flag = 1;
+  }
+
+  if (return_message != NULL) {
+    int message_size = strlen(return_message);
+    if (message_size > MAX_RETURN_MESSAGE) {
+      req_wrap->err_flag = 1;
+      req_wrap->ret_msg =
+          iotjs_string_create_with_size("invalid return_message",
+                                        strlen("invalid return_message") + 1);
+    } else {
+      req_wrap->ret_msg =
+          iotjs_string_create_with_buffer(return_message,
+                                          strlen(return_message));
+    }
+  }
+
+  iotjs_string_destroy(&req_wrap->module);
+  iotjs_string_destroy(&req_wrap->command);
+  iotjs_string_destroy(&req_wrap->message);
+}
+
+/**
+ * send async message
+ */
+JS_FUNCTION(MessageAsync) {
+  DJS_CHECK_THIS();
+  DJS_CHECK_ARGS(3, string, string, string);
+  DJS_CHECK_ARG_IF_EXIST(3, function);
+
+  iotjs_string_t module_name = JS_GET_ARG(0, string);
+  iotjs_string_t module_command = JS_GET_ARG(1, string);
+  iotjs_string_t command_message = JS_GET_ARG(2, string);
+  jerry_value_t jcallback = JS_GET_ARG_IF_EXIST(3, function);
+
+  if (!jerry_value_is_null(jcallback)) { // async call
+    uv_loop_t* loop = iotjs_environment_loop(iotjs_environment_get());
+    iotjs_module_msg_reqwrap_t* req_wrap =
+        iotjs_module_msg_reqwrap_create(jcallback, module_name, module_command,
+                                        command_message);
+    uv_queue_work(loop, &req_wrap->req, module_msg_worker, after_worker);
+  } else { // sync call
+    jerry_value_t jmsg;
+    int return_value;
+    char* return_message = NULL;
+
+    return_value =
+        iotjs_bridge_call(iotjs_string_data(&module_name),
+                          iotjs_string_data(&module_command),
+                          iotjs_string_data(&command_message), &return_message);
+
+    if (return_value < 0) { // error..
+      if (return_message != NULL) {
+        jmsg = JS_CREATE_ERROR(COMMON, return_message);
+        iotjs_buffer_release(return_message);
+      } else {
+        jmsg = JS_CREATE_ERROR(COMMON, (jerry_char_t*)"Unknown native error..");
+      }
+    } else {
+      if (return_message != NULL) {
+        jmsg = jerry_create_string((jerry_char_t*)return_message);
+        iotjs_buffer_release(return_message);
+      } else {
+        jmsg = jerry_create_string((jerry_char_t*)"");
+      }
+    }
+    iotjs_string_destroy(&module_name);
+    iotjs_string_destroy(&module_command);
+    iotjs_string_destroy(&command_message);
+    return jmsg;
+  }
+
+  return jerry_create_string((jerry_char_t*)"");
+}
+
+/**
+ * Init method called by IoT.js
+ */
+jerry_value_t InitBridge() {
+  jerry_value_t messagModule = jerry_create_object();
+  iotjs_jval_set_method(messagModule, "send", MessageAsync);
+  iotjs_bridge_init();
+  return messagModule;
+}

--- a/src/modules/iotjs_module_bridge.h
+++ b/src/modules/iotjs_module_bridge.h
@@ -1,0 +1,31 @@
+/* Copyright 2018-present Samsung Electronics Co., Ltd. and other contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef IOTJS_BRIDGE_H
+#define IOTJS_BRIDGE_H
+
+#define MAX_RETURN_MESSAGE 512 * 2
+
+/*
+ * return value
+ *  0: success
+ * <0: error (return_message will be used as an error message)
+ */
+typedef int (*iotjs_bridge_func)(const char* command, const char* message,
+                                 char** return_message);
+
+int iotjs_bridge_register(char* module_name, iotjs_bridge_func callback);
+int iotjs_bridge_set_return(char** return_message, char* result);
+#endif


### PR DESCRIPTION
I would like to add a new module to help developer who want to create a simple module(e.g. just providing some system path). Bridge module supports synchronous and asynchronous methods for sending messages from a module, and helping to communicate between the C part and the Javascript part of a module.

1. compile..
./tools/build.py --external-modules=./samples/bridge_sample --cmake-param=-DENABLE_MODULE_BRIDGE_SAMPLE=ON

2. testing..
./build/x86_64-linux/debug/bin/iotjs samples/bridge_sample/test.js

IoT.js-DCO-1.0-Signed-off-by: Haesik, Jun haesik.jun@samsung.com