### PR TITLE
Fix features list in 'iotjs_build_info.js'.

### DIFF
--- a/test/testsets.json
+++ b/test/testsets.json
@@ -343,8 +343,7 @@
       ],
       "reason": "need to setup test environment",
       "required-modules": [
-        "gpio",
-        "tools/systemio_common"
+        "gpio"
       ]
     },
     {
@@ -354,8 +353,7 @@
       ],
       "reason": "need to setup test environment",
       "required-modules": [
-        "gpio",
-        "tools/systemio_common"
+        "gpio"
       ]
     },
     {
@@ -365,8 +363,7 @@
       ],
       "reason": "need to setup test environment",
       "required-modules": [
-        "gpio",
-        "tools/systemio_common"
+        "gpio"
       ]
     },
     {
@@ -376,8 +373,7 @@
       ],
       "reason": "need to setup test environment",
       "required-modules": [
-        "i2c",
-        "tools/systemio_common"
+        "i2c"
       ]
     },
     {
@@ -661,8 +657,7 @@
       ],
       "reason": "need to setup test environment",
       "required-modules": [
-        "pwm",
-        "tools/systemio_common"
+        "pwm"
       ]
     },
     {
@@ -672,8 +667,7 @@
       ],
       "reason": "need to setup test environment",
       "required-modules": [
-        "pwm",
-        "tools/systemio_common"
+        "pwm"
       ]
     },
     {
@@ -683,8 +677,7 @@
       ],
       "reason": "Different env on Linux desktop/travis/rpi",
       "required-modules": [
-        "spi",
-        "tools/systemio_common"
+        "spi"
       ]
     },
     {
@@ -694,8 +687,7 @@
       ],
       "reason": "need to setup test environment",
       "required-modules": [
-        "spi",
-        "tools/systemio_common"
+        "spi"
       ]
     },
     {
@@ -705,8 +697,7 @@
       ],
       "reason": "need to setup test environment",
       "required-modules": [
-        "spi",
-        "tools/systemio_common"
+        "spi"
       ]
     },
     {
@@ -716,8 +707,7 @@
       ],
       "reason": "need to setup test environment",
       "required-modules": [
-        "spi",
-        "tools/systemio_common"
+        "spi"
       ]
     },
     {
@@ -781,8 +771,7 @@
       ],
       "reason": "need to setup test environment",
       "required-modules": [
-        "uart",
-        "tools/systemio_common"
+        "uart"
       ]
     },
     {

--- a/test/tools/iotjs_build_info.js
+++ b/test/tools/iotjs_build_info.js
@@ -26,7 +26,7 @@ function hasFeatures(object, features) {
   supported = true;
 
   for (feature in features) {
-    supported = supported && object.hasOwnProperty(feature);
+    supported = supported && object.hasOwnProperty(features[feature]);
   }
 
   return supported;
@@ -55,13 +55,13 @@ var typedArrayFeatures = [
   'Float64Array'
 ];
 
-if (hasFeatures(this, ['Promise']))
+if (hasFeatures(global, ['Promise']))
   features.Promise = true;
 
-if (hasFeatures(this, ['ArrayBuffer']))
+if (hasFeatures(global, ['ArrayBuffer']))
   features.ArrayBuffer = true;
 
-if (hasFeatures(this, typedArrayFeatures))
+if (hasFeatures(global, typedArrayFeatures))
   features.TypedArray = true;
 
 if (hasArrowFunction())


### PR DESCRIPTION
The implementation of the JS engine features list was not correct,
so the Promise related tests did not run on the CI. Also removed
'tools/systemio_common' module requirement from the testsets.json,
because it is not a built-in module.

IoT.js-DCO-1.0-Signed-off-by: László Langó llango.u-szeged@partner.samsung.com