### PR TITLE
Enable getaddrinfo for TizenRT.

### DIFF
--- a/src/js/dns.js
+++ b/src/js/dns.js
@@ -45,7 +45,7 @@ exports.lookup = function lookup(hostname, options, callback) {
   if (family !== 0 && family !== 4 && family !== 6)
     throw new TypeError('invalid argument: family must be 4 or 6');
 
-  if (process.platform != 'nuttx' && process.platform != 'tizenrt') {
+  if (process.platform != 'nuttx') {
     native.getaddrinfo(hostname, family, hints, callback);
   } else {
     // native.getaddrinfo is synchronous on these platforms.

--- a/src/modules/iotjs_module_dns.c
+++ b/src/modules/iotjs_module_dns.c
@@ -50,7 +50,7 @@ jerry_value_t iotjs_getaddrinfo_reqwrap_jcallback(
 }
 
 
-#if !defined(__NUTTX__) && !defined(__TIZENRT__)
+#if !defined(__NUTTX__)
 char* getaddrinfo_error_str(int status) {
   switch (status) {
     case UV__EAI_ADDRFAMILY:
@@ -175,7 +175,7 @@ JS_FUNCTION(GetAddressInfo) {
     return JS_CREATE_ERROR(TYPE, "bad address family");
   }
 
-#if defined(__NUTTX__) || defined(__TIZENRT__)
+#if defined(__NUTTX__)
   iotjs_jargs_t args = iotjs_jargs_create(3);
   char ip[INET6_ADDRSTRLEN] = "";
   const char* hostname_data = iotjs_string_data(&hostname);


### PR DESCRIPTION
Enabled `getaddrinfo` usage in case of TizenRT because that is implemented in the OS. Only the NuttX OS doesn't support that function, that's why only that target needs a different code-path.

Notes:
  * https://github.com/Samsung/libtuv/pull/114 should be landed and `libtuv` should be updated.
  * #1660 requires this patch to resolve the domain names (httpbin.org, api.artik.cloud) that are defined in the HTTPS test files.