### PR TITLE
Use correct file stat macros on Windows

### DIFF
--- a/src/iotjs_compatibility.h
+++ b/src/iotjs_compatibility.h
@@ -1,0 +1,37 @@
+/* Copyright 2018-present Samsung Electronics Co., Ltd. and other contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#ifndef IOTJS_COMPATIBILITY_H
+#define IOTJS_COMPATIBILITY_H
+
+/* Windows compatiblity defines */
+#ifdef WIN32
+#include <fcntl.h>
+/* Map windows _O_* to O_* defines as on Linux systems. */
+#define O_APPEND _O_APPEND
+#define O_CREAT _O_CREAT
+#define O_EXCL _O_EXCL
+#define O_RDONLY _O_RDONLY
+#define O_RDWR _O_RDWR
+#define O_TRUNC _O_TRUNC
+#define O_WRONLY _O_WRONLY
+/* On windows there is no O_SYNC directly, disable it for now. */
+#define O_SYNC 0x0
+#endif
+
+#ifndef S_ISREG
+#define S_ISREG(mode) (((mode) & (S_IFMT)) == S_IFREG)
+#endif
+
+#endif /* IOTJS_COMPATIBILITY_H */

--- a/src/modules/iotjs_module_constants.c
+++ b/src/modules/iotjs_module_constants.c
@@ -15,7 +15,7 @@
 
 #include "iotjs_def.h"
 #include "iotjs_module.h"
-
+#include "iotjs_compatibility.h"
 
 #define SET_CONSTANT(object, constant)                           \
   do {                                                           \

--- a/src/modules/iotjs_module_process.c
+++ b/src/modules/iotjs_module_process.c
@@ -14,6 +14,7 @@
  */
 
 #include "iotjs_def.h"
+#include "iotjs_compatibility.h"
 #include "iotjs_js.h"
 #include "jerryscript-debugger.h"
 


### PR DESCRIPTION
The file stat macros are defined in a different name on Windows.
Adding a few compatibility defines in case of Windows build.