### PR TITLE
Fix main sequence to avoid errors

### DIFF
--- a/src/iotjs_debuglog.c
+++ b/src/iotjs_debuglog.c
@@ -26,7 +26,7 @@ void iotjs_set_console_out(iotjs_console_out_t output) {
 
 #ifdef ENABLE_DEBUG_LOG
 int iotjs_debug_level = DBGLEV_ERR;
-FILE* iotjs_log_stream;
+FILE* iotjs_log_stream = NULL;
 const char* iotjs_debug_prefix[4] = { "", "ERR", "WRN", "INF" };
 #endif // ENABLE_DEBUG_LOG
 
@@ -61,7 +61,8 @@ void iotjs_debuglog_init() {
 
 void iotjs_debuglog_release() {
 #ifdef ENABLE_DEBUG_LOG
-  if (iotjs_log_stream != stderr && iotjs_log_stream != stdout) {
+  if (iotjs_log_stream && iotjs_log_stream != stderr &&
+      iotjs_log_stream != stdout) {
     fclose(iotjs_log_stream);
   }
   // some embed systems(ex, nuttx) may need this


### PR DESCRIPTION
This commit includes the below fixes:
- Not clean up jerry when iotjs_initialize fails
- Segment faults due to debuglog initialization
- Naming mismatching to iotjs_start
- Missing the state change

IoT.js-DCO-1.0-Signed-off-by: Daeyeon Jeong daeyeon.jeong@samsung.com