### PR TITLE
Fix exitcode returning 0 in some cases

### DIFF
--- a/src/iotjs_binding_helper.c
+++ b/src/iotjs_binding_helper.c
@@ -145,6 +145,11 @@ int iotjs_process_exitcode() {
   } else {
     exitcode = (uint8_t)iotjs_jval_as_number(num_val);
   }
+
+  uint8_t native_exitcode = iotjs_environment_get()->exitcode;
+  if (native_exitcode != exitcode && native_exitcode) {
+    exitcode = native_exitcode;
+  }
   jerry_release_value(num_val);
   jerry_release_value(jexitcode);
   return (int)exitcode;
@@ -156,8 +161,12 @@ void iotjs_set_process_exitcode(int code) {
   jerry_value_t jstring =
       jerry_create_string((jerry_char_t*)IOTJS_MAGIC_STRING_EXITCODE);
   jerry_value_t jcode = jerry_create_number(code);
-  jerry_release_value(jerry_set_property(process, jstring, jcode));
+  jerry_value_t ret_val = jerry_set_property(process, jstring, jcode);
+  if (jerry_value_is_error(ret_val)) {
+    iotjs_environment_get()->exitcode = 1;
+  }
 
+  jerry_release_value(ret_val);
   jerry_release_value(jstring);
   jerry_release_value(jcode);
 }

--- a/src/iotjs_env.c
+++ b/src/iotjs_env.c
@@ -80,6 +80,7 @@ static void initialize(iotjs_environment_t* env) {
   env->config.memstat = false;
   env->config.show_opcode = false;
   env->config.debugger = NULL;
+  env->exitcode = 0;
 }
 
 

--- a/src/iotjs_env.h
+++ b/src/iotjs_env.h
@@ -53,6 +53,9 @@ typedef struct {
 
   // Run config
   Config config;
+
+  // Exitcode
+  uint8_t exitcode;
 } iotjs_environment_t;
 
 

--- a/src/js/iotjs.js
+++ b/src/js/iotjs.js
@@ -148,6 +148,7 @@
   process.exitCode = 0;
   process._exiting = false;
   process.emitExit = function(code) {
+    code = code || process.exitCode;
     if (typeof code !== 'number') {
       code = 0;
     }


### PR DESCRIPTION
There are some special cases, where the exitcode should return an error, however it returns with 0.
This patch fixes it.
Related test: test-issue-1570.js

I could add more tests, however all of them would be in seperate files, and those would mean plus 3-4 tests.

IoT.js-DCO-1.0-Signed-off-by: Daniel Balla dballa@inf.u-szeged.hu