### PR TITLE
build: Add fallback linux config for unsupported arch

### DIFF
--- a/cmake/config/noarch-linux.cmake
+++ b/cmake/config/noarch-linux.cmake
@@ -1,0 +1,15 @@
+# Copyright 2018-present Samsung Electronics Co., Ltd. and other contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set(CMAKE_SYSTEM_NAME Linux)


### PR DESCRIPTION
This rule is helpful for non supported arch,
to rely on system compiler with default flags.

For instance debian uses i386 arch (while upstream supports only i686),
this could also apply to other non supported archs.

For the record most debian arch were building on 1.0 (not ia64, sh4):

https://buildd.debian.org/status/package.php?p=iotjs&suite=unstable

IoT.js-DCO-1.0-Signed-off-by: Philippe Coval philippe.coval@osg.samsung.com