### PR TITLE
Updated the '--jerry-profile' and '--js-backtrace' build options.

### DIFF
--- a/docs/build/Build-Script.md
+++ b/docs/build/Build-Script.md
@@ -297,12 +297,22 @@ Enable memstat of JerryScript engine.
 
 ---
 #### `--jerry-profile`
-* `es5.1` | `es2015-subset`
+* `es5.1` | `es2015-subset | absolute path to a custom profile file`
 
-Specify the profile for JerryScript (default: es5.1).
+Specify the profile for JerryScript (default: es5.1). In JerryScript all of the features are enabled by default, so an empty profile file turns on all of the available ECMA features. See also the related [README.md](https://github.com/jerryscript-project/jerryscript/blob/master/jerry-core/profiles/README.md).
+
+E.g.:
+**/home/iotjs/my-jerry-profile.profile**
+```
+# Turn off every ES2015 feature EXCEPT the arrow functions
+CONFIG_DISABLE_ES2015_BUILTIN
+CONFIG_DISABLE_ES2015_PROMISE_BUILTIN
+CONFIG_DISABLE_ES2015_TEMPLATE_STRINGS
+CONFIG_DISABLE_ES2015_TYPEDARRAY_BUILTIN
+```
 
 ```
-./tools/build.py --jerry-profile=es2015-subset
+./tools/build.py --jerry-profile=/home/iotjs/my-jerry-profile.profile
 ```
 
 ---

--- a/tools/build.py
+++ b/tools/build.py
@@ -184,13 +184,14 @@ def init_options():
         action='store_true', default=False,
         help='Enable JerryScript heap statistics')
     jerry_group.add_argument('--jerry-profile',
-        choices=['es5.1', 'es2015-subset'], default='es5.1',
-        help='Specify the profile for JerryScript (default: %(default)s).')
+        metavar='FILE', action='store', default='es5.1',
+        help='Specify the profile for JerryScript (default: %(default)s). '
+             'Possible values are "es5.1", "es2015-subset" or an absolute '
+             'path to a custom JerryScript profile file.')
     jerry_group.add_argument('--js-backtrace',
         choices=['ON', 'OFF'], type=str.upper,
         help='Enable/disable backtrace information of JavaScript code '
              '(default: ON in debug and OFF in release build)')
-
 
     options = parser.parse_args(argv)
     options.config = build_config
@@ -235,9 +236,12 @@ def adjust_options(options):
     cmake_path = fs.join(path.PROJECT_ROOT, 'cmake', 'config', '%s.cmake')
     options.cmake_toolchain_file = cmake_path % options.target_tuple
 
-    # Specify the file of JerryScript profile.
-    options.jerry_profile = fs.join(path.JERRY_PROFILE_ROOT,
-                                    options.jerry_profile + '.profile')
+    # Set the default value of '--js-backtrace' if it is not defined.
+    if not options.js_backtrace:
+        if options.buildtype == 'debug':
+            options.js_backtrace = "ON"
+        else:
+            options.js_backtrace = "OFF"
 
 
 def print_progress(msg):
@@ -343,11 +347,6 @@ def build_iotjs(options):
         cmake_opt.append("-DFEATURE_DEBUGGER=ON")
 
     # --js-backtrace
-    if not options.js_backtrace:
-        if options.buildtype == 'debug':
-            options.js_backtrace = "ON"
-        else:
-            options.js_backtrace = "OFF"
     cmake_opt.append("-DFEATURE_JS_BACKTRACE=%s" %
                      options.js_backtrace)
 


### PR DESCRIPTION
Updated the '--jerry-profile' build option to accept custom
JerryScript profiles with an absolute path. Added more description
of the build option to the related documentation. Moved the default
value setting of '--js-backtrace' to the 'adjust_option' function
in the 'build.py'.

IoT.js-DCO-1.0-Signed-off-by: László Langó llango.u-szeged@partner.samsung.com