### PR TITLE
Fix for setHeader

### DIFF
--- a/src/js/http_outgoing.js
+++ b/src/js/http_outgoing.js
@@ -162,7 +162,7 @@ OutgoingMessage.prototype.setHeader = function(name, value) {
     throw new TypeError('Name must be string.');
   }
 
-  if (!value) {
+  if (util.isNullOrUndefined(value)) {
     throw new Error('value required in setHeader(' + name + ', value)');
   }
 

--- a/test/run_pass/test_net_headers.js
+++ b/test/run_pass/test_net_headers.js
@@ -53,6 +53,8 @@ var server = http.createServer(function (req, res) {
       res.setHeader('h' + (5 + i), 'h' + (5 + i));
     }
 
+    res.setHeader('content-length', 0);
+
     res.end(function(){
       server.close();
     });
@@ -79,6 +81,7 @@ var postResponseHandler = function (res) {
   assert.equal(res.headers['h1'], 'h1');
   assert.equal(res.headers['h2'], undefined);
   assert.equal(res.headers['h3'], 'h3prime');
+  assert.equal(res.headers['content-length'], 0);
 
   var endHandler = function(){
     checkReqFinish = true;


### PR DESCRIPTION
This patch fixes the error from the following case:

```js
var str = '';
res.setHeader('Content-Length', str.length);
```

IoT.js-DCO-1.0-Signed-off-by: Daeyeon Jeong daeyeon.jeong@samsung.com