### PR TITLE
Fix iotjs-string allocation

### DIFF
--- a/src/iotjs_string.c
+++ b/src/iotjs_string.c
@@ -21,6 +21,7 @@
 #include <string.h>
 
 
+
 iotjs_string_t iotjs_string_create() {
   iotjs_string_t str;
 
@@ -38,7 +39,7 @@ iotjs_string_t iotjs_string_create_with_size(const char* data, size_t size) {
 
   if (size > 0) {
     IOTJS_ASSERT(data != NULL);
-    str.data = iotjs_buffer_allocate(size);
+    str.data = iotjs_buffer_allocate(size + 1);
     memcpy(str.data, data, size);
   } else {
     str.data = NULL;
@@ -46,7 +47,6 @@ iotjs_string_t iotjs_string_create_with_size(const char* data, size_t size) {
 
   return str;
 }
-
 
 iotjs_string_t iotjs_string_create_with_buffer(char* buffer, size_t size) {
   iotjs_string_t str;
@@ -82,10 +82,10 @@ void iotjs_string_append(iotjs_string_t* str, const char* data, size_t size) {
   }
 
   if (str->data != NULL) {
-    str->data = iotjs_buffer_reallocate(str->data, str->size + size);
+    str->data = iotjs_buffer_reallocate(str->data, str->size + size + 1) ;
   } else {
     IOTJS_ASSERT(str->size == 0);
-    str->data = iotjs_buffer_allocate(size);
+    str->data = iotjs_buffer_allocate(size + 1);
   }
 
   memcpy(str->data + str->size, data, size);

--- a/src/modules/iotjs_module_bridge.c
+++ b/src/modules/iotjs_module_bridge.c
@@ -116,7 +116,7 @@ void iotjs_bridge_set_err(void* handle, char* err) {
   if (!jerry_value_is_undefined(bridgecall->jcallback)) {
     uv_mutex_lock(&bridgecall->call_lock);
   }
-  bridgecall->ret_msg = iotjs_string_create_with_size(err, strlen(err) + 1);
+  bridgecall->ret_msg = iotjs_string_create_with_size(err, strlen(err));
   bridgecall->status = CALL_STATUS_ERROR;
 
   if (bridgecall->async != NULL) {
@@ -135,7 +135,7 @@ void iotjs_bridge_set_msg(void* handle, char* msg) {
   if (msg == NULL) {
     msg = "";
   } else {
-    size = strlen(msg) + 1;
+    size = strlen(msg);
   }
   if (size > MAX_RETURN_MESSAGE) {
     iotjs_bridge_set_err(handle, "The message exceeds the maximum");


### PR DESCRIPTION
The size inside of iotjs_string not include null character,
So, size + 1 buffer is needed to store a string

IoT.js-DCO-1.0-Signed-off-by: Haesik Jun haesik.jun@samsung.com