### PR TITLE
Add a simple server to the docker image for travis-ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ services:
   - docker
 
 before_install:
-  - if [[ "$RUN_DOCKER" == "yes" ]]; then docker pull iotjs/ubuntu:0.8; fi
+  - if [[ "$RUN_DOCKER" == "yes" ]]; then docker pull iotjs/ubuntu:0.9; fi
 
 script:
   tools/travis_script.py


### PR DESCRIPTION
Add a simple https server with httpbin like responses and
a websocket echo server to run https and websocket test locally on travis-ci.
This way we can avoid the latency from the remote host.

IoT.js-DCO-1.0-Signed-off-by: Istvan Miklos imiklos2@inf.u-szeged.hu