### PR TITLE
Add calling js functions based on string parameters

### DIFF
--- a/include/iotjs_module_tizen.h
+++ b/include/iotjs_module_tizen.h
@@ -1,0 +1,47 @@
+/* Copyright 2018-present Samsung Electronics Co., Ltd. and other contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef IOTJS_MODULE_TIZEN_H
+#define IOTJS_MODULE_TIZEN_H
+
+#ifndef IOTJS_EXTERN_C
+#ifdef __cplusplus
+#define IOTJS_EXTERN_C extern "C"
+#else /* !__cplusplus */
+#define IOTJS_EXTERN_C extern
+#endif /* !__cplusplus */
+#endif /* !IOTJS_EXTERN_C */
+
+#include <app_control.h>
+#include <string.h>
+
+typedef void (*user_callback_t)(int error, const char* data);
+
+IOTJS_EXTERN_C
+void iotjs_tizen_app_control_cb(app_control_h app_control, void* user_data);
+
+IOTJS_EXTERN_C
+int iotjs_tizen_bridge_native(const char* fn_name, unsigned fn_name_size,
+                              const char* message, unsigned message_size,
+                              user_callback_t cb);
+
+#define IOTJS_TIZEN_CALL_JFUNC(name, msg, cb)                              \
+  ({                                                                       \
+    if (name != NULL && (msg) != NULL)                                     \
+      iotjs_tizen_bridge_native(name, strlen(name), msg, strlen(msg), cb); \
+  })
+
+
+#endif /* IOTJS_MODULE_TIZEN_H */

--- a/samples/tizen-bridge-native/tizen_bridge_native.c
+++ b/samples/tizen-bridge-native/tizen_bridge_native.c
@@ -1,0 +1,52 @@
+/* Copyright 2018-present Samsung Electronics Co., Ltd. and other contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "iotjs.h"
+#include "iotjs_module_tizen.h"
+
+/* thread */
+#include <pthread.h>
+#include <unistd.h>
+/* printf */
+#include <stdio.h>
+
+
+static void user_cb(int err, const char* data) {
+  printf("err: %d, data: %s\n", err, data);
+}
+
+
+void* thread(void* data) {
+  sleep(1);
+
+  char* str = "1234567A1234567B1234567C";
+  IOTJS_TIZEN_CALL_JFUNC("hello", "world", user_cb);
+  IOTJS_TIZEN_CALL_JFUNC("hello", str, user_cb);
+  IOTJS_TIZEN_CALL_JFUNC("hello", "", user_cb);
+  IOTJS_TIZEN_CALL_JFUNC("", "", user_cb);
+  IOTJS_TIZEN_CALL_JFUNC("", "", NULL);
+  IOTJS_TIZEN_CALL_JFUNC("notReturnString", "", user_cb);
+  return 0;
+}
+
+
+int main(int argc, char** argv) {
+  pthread_t tid;
+  if (pthread_create(&(tid), NULL, &thread, NULL)) {
+    return 1;
+  }
+
+  return iotjs_entry(argc, argv);
+}

--- a/samples/tizen-bridge-native/tizen_bridge_native.js
+++ b/samples/tizen-bridge-native/tizen_bridge_native.js
@@ -1,0 +1,27 @@
+/* Copyright 2018-present Samsung Electronics Co., Ltd. and other contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+var tizen = require('tizen');
+
+tizen.hello = function(data) {
+  return 'tizen.hello is called with data, ' + (data ? data : 'null');
+}
+
+tizen.notReturnString = function(data) {
+}
+
+setInterval(function() {
+  console.log('heartbeat');
+}, 10000);

--- a/src/iotjs_util.h
+++ b/src/iotjs_util.h
@@ -32,6 +32,9 @@ void iotjs_buffer_release(char* buff);
 #define IOTJS_ALLOC(type) /* Allocate (type)-sized, (type*)-typed memory */ \
   (type*)iotjs_buffer_allocate(sizeof(type))
 
+#define IOTJS_CALLOC(num, type) \
+  (type*)iotjs_buffer_allocate((num * sizeof(type)))
+
 #define IOTJS_RELEASE(ptr) /* Release memory allocated by IOTJS_ALLOC() */ \
   ({                                                                       \
     iotjs_buffer_release((char*)ptr);                                      \

--- a/src/js/tizen.js
+++ b/src/js/tizen.js
@@ -134,7 +134,7 @@ function launchAppControl(option) {
 
 
 var getResPath = function() {
-  return this.bridge.sendSync('getResPath', '');
+  return bridge.sendSync('getResPath', '');
 };
 
 


### PR DESCRIPTION
As written in iotjs_tizen_service_app.c, iot.js app for tizen is a
hybrid one, which combines features of both native and js app.
This commit provides a way to call js function bound with tizen
module in the app model.

This also includes a patch for the bug in getResPath.

IoT.js-DCO-1.0-Signed-off-by: Daeyeon Jeong daeyeon.jeong@samsung.com