### PR TITLE
Add sonarqube badge

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,6 +33,9 @@ env:
     - OPTS="misc" RUN_DOCKER=yes
 
 matrix:
+  allow_failures:
+    - env: OPTS="sonarqube"
+    - env: OPTS="coverity"
   include:
     - os: osx
       env: OPTS="host-darwin"

--- a/README.md
+++ b/README.md
@@ -1,7 +1,8 @@
 # IoT.js: Platform for Internet of Things with JavaScript
 [![License](https://img.shields.io/badge/licence-Apache%202.0-brightgreen.svg?style=flat)](LICENSE)
 [![Build Status](https://travis-ci.org/Samsung/iotjs.svg?branch=master)](https://travis-ci.org/Samsung/iotjs)
-[![Coverity Scan Build Status](https://img.shields.io/coverity/scan/12140.svg)](https://scan.coverity.com/projects/samsung-iotjs)
+[![Coverity Scan Build Status](https://scan.coverity.com/projects/12140/badge.svg)](https://scan.coverity.com/projects/samsung-iotjs)
+[![SonarCloud Status](https://sonarcloud.io/api/project_badges/measure?project=samsung.iot.js&metric=alert_status)](https://sonarcloud.io/dashboard?id=samsung.iot.js)
 [![FOSSA Status](https://app.fossa.io/api/projects/git%2Bhttps%3A%2F%2Fgithub.com%2FSamsung%2Fiotjs.svg?type=shield)](https://app.fossa.io/projects/git%2Bhttps%3A%2F%2Fgithub.com%2FSamsung%2Fiotjs?ref=badge_shield)
 [![IRC Channel](https://img.shields.io/badge/chat-on%20freenode-brightgreen.svg)](https://kiwiirc.com/client/irc.freenode.net/#iotjs)
 


### PR DESCRIPTION
This patch also includes the followings:
- Setting static analysis tasks as allow_failures items
- Changing the url for coverity badge

IoT.js-DCO-1.0-Signed-off-by: Daeyeon Jeong daeyeon.jeong@samsung.com