### PR TITLE
Change iotjs_jval_as_string to use utf8 buffers

### DIFF
--- a/src/iotjs_binding.c
+++ b/src/iotjs_binding.c
@@ -126,7 +126,7 @@ bool iotjs_jbuffer_as_string(jerry_value_t jval, iotjs_string_t* out_string) {
 iotjs_string_t iotjs_jval_as_string(jerry_value_t jval) {
   IOTJS_ASSERT(jerry_value_is_string(jval));
 
-  jerry_size_t size = jerry_get_string_size(jval);
+  jerry_size_t size = jerry_get_utf8_string_size(jval);
 
   if (size == 0)
     return iotjs_string_create();
@@ -134,7 +134,7 @@ iotjs_string_t iotjs_jval_as_string(jerry_value_t jval) {
   char* buffer = iotjs_buffer_allocate(size + 1);
   jerry_char_t* jerry_buffer = (jerry_char_t*)(buffer);
 
-  size_t check = jerry_string_to_char_buffer(jval, jerry_buffer, size);
+  size_t check = jerry_string_to_utf8_char_buffer(jval, jerry_buffer, size);
 
   IOTJS_ASSERT(check == size);
   buffer[size] = '\0';


### PR DESCRIPTION
Fixes #1562
With this patch strings coming from JS side are handled as UTF8 strings.

IoT.js-DCO-1.0-Signed-off-by: Daniel Balla dballa@inf.u-szeged.hu