### PR TITLE
tizenrt: Relocate downstream Makefile to config dir (along Kconfig)

### DIFF
--- a/config/tizenrt/Makefile
+++ b/config/tizenrt/Makefile
@@ -1,0 +1,54 @@
+###########################################################################
+#
+# Copyright 2018 Samsung Electronics All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+# either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+#
+###########################################################################
+
+-include $(TOPDIR)/.config
+-include $(TOPDIR)/Make.defs
+
+IOTJS_ROOT_DIR ?= $(TOPDIR)/$(EXTDIR)/iotjs
+IOTJS_BUILD_OPTION ?=
+ifeq ($(CONFIG_DEBUG),y)
+  IOTJS_BUILDTYPE = debug
+else
+  IOTJS_BUILDTYPE = release
+endif
+IOTJS_OS ?= tizenrt
+IOTJS_ARCH ?= arm
+IOTJS_BUILDCONFIG ?= ${IOTJS_ARCH}-${IOTJS_OS}
+IOTJS_LIB_DIR ?= $(IOTJS_ROOT_DIR)/build/${IOTJS_BUILDCONFIG}/$(IOTJS_BUILDTYPE)/lib
+IOTJS_ROOT_DIR ?= .
+IOTJS_PROFILE_FILE ?= ${IOTJS_ROOT_DIR}/test/profiles/tizenrt.profile
+
+all: build
+.PHONY: depend clean distclean
+
+build: $(IOTJS_ROOT_DIR)/tools/build.py ${IOTJS_PROFILE_FILE}
+	$(Q) python $< \
+	--target-arch=$(CONFIG_ARCH) \
+	--target-os=${IOTJS_OS} \
+	--sysroot=$(TOPDIR) --target-board=$(CONFIG_ARCH_BOARD) --jerry-heaplimit=$(CONFIG_IOTJS_JERRY_HEAP) \
+	--buildtype=$(IOTJS_BUILDTYPE) --no-init-submodule $(IOTJS_BUILD_OPTION) \
+	--profile ${IOTJS_PROFILE_FILE}
+	$(Q) cp $(IOTJS_LIB_DIR)/*.a $(IOTJS_ROOT_DIR)
+
+depend:
+
+clean:
+	$(Q) $(call DELDIR, $(IOTJS_ROOT_DIR)/build)
+	$(Q) $(call DELFILE, $(IOTJS_ROOT_DIR)/*.a)
+
+distclean:


### PR DESCRIPTION
[Philippe Coval]

After some (recent) refactoring in build script,
This file was over imported iotjs module in TizenRT.

Like done previously with Kconfig file,
it will be better to minimize downstream patches.

One benefit to have those build related files,
is that then IoT.js can be upgraded into TizenRT
by just cloning iotjs's again into subdir:
TizenRT/external/iotjs

Note: Extra minor changes has been done over TizenRT's patch
to make some options overridable from env var (profile file...)

[Sunghan Chang]

Makefile: move IoT.js-specific build step to IoT.js folder

Because Makefile.unix has TizenRT-common build step,
it is not good including IoT.js-specific step.
Let's add Makefile in IoT.js and execute all of step in it.

Thanks-to: sunghan-chang <sh924.chang@samsung.com>
Change-Id: Iddeb272dc6ad6c283ccad9f92bf02754f9ba3240
Bug-TizenRT: https://github.com/Samsung/TizenRT/pull/2111
Origin: https://github.com/Samsung/TizenRT/commit/bbd3cdbd498ff11eeca3f021496423cc0222497e
Relate-to: https://github.com/Samsung/iotjs/issues/1726
Forwarded: https://github.com/Samsung/iotjs
IoT.js-DCO-1.0-Signed-off-by: Philippe Coval p.coval@samsung.com