### PR TITLE
Add error handling of TLS

### DIFF
--- a/src/modules/iotjs_module_tls.c
+++ b/src/modules/iotjs_module_tls.c
@@ -539,6 +539,9 @@ JS_FUNCTION(Read) {
     iotjs_bufferwrap_t *buf = iotjs_bufferwrap_from_jbuffer(jbuffer);
     data = buf->buffer;
     length = iotjs_bufferwrap_length(buf);
+  } else {
+    iotjs_tls_notify_error(tls_data);
+    return jerry_create_boolean(false);
   }
 
   do {


### PR DESCRIPTION
'data' will be passed to the iotjs_bio_write even if it is NULL

IoT.js-DCO-1.0-Signed-off-by: Haesik Jun haesik.jun@samsung.com