### PR TITLE
Skip the test_mqtt.js test file

### DIFF
--- a/test/testsets.json
+++ b/test/testsets.json
@@ -52,7 +52,7 @@
     { "name": "test_module_json.js" },
     { "name": "test_module_require.js", "skip": ["nuttx"], "reason": "not implemented for nuttx" },
     { "name": "test_module_dynamicload.js", "skip": ["darwin", "nuttx", "tizenrt"], "reason": "embedded and macos does not support dynamic loading" },
-    { "name": "test_mqtt.js" },
+    { "name": "test_mqtt.js", "skip": ["all"], "reason": "MQTT module is not enabled by default" },
     { "name": "test_net_1.js" },
     { "name": "test_net_2.js" },
     { "name": "test_net_3.js", "skip": ["nuttx"], "reason": "[nuttx]: requires too many socket descriptors and too large buffers" },


### PR DESCRIPTION
I would like to skip the mqtt test file because this module is not enabled by default.

Note: js-remote-test does not have logic to check which modules are compiled, and which modules are used by the tests. After https://github.com/Samsung/iotjs/issues/1595 finished, the module checking logic can be supported easily in js-remote-test.