### PR TITLE
Use do-while in IOTJS_RELEASE

### DIFF
--- a/src/iotjs_util.h
+++ b/src/iotjs_util.h
@@ -36,10 +36,10 @@ void iotjs_buffer_release(char* buff);
   (type*)iotjs_buffer_allocate((num * sizeof(type)))
 
 #define IOTJS_RELEASE(ptr) /* Release memory allocated by IOTJS_ALLOC() */ \
-  ({                                                                       \
+  do {                                                                     \
     iotjs_buffer_release((char*)ptr);                                      \
     ptr = NULL;                                                            \
-  })
+  } while (0)
 
 
 #endif /* IOTJS_UTIL_H */


### PR DESCRIPTION
The syntax used in IOTJS_RELEASE was
not compatible with the Windows toolchain.
Using do {..} while(0) construct achieves a better
usage.