### PR TITLE
Update the test-net-bind-twice.js test.

### DIFF
--- a/test/node/common.js
+++ b/test/node/common.js
@@ -57,6 +57,7 @@ exports.isLinuxPPCBE = (process.platform === 'linux') &&
 exports.isSunOS = process.platform === 'sunos';
 exports.isFreeBSD = process.platform === 'freebsd';
 exports.isLinux = process.platform === 'linux';
+exports.isNuttX = process.platform === 'nuttx';
 exports.isTizen = process.platform === 'tizen';
 exports.isOSX = process.platform === 'darwin';
 

--- a/test/node/parallel/test-net-bind-twice.js
+++ b/test/node/parallel/test-net-bind-twice.js
@@ -46,9 +46,11 @@ server1.listen(0, '127.0.0.1', common.mustCall(function() {
   var server2 = net.createServer(common.fail);
 
   server2.on('error', common.mustCall(function(e) {
-    // EADDRINUSE have different value on OSX.
+    // EADDRINUSE has different values on OSX and NuttX.
     if (common.isOSX) {
       assert.strictEqual(e, -48);
+    } else if (common.isNuttX) {
+      assert.strictEqual(e, -112);
     } else {
       assert.strictEqual(e, -98);
     }


### PR DESCRIPTION
The latest NuttX version (nuttx_7.25) uses `112` (as error code) for EADDRINUSE. (https://bitbucket.org/nuttx/nuttx/src/0eb9a05b9ea1a426330be21016b70a34a234f4ec/include/errno.h?at=nuttx-7.25&fileviewer=file-view-default#errno.h-327)