### PR TITLE
Rework the connect function in the tls module

### DIFF
--- a/docs/api/IoT.js-API-TLS.md
+++ b/docs/api/IoT.js-API-TLS.md
@@ -57,6 +57,25 @@ var socket = tls.connect(opts, function() {
 });
 ```
 
+### tls.connect(port[,host][,options][,callback])
+- `port` {number} Port the client should connect to.
+- `host` {string} Host the client should connect to, defaults to 'localhost'.
+- `options` {Object} See `tls.connect()`.
+- `callback` {Function} See `tls.connect()`.
+
+Same as tls.connect() except that port and host can be provided as arguments instead of options.
+A port or host option, if specified, will take precedence over any port or host argument.
+
+**Example**
+```js
+var tls = require('tls');
+
+var socket = tls.connect(443, 'localhost', function() {
+    socket.write('Hello IoT.js');
+    socket.end();
+});
+```
+
 ### tlsSocket.address()
 Returns an object containing the bound address, family name, and port of the socket.`{port: 443, family: 'IPv4', address: '127.0.0.1'}`
 

--- a/src/js/tls.js
+++ b/src/js/tls.js
@@ -205,21 +205,56 @@ function createServer(options, secureConnectionListener) {
   return new Server(options, secureConnectionListener);
 }
 
-function connect(options, callback) {
-  options = Object.create(options, {
-    isServer: { value: false, enumerable: true },
-  });
-
-  if (!options.host) {
-    options.host = 'localhost';
+function connect(arg0, arg1, arg2, callback) {
+  var options;
+  var tlsSocket;
+  if (typeof arg0 == 'object') {
+    options = Object.create(arg0, {
+      isServer: { value: false, enumerable: true },
+    });
+    options.host = options.host || 'localhost';
+    options.port = options.port || 443;
+    options.rejectUnauthorized = options.rejectUnauthorized || false;
+    callback = arg1;
+  } else if (typeof arg0 == 'number') {
+    if (typeof arg1 == 'string') {
+      if (typeof arg2 == 'object') {
+        options = Object.create(arg2, {
+          isServer: { value: false, enumerable: true },
+        });
+        options.port = arg0;
+        options.host = arg1;
+        options.rejectUnauthorized = options.rejectUnauthorized || false;
+      } else {
+        options = {
+          isServer: false,
+          rejectUnauthorized: false,
+          port: arg0,
+          host: arg1,
+        };
+        callback = arg2;
+      }
+    } else if (typeof arg1 == 'object') {
+      options = Object.create(arg1, {
+        isServer: { value: false, enumerable: true },
+      });
+      options.port = arg0;
+      options.host = options.host || 'localhost';
+      options.rejectUnauthorized = options.rejectUnauthorized || false;
+      callback = arg2;
+    } else {
+      options = {
+        isServer: false,
+        rejectUnauthorized: false,
+        host: 'localhost',
+        port: arg0,
+      };
+      callback = arg1;
+    }
   }
-  if (!options.port) {
-    options.port = 443;
-  }
-
-  var tlsSocket = new TLSSocket(new net.Socket(), options);
-
+  tlsSocket = new TLSSocket(new net.Socket(), options);
   tlsSocket.connect(options, callback);
+
   return tlsSocket;
 }
 

--- a/test/run_pass/test_tls.js
+++ b/test/run_pass/test_tls.js
@@ -114,6 +114,106 @@ socket3.on('error', function(error) {
   socket_handshake_error_caught = error instanceof Error;
 });
 
+var server3 = tls.createServer(options, function(socket) {
+   socket.write('Server hello');
+
+   socket.on('data', function(data) {
+     client_message = data.toString();
+   });
+
+}).listen(9090, function() { });
+
+server3.on('secureConnection', function() {
+ server_handshake_done = true;
+});
+
+server3.on('close', function() {
+ server_closed = true;
+});
+
+var opt = {
+   rejectUnauthorized: false,
+}
+
+var socket4 = tls.connect(9090);
+
+socket4.on('secureConnect', function(){
+  handshake_done = true;
+});
+
+socket4.on('data', function(data) {
+  server_message = data.toString();
+  socket4.write('Client hello');
+  socket4.end();
+});
+
+var socket5 = tls.connect(9090, 'localhost');
+
+socket5.on('secureConnect', function(){
+  handshake_done = true;
+});
+
+socket5.on('data', function(data) {
+  server_message = data.toString();
+  socket5.write('Client hello');
+  socket5.end();
+});
+
+var socket6 = tls.connect(9090, 'localhost', opt);
+
+socket6.on('secureConnect', function(){
+  handshake_done = true;
+});
+
+socket6.on('data', function(data) {
+  server_message = data.toString();
+  socket6.write('Client hello');
+  socket6.end();
+});
+
+var socket7 = tls.connect(9090, 'localhost', opt, function() {
+});
+
+socket7.on('secureConnect', function(){
+  handshake_done = true;
+});
+
+socket7.on('data', function(data) {
+  server_message = data.toString();
+  socket7.write('Client hello');
+  socket7.end();
+});
+
+var socket8 = tls.connect(9090, 'localhost', function() {
+});
+
+socket8.on('secureConnect', function(){
+ handshake_done = true;
+});
+
+socket8.on('data', function(data) {
+ server_message = data.toString();
+ socket8.write('Client hello');
+ socket8.end();
+});
+
+var socket9 = tls.connect(9090, function() {
+});
+
+socket9.on('secureConnect', function(){
+ handshake_done = true;
+});
+
+socket9.on('end', function() {
+ server3.close();
+});
+
+socket9.on('data', function(data) {
+ server_message = data.toString();
+ socket9.write('Client hello');
+ socket9.end();
+});
+
 process.on('exit', function() {
   assert.equal(error_caught, true);
   assert.equal(handshake_done, true);


### PR DESCRIPTION
We can pass the port and host as argument to the connect function.

IoT.js-DCO-1.0-Signed-off-by: Istvan Miklos imiklos2@inf.u-szeged.hu