### PR TITLE
tizenrt: Add more doxygen info in header

### DIFF
--- a/include/iotjs.h
+++ b/include/iotjs.h
@@ -13,6 +13,19 @@
  * limitations under the License.
  */
 
+/**
+ * @defgroup IOTJS IOTJS
+ * @ingroup IOTJS
+ * @{
+ */
+
+/**
+ * @file iotjs.h
+ * @brief IoT.js is Open Source software under the Apache 2.0 license. Complete license and copyright information can be found within the code.\n\n
+ * Official website : http://iotjs.net\n
+ * Online API Reference : https://github.com/Samsung/iotjs/blob/master/docs/api/IoT.js-API-reference.md\n
+ */
+
 #ifndef IOTJS_IOTJS_H
 #define IOTJS_IOTJS_H
 
@@ -30,3 +43,4 @@ IOTJS_EXTERN_C void iotjs_conf_console_out(int (*fp)(int level, const char* fmt,
                                                      ...));
 
 #endif /* IOTJS_IOTJS_H */
+/** @} */ // end of IOTJS group


### PR DESCRIPTION
[Philippe Coval]

While working along master branches of TizenRT and IoTjs,
I observed that this patch was applied old version,
This harmless change wasn't forwarded upstream,
while can still even apply today.

[Dongeon Kim]

external/iotjs: merge description file

Author: Dongeon Kim <devil.kim@samsung.com>
Change-Id: I30a8e2d8772d7643b2113d7e40f87f885da4f3de
Origin: https://github.com/Samsung/TizenRT/pull/926
Bug-TizenRT: https://github.com/Samsung/TizenRT/pull/2018
Forwarded: https://github.com/samsung/iotjs/pulls
IoT.js-DCO-1.0-Signed-off-by: Philippe Coval p.coval@samsung.com