### PR TITLE
process: Path lookup in "rom" partition for TizenRT

### DIFF
--- a/src/modules/iotjs_module_process.c
+++ b/src/modules/iotjs_module_process.c
@@ -253,8 +253,10 @@ static void SetProcessEnv(jerry_value_t process) {
 
   iotjspath = getenv(IOTJS_MAGIC_STRING_IOTJS_PATH_U);
   if (iotjspath == NULL) {
-#if defined(__NUTTX__) || defined(__TIZENRT__)
+#if defined(__NUTTX__)
     iotjspath = "/mnt/sdcard";
+#elif defined(__TIZENRT__)
+    iotjspath = "/rom";
 #else
     iotjspath = "";
 #endif


### PR DESCRIPTION
There is no sdcard on TizenRT's reference hardware (ARTIK05x),
while TizenRT "iotjs" configuration is enabling a /rom partition.

IoT.js-DCO-1.0-Signed-off-by: Philippe Coval philippe.coval@osg.samsung.com