### PR TITLE
Change the type of data read from the serial

### DIFF
--- a/docs/api/IoT.js-API-UART.md
+++ b/docs/api/IoT.js-API-UART.md
@@ -133,7 +133,7 @@ Closes the UART device synchronously.
 
 ### Event: 'data'
 * `callback` {Function}
-  * `data` {string} A string from the sender.
+  * `data` {Buffer} A data from the sender.
 
 **Example**
 


### PR DESCRIPTION
The buffer type is correct for reading raw data.

IoT.js-DCO-1.0-Signed-off-by: Hosung Kim hs852.kim@samsung.com