### PR TITLE
Disable PIE when iotjs build type set to debug

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 cmake_minimum_required(VERSION 2.8)
+include(CheckCCompilerFlag)
 
 project(IOTJS C)
 
@@ -67,9 +68,14 @@ macro(iotjs_add_link_flags)
   iotjs_add_flags(IOTJS_LINKER_FLAGS ${ARGV})
 endmacro()
 
+CHECK_C_COMPILER_FLAG(-no-pie HAS_NO_PIE)
+
 # Add buildtype-related flags
 if("${CMAKE_BUILD_TYPE}" STREQUAL "Debug")
   iotjs_add_compile_flags(-DDEBUG -DENABLE_DEBUG_LOG)
+  if(HAS_NO_PIE)
+    iotjs_add_link_flags(-no-pie)
+  endif()
 endif()
 
 if(EXPERIMENTAL)


### PR DESCRIPTION
In certain operating systems the gcc is configured to build `-pie` binaries by default.
In this case we do not have backtrace information because the addr2line cannot resolve the memory addresses.
Fixes #1566

IoT.js-DCO-1.0-Signed-off-by: Istvan Miklos imiklos2@inf.u-szeged.hu