### PR TITLE
Environment dependent color output for Python tools

### DIFF
--- a/tools/build.py
+++ b/tools/build.py
@@ -30,6 +30,7 @@ import os
 from common_py import path
 from common_py.system.filesystem import FileSystem as fs
 from common_py.system.executor import Executor as ex
+from common_py.system.executor import Terminal
 from common_py.system.platform import Platform
 
 platform = Platform()
@@ -419,7 +420,7 @@ if __name__ == '__main__':
 
     build_iotjs(options)
 
-    print("\n%sIoT.js Build Succeeded!!%s\n" % (ex._TERM_GREEN, ex._TERM_EMPTY))
+    Terminal.pprint("\nIoT.js Build Succeeded!!\n", Terminal.green)
 
     # Run tests.
     if options.run_test:
@@ -433,8 +434,8 @@ if __name__ == '__main__':
         else:
             print("Skip unit tests - target-host pair is not allowed\n")
     else:
-        print("\n%sTo run tests use '--run-test' "
-              "or one of the folowing commands:%s"
-              % (ex._TERM_BLUE, ex._TERM_EMPTY))
+        Terminal.pprint("\nTo run tests use '--run-test' "
+                        "or one of the folowing commands:",
+                        Terminal.blue)
         print("\n    tools/testrunner.py %s/%s/%s/bin/iotjs\n"
               % (options.builddir, options.target_tuple, options.buildtype))

--- a/tools/check_tidy.py
+++ b/tools/check_tidy.py
@@ -29,6 +29,7 @@ from distutils import spawn
 from check_license import CheckLicenser
 from common_py.system.filesystem import FileSystem as fs
 from common_py.system.executor import Executor as ex
+from common_py.system.executor import Terminal
 
 
 def parse_option():
@@ -110,11 +111,11 @@ class ClangFormat(object):
         if not clang_format:
             clang_format = spawn.find_executable("clang-format")
             if clang_format:
-                print("%sUsing %s instead of %s%s"
-                      % (ex._TERM_YELLOW, clang_format, base, ex._TERM_EMPTY))
+                Terminal.pprint(
+                    "Using %s instead of %s" % (clang_format, base),
+                    Terminal.yellow)
             else:
-                print("%sNo %s found, skipping checks!%s"
-                      % (ex._TERM_RED, base, ex._TERM_EMPTY))
+                Terminal.pprint("No %s found, skipping checks!", Terminal.red)
 
         self._clang_format = clang_format
 
@@ -161,16 +162,14 @@ class EslintChecker(object):
     def _check_eslint(self):
         self._node = spawn.find_executable('node')
         if not self._node:
-            print('%sNo node found.%s'
-                    % (ex._TERM_RED, ex._TERM_EMPTY))
+            Terminal.pprint('No node found,', Terminal.red)
             return
 
         self._eslint = spawn.find_executable('node_modules/.bin/eslint')
         if not self._eslint:
             self._eslint = spawn.find_executable('eslint')
             if not self._eslint:
-                print('%sNo eslint found.%s'
-                        % (ex._TERM_RED, ex._TERM_EMPTY))
+                Terminal.pprint('No eslint found.', Terminal.red)
 
     def check(self):
         self.error_count = 0
@@ -264,8 +263,8 @@ def check_tidy(src_dir, options=None):
     print("* clang-format errors: %d" % clang.error_count)
     print("* eslint errors: %d" % eslint.error_count)
 
-    msg_color = ex._TERM_RED if total_errors > 0 else ex._TERM_GREEN
-    print("%s* total errors: %d%s" % (msg_color, total_errors, ex._TERM_EMPTY))
+    msg_color = Terminal.red if total_errors > 0 else Terminal.green
+    Terminal.pprint("* total errors: %d" % (total_errors), msg_color)
     print()
 
     if total_errors:

--- a/tools/common_py/system/executor.py
+++ b/tools/common_py/system/executor.py
@@ -14,15 +14,34 @@
 
 from __future__ import print_function
 
+import collections
+import os
 import subprocess
+
+_colors = {
+    "empty": "\033[0m",
+    "red": "\033[1;31m",
+    "green": "\033[1;32m",
+    "yellow": "\033[1;33m",
+    "blue": "\033[1;34m"
+}
+
+if "TERM" not in os.environ:
+    # if there is no "TERM" environment variable
+    # assume that we can't output colors.
+    # So reset the ANSI color escapes.
+    _colors = _colors.fromkeys(_colors, "")
+
+_TerminalType = collections.namedtuple('Terminal', _colors.keys())
+class _Terminal(_TerminalType):
+
+    def pprint(self, text, color=_colors["empty"]):
+        print("%s%s%s" % (color, text, self.empty))
+
+Terminal = _Terminal(**_colors)
 
 
 class Executor(object):
-    _TERM_RED = "\033[1;31m"
-    _TERM_YELLOW = "\033[1;33m"
-    _TERM_GREEN = "\033[1;32m"
-    _TERM_BLUE = "\033[1;34m"
-    _TERM_EMPTY = "\033[0m"
 
     @staticmethod
     def cmd_line(cmd, args=[]):
@@ -30,14 +49,13 @@ class Executor(object):
 
     @staticmethod
     def print_cmd_line(cmd, args=[]):
-        print("%s%s%s" % (Executor._TERM_BLUE, Executor.cmd_line(cmd, args),
-                          Executor._TERM_EMPTY))
+        Terminal.pprint(Executor.cmd_line(cmd, args), Terminal.blue)
         print()
 
     @staticmethod
     def fail(msg):
         print()
-        print("%s%s%s" % (Executor._TERM_RED, msg, Executor._TERM_EMPTY))
+        Terminal.pprint(msg, Terminal.red)
         print()
         exit(1)
 

--- a/tools/testrunner.py
+++ b/tools/testrunner.py
@@ -27,7 +27,8 @@ import time
 from collections import OrderedDict
 from common_py import path
 from common_py.system.filesystem import FileSystem as fs
-from common_py.system.executor import Executor as ex
+from common_py.system.executor import Executor
+from common_py.system.executor import Terminal
 from common_py.system.platform import Platform
 
 # Defines the folder that will contain the coverage info.
@@ -82,25 +83,25 @@ def remove_coverage_code(testfile, coverage):
 
 class Reporter(object):
     @staticmethod
-    def message(msg="", color=ex._TERM_EMPTY):
-        print("%s%s%s" % (color, msg, ex._TERM_EMPTY))
+    def message(msg="", color=Terminal.empty):
+        print("%s%s%s" % (color, msg, Terminal.empty))
 
     @staticmethod
     def report_testset(testset):
         Reporter.message()
-        Reporter.message("Testset: %s" % testset, ex._TERM_BLUE)
+        Reporter.message("Testset: %s" % testset, Terminal.blue)
 
     @staticmethod
     def report_pass(test, time):
-        Reporter.message("  PASS: %s (%ss)" % (test, time), ex._TERM_GREEN)
+        Reporter.message("  PASS: %s (%ss)" % (test, time), Terminal.green)
 
     @staticmethod
     def report_fail(test, time):
-        Reporter.message("  FAIL: %s (%ss)" % (test, time), ex._TERM_RED)
+        Reporter.message("  FAIL: %s (%ss)" % (test, time), Terminal.red)
 
     @staticmethod
     def report_timeout(test):
-        Reporter.message("  TIMEOUT: %s" % test, ex._TERM_RED)
+        Reporter.message("  TIMEOUT: %s" % test, Terminal.red)
 
     @staticmethod
     def report_skip(test, reason):
@@ -109,7 +110,7 @@ class Reporter(object):
         if reason:
             skip_message += "   (Reason: %s)" % reason
 
-        Reporter.message(skip_message, ex._TERM_YELLOW)
+        Reporter.message(skip_message, Terminal.yellow)
 
     @staticmethod
     def report_configuration(testrunner):
@@ -124,11 +125,11 @@ class Reporter(object):
     @staticmethod
     def report_final(results):
         Reporter.message()
-        Reporter.message("Finished with all tests:", ex._TERM_BLUE)
-        Reporter.message("  PASS:    %d" % results["pass"], ex._TERM_GREEN)
-        Reporter.message("  FAIL:    %d" % results["fail"], ex._TERM_RED)
-        Reporter.message("  TIMEOUT: %d" % results["timeout"], ex._TERM_RED)
-        Reporter.message("  SKIP:    %d" % results["skip"], ex._TERM_YELLOW)
+        Reporter.message("Finished with all tests:", Terminal.blue)
+        Reporter.message("  PASS:    %d" % results["pass"], Terminal.green)
+        Reporter.message("  FAIL:    %d" % results["fail"], Terminal.red)
+        Reporter.message("  TIMEOUT: %d" % results["timeout"], Terminal.red)
+        Reporter.message("  SKIP:    %d" % results["skip"], Terminal.yellow)
 
 
 class TimeoutException(Exception):
@@ -153,8 +154,8 @@ class TestRunner(object):
             self.skip_modules = options.skip_modules.split(",")
 
         # Process the iotjs build information.
-        iotjs_output = ex.check_run_cmd_output(self.iotjs,
-                                    [path.BUILD_INFO_PATH])
+        iotjs_output = Executor.check_run_cmd_output(self.iotjs,
+                                                     [path.BUILD_INFO_PATH])
         build_info = json.loads(iotjs_output)
 
         self.builtins = set(build_info["builtins"])


### PR DESCRIPTION
The Python tools are outputting coloured text during
build, tests, and checks. However on some systems
the ANSI colour escape sequences are not valid.

To print allow colour sequences a minimal check is
performed: the "TERM" environment variable
is checked. If it is present assume that the terminal
can handle colours. If it is missing avoid colour output.