### PR TITLE
Remove three derivative reqwrap_t structures

### DIFF
--- a/src/iotjs_reqwrap.c
+++ b/src/iotjs_reqwrap.c
@@ -25,6 +25,14 @@ void iotjs_reqwrap_initialize(iotjs_reqwrap_t* reqwrap, jerry_value_t jcallback,
 }
 
 
+void iotjs_reqwrap_create_for_uv_data(uv_req_t* request,
+                                      jerry_value_t jcallback) {
+  IOTJS_ASSERT(request != NULL);
+  iotjs_reqwrap_t* reqwrap = IOTJS_ALLOC(iotjs_reqwrap_t);
+  iotjs_reqwrap_initialize(reqwrap, jcallback, request);
+}
+
+
 void iotjs_reqwrap_destroy(iotjs_reqwrap_t* reqwrap) {
   jerry_release_value(reqwrap->jcallback);
 }

--- a/src/iotjs_reqwrap.h
+++ b/src/iotjs_reqwrap.h
@@ -35,6 +35,8 @@ typedef struct {
 
 void iotjs_reqwrap_initialize(iotjs_reqwrap_t* reqwrap, jerry_value_t jcallback,
                               uv_req_t* request);
+void iotjs_reqwrap_create_for_uv_data(uv_req_t* request,
+                                      jerry_value_t jcallback);
 void iotjs_reqwrap_destroy(iotjs_reqwrap_t* reqwrap);
 
 // To retrieve javascript callback function object.

--- a/src/modules/iotjs_module_tcp.h
+++ b/src/modules/iotjs_module_tcp.h
@@ -42,32 +42,6 @@ iotjs_tcpwrap_t* iotjs_tcpwrap_from_jobject(jerry_value_t jtcp);
 
 uv_tcp_t* iotjs_tcpwrap_tcp_handle(iotjs_tcpwrap_t* tcpwrap);
 
-
-typedef struct {
-  iotjs_reqwrap_t reqwrap;
-  uv_connect_t req;
-} iotjs_connect_reqwrap_t;
-
-iotjs_connect_reqwrap_t* iotjs_connect_reqwrap_create(jerry_value_t jcallback);
-
-
-typedef struct {
-  iotjs_reqwrap_t reqwrap;
-  uv_write_t req;
-} iotjs_write_reqwrap_t;
-
-iotjs_write_reqwrap_t* iotjs_write_reqwrap_create(jerry_value_t jcallback);
-
-
-typedef struct {
-  iotjs_reqwrap_t reqwrap;
-  uv_shutdown_t req;
-} iotjs_shutdown_reqwrap_t;
-
-iotjs_shutdown_reqwrap_t* iotjs_shutdown_reqwrap_create(
-    jerry_value_t jcallback);
-
-
 void AddressToJS(jerry_value_t obj, const sockaddr* addr);
 
 


### PR DESCRIPTION
The following structures were removed:
 * iotjs_connect_reqwrap_t
 * iotjs_shutdown_reqwrap_t
 * iotjs_write_reqwrap_t

Each of these structs had a member of iotjs_reqwrap_t type
and a corresponding uv_req_t typed member. After allocating one such
structure the uv_req_t member's data pointer was set to the
newly allocated structure additionally the iotjs_reqwarp_t
also has a data member initialized to the given un_req_t value.

This created a double "link" to the same structure.
By removing the above mentioned structures the double "link"
can be eliminated. Instead of the structures the corresponding uv
structure is used directly.

Additionally the destroy and After* methods can be merged together.

IoT.js-DCO-1.0-Signed-off-by: Peter Gal pgal.u-szeged@partner.samsung.com