### PR TITLE
Hardening security of iotjs_bufferwrap_create_buffer

### DIFF
--- a/src/modules/iotjs_module_buffer.h
+++ b/src/modules/iotjs_module_buffer.h
@@ -19,8 +19,8 @@
 
 typedef struct {
   jerry_value_t jobject;
-  char* buffer;
   size_t length;
+  char buffer[];
 } iotjs_bufferwrap_t;
 
 
@@ -38,7 +38,7 @@ size_t iotjs_bufferwrap_copy(iotjs_bufferwrap_t* bufferwrap, const char* src,
                              size_t len);
 iotjs_bufferwrap_t* iotjs_jbuffer_get_bufferwrap_ptr(const jerry_value_t);
 
-// Create buffer object.
+// Fail-safe creation of Buffer object.
 jerry_value_t iotjs_bufferwrap_create_buffer(size_t len);
 
 


### PR DESCRIPTION
Currently this function calls the buffer constructor, which can be overwritten by users. The successful construction is only checked by an assert, and the return value of this function is never checked.

Furthermore the memory consumption of buffers is reduced by allocating data space after the buffer, so the buffer pointer is removed.