### PR TITLE
Change ../../libapps paths in NuttX configuration Makefile

### DIFF
--- a/config/nuttx/stm32f4dis/app/Makefile
+++ b/config/nuttx/stm32f4dis/app/Makefile
@@ -88,12 +88,12 @@ ifneq ($(CONFIG_BUILD_KERNEL),y)
 endif
 
 ifeq ($(CONFIG_WINDOWS_NATIVE),y)
-  BIN = ..\..\libapps$(LIBEXT)
+  BIN = $(APPDIR)\libapps$(LIBEXT)
 else
 ifeq ($(WINTOOL),y)
-  BIN = ..\\..\\libapps$(LIBEXT)
+  BIN = $(APPDIR)\\libapps$(LIBEXT)
 else
-  BIN = ../../libapps$(LIBEXT)
+  BIN = $(APPDIR)/libapps$(LIBEXT)
 endif
 endif
 


### PR DESCRIPTION
With the old paths, IoT.js was built with NuttX paths, which won't work if we use symlinks instead of copying IoT.js files, because the path is not the same. With these changes, the old method still works, and application files are buildable both with symlink and cp method.

IoT.js-DCO-1.0-Signed-off-by: Bela Toth tbela@inf.u-szeged.hu