### PR TITLE
Removed 'iotjs_jhelper_call' function from bindings.

### DIFF
--- a/src/iotjs_binding.c
+++ b/src/iotjs_binding.c
@@ -380,18 +380,6 @@ jerry_value_t iotjs_jval_get_property_by_index(jerry_value_t jarr,
 }
 
 
-jerry_value_t iotjs_jhelper_call(jerry_value_t jfunc, jerry_value_t jthis,
-                                 const iotjs_jargs_t* jargs) {
-  IOTJS_ASSERT(jerry_value_is_object(jfunc));
-
-  jerry_length_t jargc_ = iotjs_jargs_length(jargs);
-
-  jerry_value_t jres = jerry_call_function(jfunc, jthis, jargs->argv, jargc_);
-
-  return jres;
-}
-
-
 jerry_value_t iotjs_jhelper_eval(const char* name, size_t name_len,
                                  const uint8_t* data, size_t size,
                                  bool strict_mode) {

--- a/src/iotjs_binding.h
+++ b/src/iotjs_binding.h
@@ -111,10 +111,6 @@ void iotjs_jargs_append_error(iotjs_jargs_t* jargs, const char* msg);
 
 void iotjs_jargs_replace(iotjs_jargs_t* jargs, uint16_t index, jerry_value_t x);
 
-// Calls JavaScript function.
-jerry_value_t iotjs_jhelper_call(jerry_value_t jfunc, jerry_value_t jthis,
-                                 const iotjs_jargs_t* jargs);
-
 // Evaluates javascript source file.
 jerry_value_t iotjs_jhelper_eval(const char* name, size_t name_len,
                                  const uint8_t* data, size_t size,

--- a/src/iotjs_binding_helper.c
+++ b/src/iotjs_binding_helper.c
@@ -27,12 +27,9 @@ void iotjs_uncaught_exception(jerry_value_t jexception) {
       iotjs_jval_get_property(process, IOTJS_MAGIC_STRING__ONUNCAUGHTEXCEPTION);
   IOTJS_ASSERT(jerry_value_is_function(jonuncaughtexception));
 
-  iotjs_jargs_t args = iotjs_jargs_create(1);
-  iotjs_jargs_append_jval(&args, jexception);
+  jerry_value_t jres =
+      jerry_call_function(jonuncaughtexception, process, &jexception, 1);
 
-  jerry_value_t jres = iotjs_jhelper_call(jonuncaughtexception, process, &args);
-
-  iotjs_jargs_destroy(&args);
   jerry_release_value(jonuncaughtexception);
 
   if (jerry_value_is_error(jres)) {
@@ -55,16 +52,14 @@ void iotjs_process_emit_exit(int code) {
       iotjs_jval_get_property(process, IOTJS_MAGIC_STRING_EMITEXIT);
 
   if (jerry_value_is_function(jexit)) {
-    iotjs_jargs_t jargs = iotjs_jargs_create(1);
-    iotjs_jargs_append_number(&jargs, code);
-
-    jerry_value_t jres = iotjs_jhelper_call(jexit, process, &jargs);
+    jerry_value_t jcode = jerry_create_number(code);
+    jerry_value_t jres = jerry_call_function(jexit, process, &jcode, 1);
 
     if (jerry_value_is_error(jres)) {
       iotjs_set_process_exitcode(2);
     }
 
-    iotjs_jargs_destroy(&jargs);
+    jerry_release_value(jcode);
     jerry_release_value(jres);
   }
 
@@ -87,8 +82,7 @@ bool iotjs_process_next_tick() {
   IOTJS_ASSERT(jerry_value_is_function(jon_next_tick));
 
   jerry_value_t jres =
-      iotjs_jhelper_call(jon_next_tick, jerry_create_undefined(),
-                         iotjs_jargs_get_empty());
+      jerry_call_function(jon_next_tick, jerry_create_undefined(), NULL, 0);
 
   bool ret = false;
 
@@ -106,23 +100,25 @@ bool iotjs_process_next_tick() {
 // Make a callback for the given `function` with `this_` binding and `args`
 // arguments. The next tick callbacks registered via `process.nextTick()`
 // will be called after the callback function `function` returns.
-void iotjs_make_callback(jerry_value_t jfunction, jerry_value_t jthis,
+void iotjs_make_callback(jerry_value_t jfunc, jerry_value_t jthis,
                          const iotjs_jargs_t* jargs) {
-  jerry_value_t result =
-      iotjs_make_callback_with_result(jfunction, jthis, jargs);
+  jerry_value_t result = iotjs_make_callback_with_result(jfunc, jthis, jargs);
   jerry_release_value(result);
 }
 
 
-jerry_value_t iotjs_make_callback_with_result(jerry_value_t jfunction,
+jerry_value_t iotjs_make_callback_with_result(jerry_value_t jfunc,
                                               jerry_value_t jthis,
                                               const iotjs_jargs_t* jargs) {
+  IOTJS_ASSERT(jerry_value_is_function(jfunc));
+
   // If the environment is already exiting just return an undefined value.
   if (iotjs_environment_is_exiting(iotjs_environment_get())) {
     return jerry_create_undefined();
   }
   // Calls back the function.
-  jerry_value_t jres = iotjs_jhelper_call(jfunction, jthis, jargs);
+  jerry_value_t jres =
+      jerry_call_function(jfunc, jthis, jargs->argv, jargs->argc);
   if (jerry_value_is_error(jres)) {
     jerry_value_t errval = jerry_get_value_from_error(jres, false);
     iotjs_uncaught_exception(errval);

--- a/src/iotjs_binding_helper.h
+++ b/src/iotjs_binding_helper.h
@@ -26,10 +26,10 @@ void iotjs_process_emit_exit(int code);
 
 bool iotjs_process_next_tick();
 
-void iotjs_make_callback(jerry_value_t jfunction, jerry_value_t jthis,
+void iotjs_make_callback(jerry_value_t jfunc, jerry_value_t jthis,
                          const iotjs_jargs_t* jargs);
 
-jerry_value_t iotjs_make_callback_with_result(jerry_value_t jfunction,
+jerry_value_t iotjs_make_callback_with_result(jerry_value_t jfunc,
                                               jerry_value_t jthis,
                                               const iotjs_jargs_t* jargs);
 

--- a/src/modules/iotjs_module_tcp.c
+++ b/src/modules/iotjs_module_tcp.c
@@ -275,8 +275,7 @@ static void OnConnection(uv_stream_t* handle, int status) {
     IOTJS_ASSERT(jerry_value_is_function(jcreate_tcp));
 
     jerry_value_t jclient_tcp =
-        iotjs_jhelper_call(jcreate_tcp, jerry_create_undefined(),
-                           iotjs_jargs_get_empty());
+        jerry_call_function(jcreate_tcp, jerry_create_undefined(), NULL, 0);
     IOTJS_ASSERT(!jerry_value_is_error(jclient_tcp));
     IOTJS_ASSERT(jerry_value_is_object(jclient_tcp));
 

--- a/src/modules/iotjs_module_uart.c
+++ b/src/modules/iotjs_module_uart.c
@@ -74,7 +74,6 @@ static void iotjs_uart_read_cb(uv_poll_t* req, int status, int events) {
                                 IOTJS_MAGIC_STRING_EMIT);
     IOTJS_ASSERT(jerry_value_is_function(jemit));
 
-    iotjs_jargs_t jargs = iotjs_jargs_create(2);
     jerry_value_t str =
         jerry_create_string((const jerry_char_t*)IOTJS_MAGIC_STRING_DATA);
 
@@ -82,17 +81,15 @@ static void iotjs_uart_read_cb(uv_poll_t* req, int status, int events) {
     iotjs_bufferwrap_t* buf_wrap = iotjs_bufferwrap_from_jbuffer(jbuf);
     iotjs_bufferwrap_copy(buf_wrap, buf, (size_t)i);
 
-    iotjs_jargs_append_jval(&jargs, str);
-    iotjs_jargs_append_jval(&jargs, jbuf);
+    jerry_value_t jargs[] = { str, jbuf };
     jerry_value_t jres =
-        iotjs_jhelper_call(jemit, iotjs_handlewrap_jobject(&uart->handlewrap),
-                           &jargs);
+        jerry_call_function(jemit, iotjs_handlewrap_jobject(&uart->handlewrap),
+                            jargs, 2);
     IOTJS_ASSERT(!jerry_value_is_error(jres));
 
     jerry_release_value(jres);
     jerry_release_value(str);
     jerry_release_value(jbuf);
-    iotjs_jargs_destroy(&jargs);
     jerry_release_value(jemit);
   }
 }

--- a/src/modules/linux/iotjs_module_blehcisocket-linux.c
+++ b/src/modules/linux/iotjs_module_blehcisocket-linux.c
@@ -281,21 +281,18 @@ void iotjs_blehcisocket_poll(iotjs_blehcisocket_t* blehcisocket) {
     jerry_value_t jemit = iotjs_jval_get_property(jhcisocket, "emit");
     IOTJS_ASSERT(jerry_value_is_function(jemit));
 
-    iotjs_jargs_t jargs = iotjs_jargs_create(2);
     jerry_value_t str = jerry_create_string((const jerry_char_t*)"data");
     IOTJS_ASSERT(length >= 0);
     jerry_value_t jbuf = iotjs_bufferwrap_create_buffer((size_t)length);
     iotjs_bufferwrap_t* buf_wrap = iotjs_bufferwrap_from_jbuffer(jbuf);
     iotjs_bufferwrap_copy(buf_wrap, data, (size_t)length);
-    iotjs_jargs_append_jval(&jargs, str);
-    iotjs_jargs_append_jval(&jargs, jbuf);
-    jerry_value_t jres = iotjs_jhelper_call(jemit, jhcisocket, &jargs);
+    jerry_value_t jargs[2] = { str, jbuf };
+    jerry_value_t jres = jerry_call_function(jemit, jhcisocket, jargs, 2);
     IOTJS_ASSERT(!jerry_value_is_error(jres));
 
     jerry_release_value(jres);
     jerry_release_value(str);
     jerry_release_value(jbuf);
-    iotjs_jargs_destroy(&jargs);
     jerry_release_value(jemit);
   }
 }
@@ -319,16 +316,16 @@ void iotjs_blehcisocket_emitErrnoError(iotjs_blehcisocket_t* blehcisocket) {
   jerry_value_t jemit = iotjs_jval_get_property(jhcisocket, "emit");
   IOTJS_ASSERT(jerry_value_is_function(jemit));
 
-  iotjs_jargs_t jargs = iotjs_jargs_create(2);
   jerry_value_t str = jerry_create_string((const jerry_char_t*)"error");
-  iotjs_jargs_append_jval(&jargs, str);
-  iotjs_jargs_append_error(&jargs, strerror(errno));
-  jerry_value_t jres = iotjs_jhelper_call(jemit, jhcisocket, &jargs);
+  jerry_value_t jerror =
+      iotjs_jval_create_error_without_error_flag(strerror(errno));
+  jerry_value_t jargs[2] = { str, jerror };
+  jerry_value_t jres = jerry_call_function(jemit, jhcisocket, jargs, 2);
   IOTJS_ASSERT(!jerry_value_is_error(jres));
 
   jerry_release_value(jres);
   jerry_release_value(str);
-  iotjs_jargs_destroy(&jargs);
+  jerry_release_value(jerror);
   jerry_release_value(jemit);
 }
 

--- a/src/modules/linux/iotjs_module_gpio-linux.c
+++ b/src/modules/linux/iotjs_module_gpio-linux.c
@@ -78,8 +78,7 @@ static void gpio_emit_change_event(iotjs_gpio_t* gpio) {
   jerry_value_t jonChange = iotjs_jval_get_property(jgpio, "onChange");
   IOTJS_ASSERT(jerry_value_is_function(jonChange));
 
-  jerry_value_t jres =
-      iotjs_jhelper_call(jonChange, jgpio, iotjs_jargs_get_empty());
+  jerry_value_t jres = jerry_call_function(jonChange, jgpio, NULL, 0);
   IOTJS_ASSERT(!jerry_value_is_error(jres));
 
   jerry_release_value(jres);


### PR DESCRIPTION
Related issue: #1685

IoT.js-DCO-1.0-Signed-off-by: László Langó llango.u-szeged@partner.samsung.com