### PR TITLE
Correctly display test outputs in the testrunner when using Python3

### DIFF
--- a/tools/testrunner.py
+++ b/tools/testrunner.py
@@ -208,8 +208,8 @@ class TestRunner(object):
                 continue
 
             # Show the output.
-            if not self.quiet:
-                print(output, end="")
+            if not self.quiet and output:
+                print(output.decode("utf8"), end="")
 
             is_normal_run = (not expected_failure and exitcode == 0)
             is_expected_fail = (expected_failure and exitcode <= 2)


### PR DESCRIPTION
The data returned by the subprocess calls in the testrunner
is a byte-sequence on Python3. Byte-sequences have a
b'..' format when directly printed out. This change
will convert all output to utf-8 so there will be no
extra characters displayed.