### PR TITLE
Add checking uvloop

### DIFF
--- a/src/iotjs.c
+++ b/src/iotjs.c
@@ -102,6 +102,10 @@ bool iotjs_initialize(iotjs_environment_t* env) {
   }
 
   // Set event loop.
+  if (!uv_default_loop()) {
+    DLOG("iotjs uvloop init failed");
+    return false;
+  }
   iotjs_environment_set_loop(env, uv_default_loop());
 
   // Bind environment to global object.


### PR DESCRIPTION
uv_default_loop() can return NULL, but we didn't check the return value

IoT.js-DCO-1.0-Signed-off-by: Haesik Jun haesik.jun@samsung.com