### PR TITLE
Finish the 'iotjs_jargs_t' removal

### DIFF
--- a/src/iotjs_binding.c
+++ b/src/iotjs_binding.c
@@ -22,9 +22,6 @@
 #include <string.h>
 
 
-static iotjs_jargs_t jargs_empty;
-
-
 jerry_value_t iotjs_jval_create_string(const iotjs_string_t* v) {
   jerry_value_t jval;
 
@@ -406,106 +403,4 @@ jerry_value_t vm_exec_stop_callback(void* user_p) {
   }
 
   return jerry_create_string((const jerry_char_t*)"Abort script");
-}
-
-
-iotjs_jargs_t iotjs_jargs_create(uint16_t capacity) {
-  if (capacity == 0) {
-    return jargs_empty;
-  }
-
-  iotjs_jargs_t jargs;
-
-  jargs.capacity = capacity;
-  jargs.argc = 0;
-  unsigned buffer_size = sizeof(jerry_value_t) * capacity;
-  jargs.argv = (jerry_value_t*)iotjs_buffer_allocate(buffer_size);
-
-  return jargs;
-}
-
-
-const iotjs_jargs_t* iotjs_jargs_get_empty() {
-  return &jargs_empty;
-}
-
-
-void iotjs_jargs_destroy(iotjs_jargs_t* jargs) {
-  IOTJS_ASSERT(jargs && jargs->argc <= jargs->capacity);
-
-  if (jargs && jargs->capacity > 0) {
-    IOTJS_ASSERT(jargs->argv);
-    for (unsigned i = 0; i < jargs->argc; ++i) {
-      jerry_release_value(jargs->argv[i]);
-    }
-    IOTJS_RELEASE(jargs->argv);
-  } else {
-    IOTJS_ASSERT(jargs->argv == NULL);
-  }
-}
-
-
-uint16_t iotjs_jargs_length(const iotjs_jargs_t* jargs) {
-  IOTJS_ASSERT(jargs);
-  return jargs ? jargs->argc : 0;
-}
-
-
-void iotjs_jargs_append_jval(iotjs_jargs_t* jargs, jerry_value_t x) {
-  IOTJS_ASSERT(jargs && jargs->argc < jargs->capacity);
-  IOTJS_ASSERT(jargs->argv);
-  jargs->argv[jargs->argc++] = jerry_acquire_value(x);
-}
-
-
-void iotjs_jargs_append_undefined(iotjs_jargs_t* jargs) {
-  iotjs_jargs_append_jval(jargs, jerry_create_undefined());
-}
-
-
-void iotjs_jargs_append_null(iotjs_jargs_t* jargs) {
-  iotjs_jargs_append_jval(jargs, jerry_create_null());
-}
-
-
-void iotjs_jargs_append_bool(iotjs_jargs_t* jargs, bool x) {
-  iotjs_jargs_append_jval(jargs, jerry_create_boolean(x));
-}
-
-
-void iotjs_jargs_append_number(iotjs_jargs_t* jargs, double x) {
-  jerry_value_t jval = jerry_create_number(x);
-  iotjs_jargs_append_jval(jargs, jval);
-  jerry_release_value(jval);
-}
-
-
-void iotjs_jargs_append_string(iotjs_jargs_t* jargs, const iotjs_string_t* x) {
-  jerry_value_t jval = iotjs_jval_create_string(x);
-  iotjs_jargs_append_jval(jargs, jval);
-  jerry_release_value(jval);
-}
-
-
-void iotjs_jargs_append_error(iotjs_jargs_t* jargs, const char* msg) {
-  jerry_value_t error = iotjs_jval_create_error_without_error_flag(msg);
-  iotjs_jargs_append_jval(jargs, error);
-  jerry_release_value(error);
-}
-
-
-void iotjs_jargs_append_string_raw(iotjs_jargs_t* jargs, const char* x) {
-  jerry_value_t jval = jerry_create_string((const jerry_char_t*)x);
-  iotjs_jargs_append_jval(jargs, jval);
-  jerry_release_value(jval);
-}
-
-
-void iotjs_jargs_replace(iotjs_jargs_t* jargs, uint16_t index,
-                         jerry_value_t x) {
-  IOTJS_ASSERT(jargs && index < jargs->argc);
-  IOTJS_ASSERT(jargs->argv);
-
-  jerry_release_value(jargs->argv[index]);
-  jargs->argv[index] = jerry_acquire_value(x);
 }

--- a/src/iotjs_binding.h
+++ b/src/iotjs_binding.h
@@ -83,34 +83,6 @@ void iotjs_jval_set_property_by_index(jerry_value_t jarr, uint32_t idx,
 jerry_value_t iotjs_jval_get_property_by_index(jerry_value_t jarr,
                                                uint32_t idx);
 
-
-typedef struct {
-  uint16_t capacity;
-  uint16_t argc;
-  jerry_value_t* argv;
-} iotjs_jargs_t;
-
-
-iotjs_jargs_t iotjs_jargs_create(uint16_t capacity);
-
-const iotjs_jargs_t* iotjs_jargs_get_empty();
-
-void iotjs_jargs_destroy(iotjs_jargs_t* jargs);
-
-uint16_t iotjs_jargs_length(const iotjs_jargs_t* jargs);
-
-void iotjs_jargs_append_jval(iotjs_jargs_t* jargs, jerry_value_t x);
-void iotjs_jargs_append_undefined(iotjs_jargs_t* jargs);
-void iotjs_jargs_append_null(iotjs_jargs_t* jargs);
-void iotjs_jargs_append_bool(iotjs_jargs_t* jargs, bool x);
-void iotjs_jargs_append_number(iotjs_jargs_t* jargs, double x);
-void iotjs_jargs_append_string(iotjs_jargs_t* jargs, const iotjs_string_t* x);
-void iotjs_jargs_append_string_raw(iotjs_jargs_t* jargs, const char* x);
-void iotjs_jargs_append_error(iotjs_jargs_t* jargs, const char* msg);
-
-
-void iotjs_jargs_replace(iotjs_jargs_t* jargs, uint16_t index, jerry_value_t x);
-
 // Evaluates javascript source file.
 jerry_value_t iotjs_jhelper_eval(const char* name, size_t name_len,
                                  const uint8_t* data, size_t size,

--- a/src/iotjs_binding_helper.c
+++ b/src/iotjs_binding_helper.c
@@ -133,24 +133,6 @@ jerry_value_t iotjs_invoke_callback_with_result(jerry_value_t jfunc,
 }
 
 
-// Make a callback for the given `function` with `this_` binding and `args`
-// arguments. The next tick callbacks registered via `process.nextTick()`
-// will be called after the callback function `function` returns.
-void iotjs_make_callback(jerry_value_t jfunc, jerry_value_t jthis,
-                         const iotjs_jargs_t* jargs) {
-  jerry_value_t result = iotjs_make_callback_with_result(jfunc, jthis, jargs);
-  jerry_release_value(result);
-}
-
-
-jerry_value_t iotjs_make_callback_with_result(jerry_value_t jfunc,
-                                              jerry_value_t jthis,
-                                              const iotjs_jargs_t* jargs) {
-  return iotjs_invoke_callback_with_result(jfunc, jthis, jargs->argv,
-                                           jargs->argc);
-}
-
-
 int iotjs_process_exitcode() {
   const jerry_value_t process = iotjs_module_get("process");
 

--- a/src/iotjs_binding_helper.h
+++ b/src/iotjs_binding_helper.h
@@ -33,12 +33,6 @@ jerry_value_t iotjs_invoke_callback_with_result(jerry_value_t jfunc,
                                                 const jerry_value_t* jargv,
                                                 size_t jargc);
 
-void iotjs_make_callback(jerry_value_t jfunc, jerry_value_t jthis,
-                         const iotjs_jargs_t* jargs);
-jerry_value_t iotjs_make_callback_with_result(jerry_value_t jfunc,
-                                              jerry_value_t jthis,
-                                              const iotjs_jargs_t* jargs);
-
 int iotjs_process_exitcode();
 void iotjs_set_process_exitcode(int code);
 

--- a/src/modules/iotjs_module_mqtt.c
+++ b/src/modules/iotjs_module_mqtt.c
@@ -397,7 +397,7 @@ static int iotjs_mqtt_handle(jerry_value_t jsref, char first_byte, char *buffer,
 
       jerry_value_t fn =
           iotjs_jval_get_property(jsref, IOTJS_MAGIC_STRING_ONCONNECTION);
-      iotjs_make_callback(fn, jsref, iotjs_jargs_get_empty());
+      iotjs_invoke_callback(fn, jsref, NULL, 0);
 
       jerry_release_value(fn);
       break;
@@ -525,7 +525,7 @@ static int iotjs_mqtt_handle(jerry_value_t jsref, char first_byte, char *buffer,
 
       jerry_value_t fn =
           iotjs_jval_get_property(jsref, IOTJS_MAGIC_STRING_ONPINGRESP);
-      iotjs_make_callback(fn, jsref, iotjs_jargs_get_empty());
+      iotjs_invoke_callback(fn, jsref, NULL, 0);
       jerry_release_value(fn);
       break;
     }
@@ -536,7 +536,7 @@ static int iotjs_mqtt_handle(jerry_value_t jsref, char first_byte, char *buffer,
 
       jerry_value_t fn =
           iotjs_jval_get_property(jsref, IOTJS_MAGIC_STRING_ONEND);
-      iotjs_make_callback(fn, jsref, iotjs_jargs_get_empty());
+      iotjs_invoke_callback(fn, jsref, NULL, 0);
       jerry_release_value(fn);
       break;
     }

--- a/src/modules/tizen/iotjs_module_tizen-tizen.c
+++ b/src/modules/tizen/iotjs_module_tizen-tizen.c
@@ -124,12 +124,13 @@ void iotjs_tizen_app_control_cb(app_control_h app_control, void* user_data) {
   DDDLOG("JSON: %s", json);
 
   // call emit
-  iotjs_jargs_t jargv = iotjs_jargs_create(2);
-  iotjs_jargs_append_string_raw(&jargv, event_name);
-  iotjs_jargs_append_string_raw(&jargv, json);
+  jerry_value_t jargv[2] = { jerry_create_string(
+                                 (const jerry_char_t*)event_name),
+                             jerry_create_string((const jerry_char_t*)json) };
 
-  iotjs_make_callback(fn, tizen, &jargv);
-  iotjs_jargs_destroy(&jargv);
+  iotjs_invoke_callback(fn, tizen, jargv, 2);
+  jerry_release_value(jargv[0]);
+  jerry_release_value(jargv[1]);
 
   free(json);
   bundle_free(b);
@@ -200,9 +201,9 @@ static bool bridge_native_call(const char* module_name, const char* func_name,
     return result;
   }
 
-  iotjs_jargs_t jargv = iotjs_jargs_create(1);
-  iotjs_jargs_append_string_raw(&jargv, message);
-  jerry_value_t jres = iotjs_make_callback_with_result(jfunc, jmodule, &jargv);
+  jerry_value_t jval = jerry_create_string((const jerry_char_t*)message);
+  jerry_value_t jres =
+      iotjs_invoke_callback_with_result(jfunc, jmodule, &jval, 1);
 
   if (jerry_value_is_string(jres)) {
     IOTJS_ASSERT(output_str != NULL);
@@ -212,7 +213,7 @@ static bool bridge_native_call(const char* module_name, const char* func_name,
 
   jerry_release_value(jfunc);
   jerry_release_value(jres);
-  iotjs_jargs_destroy(&jargv);
+  jerry_release_value(jval);
   return result;
 }
 


### PR DESCRIPTION
Changed the remaining 'iotjs_make_callback' calls to 'iotjs_invoke_callback'
which does not use 'iotjs_jargs_t'. Removed the 'iotjs_jargs_t' struct and
the related functions. This patch reduces the binary size ('.text' section)
by ~1 KByte.

IoT.js-DCO-1.0-Signed-off-by: László Langó llango.u-szeged@partner.samsung.com