### PR TITLE
Build module_entry.c test-resource into different target folders.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@
 /src/iotjs_string_ext.inl.h
 /src/iotjs_module_inl.h
 /test/tmp/*
+/test/dynamicmodule/build/*
 eslint.log
 
 # IDE related files

--- a/test/dynamicmodule/CMakeLists.txt
+++ b/test/dynamicmodule/CMakeLists.txt
@@ -26,14 +26,17 @@ if(("${TARGET_OS}" STREQUAL "LINUX") OR ("${TARGET_OS}" STREQUAL "TIZEN"))
     message(FATAL_ERROR "No 'IOTJS_INCLUDE_DIR' or 'JERRY_INCLUDE_DIR'")
   endif()
 
+  string(TOLOWER ${TARGET_OS} TARGET_OS_NAME)
+
   set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -std=c99")
+  set(OUTPUT_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/build/${TARGET_OS_NAME}")
 
   add_library(${NAME} SHARED
               src/module_entry.c)
   target_include_directories(${NAME}
                              PRIVATE ${IOTJS_INCLUDE_DIR} ${JERRY_INCLUDE_DIR})
   set_target_properties(${NAME} PROPERTIES
-                        LIBRARY_OUTPUT_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+                        LIBRARY_OUTPUT_DIRECTORY ${OUTPUT_DIRECTORY}
                         PREFIX ""
                         SUFFIX ".iotjs")
 endif()

--- a/test/run_pass/test_module_dynamicload.js
+++ b/test/run_pass/test_module_dynamicload.js
@@ -16,8 +16,8 @@
 var assert = require('assert');
 var fs = require('fs');
 
-var dynamicmodule_dir = "dynamicmodule/"
-var dynamicmodule_name = "dynamicmodule"
+var dynamicmodule_dir = "dynamicmodule/build/" + process.platform + "/";
+var dynamicmodule_name = "dynamicmodule";
 var dynamicmodule_path = dynamicmodule_dir + dynamicmodule_name + ".iotjs";
 
 assert.assert(fs.existsSync(dynamicmodule_path),

--- a/tools/build.py
+++ b/tools/build.py
@@ -410,7 +410,12 @@ if __name__ == '__main__':
     adjust_options(options)
 
     if options.clean:
-        print_progress('Clear build directory')
+        print_progress('Clear build directories')
+        test_build_root = fs.join(path.TEST_ROOT,
+                                  'dynamicmodule',
+                                  'build',
+                                  options.target_os)
+        fs.rmtree(test_build_root)
         fs.rmtree(options.build_root)
 
     # Perform init-submodule.


### PR DESCRIPTION
This patch adds some missing functionalities for the `dynamicmodule.iotjs` test-resource file:

  * Support `--clean` build option to remove and re-compile that shared library.
  * Add the created shared library to the `.gitignore` file.
  * Create the `dynamicmodule.iotjs` into different target folders (e.g. `test/dynamicmodule/build/linux` `test/dynamicmodule/build/tizen` `test/dynamicmodule/build/nuttx` ...) because there could be different toolchains for the targets.