### PR TITLE
iotjs: call srand to set random seed

### DIFF
--- a/src/iotjs.c
+++ b/src/iotjs.c
@@ -28,6 +28,7 @@
 #include "jerryscript.h"
 
 #include <stdio.h>
+#include <stdlib.h>
 #include <string.h>
 
 
@@ -220,6 +221,7 @@ int iotjs_entry(int argc, char** argv) {
 
   // Initialize debug log and environments
   iotjs_debuglog_init();
+  srand((unsigned)jerry_port_get_current_time());
 
   iotjs_environment_t* env = iotjs_environment_get();
   if (!iotjs_environment_parse_command_line_arguments(env, (uint32_t)argc,


### PR DESCRIPTION
This fixes the `Math.random()` outputs the same order result in different process.

```js
for (var i = 0; i < 10; i++)
  console.log(Math.random());
```

Always output:

```
*.000007826369255781174
*.1315377880819142
*.755605321843177
*.4586501317098737
*.5327672371640801
*.21895918622612956
*.04704461619257927
*.6788647165521979
*.6792964055202902
*.9346928955055773
```