### PR TITLE
Always enable debug log on Tizen

### DIFF
--- a/config/tizen/packaging/iotjs.spec
+++ b/config/tizen/packaging/iotjs.spec
@@ -85,6 +85,7 @@ V=1 VERBOSE=1 ./tools/build.py \
   --external-include-dir=/usr/include/glib-2.0/ \
   --external-include-dir=/usr/lib/glib-2.0/include/ \
   --compile-flag=-D__TIZEN__ \
+  --compile-flag=-DENABLE_DEBUG_LOG \
   --create-shared-lib \
   --no-init-submodule \
   --no-parallel-build \


### PR DESCRIPTION
Because of the Tizen policy, the log is also displayed in release mode.

IoT.js-DCO-1.0-Signed-off-by: Hosung Kim hs852.kim@samsung.com