### PR TITLE
ignore: tmp and debian generated files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@
 /test/tmp/*
 /test/dynamicmodule/build/*
 eslint.log
+/obj-*-*/
 
 # IDE related files
 nbproject
@@ -44,3 +45,16 @@ TAGS
 # config files
 *.config
 !build.config
+
+# Local developer temporary place
+/tmp/
+
+# Debian files
+/debian/files
+/debian/*.debhelper.log
+/debian/*.substvars
+/debian/iotjs*/
+/debian/tmp/
+/debian/.debhelper/
+/debian/debhelper-build-stamp
+/debian/iotjs.1


### PR DESCRIPTION
tmp/ can be used for developers playground

Also ignore Debian generated files and objects if build in .

Bug: https://github.com/Samsung/iotjs/issues/1389
IoT.js-DCO-1.0-Signed-off-by: Philippe Coval philippe.coval@osg.samsung.com