### PR TITLE
Fix setting exit code

### DIFF
--- a/src/iotjs_binding_helper.c
+++ b/src/iotjs_binding_helper.c
@@ -171,5 +171,11 @@ int iotjs_process_exitcode() {
 
 void iotjs_set_process_exitcode(int code) {
   const jerry_value_t process = iotjs_module_get("process");
-  iotjs_jval_set_property_number(process, IOTJS_MAGIC_STRING_EXITCODE, code);
+  jerry_value_t jstring =
+      jerry_create_string((jerry_char_t*)IOTJS_MAGIC_STRING_EXITCODE);
+  jerry_value_t jcode = jerry_create_number(code);
+  jerry_release_value(jerry_set_property(process, jstring, jcode));
+
+  jerry_release_value(jstring);
+  jerry_release_value(jcode);
 }

--- a/test/run_fail/test-issue-1570.js
+++ b/test/run_fail/test-issue-1570.js
@@ -1,0 +1,17 @@
+/* Copyright 2018-present Samsung Electronics Co., Ltd. and other contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+Object.freeze(process);
+throw new Error("Some error");

--- a/test/testsets.json
+++ b/test/testsets.json
@@ -909,6 +909,10 @@
       "expected-failure": true
     },
     {
+      "name": "test-issue-1570.js",
+      "expected-failure": true
+    },
+    {
       "name": "test_module_require_invalid_file.js",
       "expected-failure": true
     },


### PR DESCRIPTION
The success of setting the exitcode property on exiting shouldn't be checked, since the property could be inaccessible for any reason.
Therefore, set it manually without the `iotjs_jval_set_property` function, and just release the return value.

Fixes #1570

IoT.js-DCO-1.0-Signed-off-by: Daniel Balla dballa@inf.u-szeged.hu