### PR TITLE
Do not build mbedtls in case of TizenRT target.

### DIFF
--- a/cmake/mbedtls.cmake
+++ b/cmake/mbedtls.cmake
@@ -14,75 +14,81 @@
 
 cmake_minimum_required(VERSION 2.8)
 
-set(DEPS_MBEDTLS deps/mbedtls)
-set(DEPS_MBEDTLS_SRC ${ROOT_DIR}/${DEPS_MBEDTLS})
-set(DEPS_MBEDTLS_BUILD_DIR ${CMAKE_BINARY_DIR}/${DEPS_MBEDTLS}/library)
 set(MODULE_NAME "tls")
-set(MODULE_BINARY_DIR ${DEPS_MBEDTLS_BUILD_DIR})
 
-if("${TARGET_OS}" STREQUAL "TIZEN")
-  set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wno-cpp")
+if ("${TARGET_OS}" STREQUAL "TIZENRT")
+  set(MBEDTLS_LIBS "")
+  set(MBEDTLS_INCLUDE_DIR ${TARGET_SYSTEMROOT}/../external/include)
+else()
+  set(DEPS_MBEDTLS deps/mbedtls)
+  set(DEPS_MBEDTLS_SRC ${ROOT_DIR}/${DEPS_MBEDTLS})
+  set(DEPS_MBEDTLS_BUILD_DIR ${CMAKE_BINARY_DIR}/${DEPS_MBEDTLS}/library)
+  set(MODULE_BINARY_DIR ${DEPS_MBEDTLS_BUILD_DIR})
+
+  if("${TARGET_OS}" STREQUAL "TIZEN")
+    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wno-cpp")
+  endif()
+  set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wno-sign-conversion")
+  set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -I${ROOT_DIR}/config/mbedtls")
+  set(CMAKE_C_FLAGS
+      "${CMAKE_C_FLAGS} -DMBEDTLS_CONFIG_FILE='<config-for-iotjs.h>'")
+
+  # FIXME:
+  #       Remove this workaround when the related bug is fixed in
+  #       mbedtls. https://github.com/ARMmbed/mbedtls/issues/1550
+  set(CMAKE_C_FLAGS_BCK "${CMAKE_C_FLAGS}")
+  string(REPLACE "-fsanitize=address" "" CMAKE_C_FLAGS ${CMAKE_C_FLAGS})
+
+  ExternalProject_Add(mbedtls
+    PREFIX ${DEPS_MBEDTLS}
+    SOURCE_DIR ${DEPS_MBEDTLS_SRC}
+    BUILD_IN_SOURCE 0
+    BINARY_DIR ${DEPS_MBEDTLS}
+    INSTALL_COMMAND
+      COMMAND ${CMAKE_COMMAND} -E copy
+        ${DEPS_MBEDTLS_BUILD_DIR}/libmbedx509.a ${ARCHIVE_DIR}
+      COMMAND ${CMAKE_COMMAND} -E copy
+        ${DEPS_MBEDTLS_BUILD_DIR}/libmbedtls.a ${ARCHIVE_DIR}
+      COMMAND ${CMAKE_COMMAND} -E copy
+        ${DEPS_MBEDTLS_BUILD_DIR}/libmbedcrypto.a ${ARCHIVE_DIR}
+    CMAKE_ARGS
+      -DCMAKE_TOOLCHAIN_FILE=${CMAKE_TOOLCHAIN_FILE}
+      -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}
+      -DCMAKE_C_FLAGS=${CMAKE_C_FLAGS}
+      -DENABLE_PROGRAMS=OFF
+      -DENABLE_TESTING=OFF
+  )
+
+  # define external mbedtls target
+  add_library(libmbedtls STATIC IMPORTED)
+  add_dependencies(libmbedtls mbedtls)
+  set_property(TARGET libmbedtls PROPERTY
+    IMPORTED_LOCATION ${ARCHIVE_DIR}/libmbedtls.a)
+
+  # define external mbedx509 target
+  add_library(libmbedx509 STATIC IMPORTED)
+  add_dependencies(libmbedx509 mbedx509)
+  set_property(TARGET libmbedx509 PROPERTY
+    IMPORTED_LOCATION ${ARCHIVE_DIR}/libmbedx509.a)
+
+  # define external libmbedcrypto target
+  add_library(libmbedcrypto STATIC IMPORTED)
+  add_dependencies(libmbedcrypto mbedcrypto)
+  set_property(TARGET libmbedcrypto PROPERTY
+    IMPORTED_LOCATION ${ARCHIVE_DIR}/libmbedcrypto.a)
+
+  set_property(DIRECTORY APPEND PROPERTY
+    ADDITIONAL_MAKE_CLEAN_FILES
+    ${ARCHIVE_DIR}/libmbedx509.a
+    ${ARCHIVE_DIR}/libmbedtls.a
+    ${ARCHIVE_DIR}/libmbedcrypto.a
+  )
+
+  set(MBEDTLS_LIBS libmbedtls libmbedx509 libmbedcrypto)
+  set(MBEDTLS_INCLUDE_DIR ${DEPS_MBEDTLS}/include)
+
+  # FIXME:
+  #       Remove this workaround when the related bug is fixed in
+  #       mbedtls. https://github.com/ARMmbed/mbedtls/issues/1550
+  set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS_BCK}")
 endif()
-set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wno-sign-conversion")
-set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -I${ROOT_DIR}/config/mbedtls")
-set(CMAKE_C_FLAGS
-    "${CMAKE_C_FLAGS} -DMBEDTLS_CONFIG_FILE='<config-for-iotjs.h>'")
-
-# FIXME:
-#       Remove this workaround when the related bug is fixed in
-#       mbedtls. https://github.com/ARMmbed/mbedtls/issues/1550
-set(CMAKE_C_FLAGS_BCK "${CMAKE_C_FLAGS}")
-string(REPLACE "-fsanitize=address" "" CMAKE_C_FLAGS ${CMAKE_C_FLAGS})
-
-ExternalProject_Add(mbedtls
-  PREFIX ${DEPS_MBEDTLS}
-  SOURCE_DIR ${DEPS_MBEDTLS_SRC}
-  BUILD_IN_SOURCE 0
-  BINARY_DIR ${DEPS_MBEDTLS}
-  INSTALL_COMMAND
-    COMMAND ${CMAKE_COMMAND} -E copy
-      ${DEPS_MBEDTLS_BUILD_DIR}/libmbedx509.a ${ARCHIVE_DIR}
-    COMMAND ${CMAKE_COMMAND} -E copy
-      ${DEPS_MBEDTLS_BUILD_DIR}/libmbedtls.a ${ARCHIVE_DIR}
-    COMMAND ${CMAKE_COMMAND} -E copy
-      ${DEPS_MBEDTLS_BUILD_DIR}/libmbedcrypto.a ${ARCHIVE_DIR}
-  CMAKE_ARGS
-    -DCMAKE_TOOLCHAIN_FILE=${CMAKE_TOOLCHAIN_FILE}
-    -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}
-    -DCMAKE_C_FLAGS=${CMAKE_C_FLAGS}
-    -DENABLE_PROGRAMS=OFF
-    -DENABLE_TESTING=OFF
-)
-
-# define external mbedtls target
-add_library(libmbedtls STATIC IMPORTED)
-add_dependencies(libmbedtls mbedtls)
-set_property(TARGET libmbedtls PROPERTY
-  IMPORTED_LOCATION ${ARCHIVE_DIR}/libmbedtls.a)
-
-# define external mbedx509 target
-add_library(libmbedx509 STATIC IMPORTED)
-add_dependencies(libmbedx509 mbedx509)
-set_property(TARGET libmbedx509 PROPERTY
-  IMPORTED_LOCATION ${ARCHIVE_DIR}/libmbedx509.a)
-
-# define external libmbedcrypto target
-add_library(libmbedcrypto STATIC IMPORTED)
-add_dependencies(libmbedcrypto mbedcrypto)
-set_property(TARGET libmbedcrypto PROPERTY
-  IMPORTED_LOCATION ${ARCHIVE_DIR}/libmbedcrypto.a)
-
-set_property(DIRECTORY APPEND PROPERTY
-  ADDITIONAL_MAKE_CLEAN_FILES
-  ${ARCHIVE_DIR}/libmbedx509.a
-  ${ARCHIVE_DIR}/libmbedtls.a
-  ${ARCHIVE_DIR}/libmbedcrypto.a
-)
-
-set(MBEDTLS_LIBS libmbedtls libmbedx509 libmbedcrypto)
-set(MBEDTLS_INCLUDE_DIR ${DEPS_MBEDTLS}/include)
-
-# FIXME:
-#       Remove this workaround when the related bug is fixed in
-#       mbedtls. https://github.com/ARMmbed/mbedtls/issues/1550
-set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS_BCK}")

--- a/src/modules/iotjs_module_tls.c
+++ b/src/modules/iotjs_module_tls.c
@@ -457,7 +457,7 @@ JS_FUNCTION(Write) {
 
     if (ret_val > 0) {
       data += ret_val;
-      length -= ret_val;
+      length -= (size_t)ret_val;
     } else if (ret_val != MBEDTLS_ERR_SSL_WANT_WRITE) {
       tls_data->state = TLS_CLOSED;
       return jerry_create_null();


### PR DESCRIPTION
The currently used `mbedtls` version is not compatible with TizenRT, that results some compile errors. SInce TIzenRT builds its own version of `mbedtls`, it's simple enough just use that.

Note: in the `cmake/mbedtls.cmake` just the following contents were added:
```cmake
if ("${TARGET_OS}" STREQUAL "TIZENRT")
  set(MBEDTLS_LIBS "")
  set(MBEDTLS_INCLUDE_DIR ${TARGET_SYSTEMROOT}/../external/include)
else()
```
The others are the same, just the indentation is modified. 