### PR TITLE
Check dns result pointer after name resolution

### DIFF
--- a/src/modules/iotjs_module_dns.c
+++ b/src/modules/iotjs_module_dns.c
@@ -106,7 +106,7 @@ static void AfterGetAddrInfo(uv_getaddrinfo_t* req, int status,
   size_t argc = 0;
   jerry_value_t args[3] = { 0 };
 
-  if (status == 0) {
+  if (status == 0 && res != NULL) {
     char ip[INET6_ADDRSTRLEN];
     int family;
     const char* addr;


### PR DESCRIPTION
After DNS name resolution check not only the status
but the result pointer also to make sure there is
no null pointer dereference.

IoT.js-DCO-1.0-Signed-off-by: Peter Gal pgal.u-szeged@partner.samsung.com