### PR TITLE
Fix osx build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -85,7 +85,7 @@ CHECK_C_COMPILER_FLAG(-no-pie HAS_NO_PIE)
 # Add buildtype-related flags
 if("${CMAKE_BUILD_TYPE}" STREQUAL "Debug")
   iotjs_add_compile_flags(-DDEBUG -DENABLE_DEBUG_LOG)
-  if(HAS_NO_PIE)
+  if(HAS_NO_PIE AND NOT "${TARGET_OS}" STREQUAL "darwin")
     iotjs_add_link_flags(-no-pie)
   endif()
 endif()


### PR DESCRIPTION
Since there was an osx upgrade on the travis-ci, the build on that target has
failed due to the `-no-pie` flag. With this patch we ignore the `-no-pie` flag on
the osx system.

IoT.js-DCO-1.0-Signed-off-by: Istvan Miklos imiklos2@inf.u-szeged.hu