### PR TITLE
Improve Buffer module internals

### DIFF
--- a/src/js/buffer.js
+++ b/src/js/buffer.js
@@ -13,8 +13,6 @@
  * limitations under the License.
  */
 
-var util = require('util');
-
 
 function checkInt(buffer, value, offset, ext, max, min) {
   if (value > max || value < min)
@@ -49,15 +47,15 @@ function getEncodingType(encoding) {
 // [4] new Buffer(string, encoding)
 // [5] new Buffer(array)
 function Buffer(subject, encoding) {
-  if (!util.isBuffer(this)) {
+  if (!Buffer.isBuffer(this)) {
     return new Buffer(subject, encoding);
   }
 
-  if (util.isNumber(subject)) {
+  if (typeof subject === 'number') {
     this.length = subject > 0 ? subject >>> 0 : 0;
-  } else if (util.isString(subject)) {
+  } else if (typeof subject === 'string') {
     this.length = Buffer.byteLength(subject, encoding);
-  } else if (util.isBuffer(subject) || util.isArray(subject)) {
+  } else if (Buffer.isBuffer(subject) || Array.isArray(subject)) {
     this.length = subject.length;
   } else {
     throw new TypeError('Bad arguments: Buffer(string|number|Buffer|Array)');
@@ -66,7 +64,7 @@ function Buffer(subject, encoding) {
   // 'native' is the buffer object created via the C API.
   native(this, this.length);
 
-  if (util.isString(subject)) {
+  if (typeof subject === 'string') {
     if (typeof encoding === 'string') {
       encoding = getEncodingType(encoding);
       if (encoding != -1) {
@@ -77,9 +75,9 @@ function Buffer(subject, encoding) {
     } else {
       this.write(subject);
     }
-  } else if (util.isBuffer(subject)) {
+  } else if (Buffer.isBuffer(subject)) {
     subject.copy(this);
-  } else if (util.isArray(subject)) {
+  } else if (Array.isArray(subject)) {
     for (var i = 0; i < this.length; ++i) {
       native.writeUInt8(this, subject[i], i);
     }
@@ -116,14 +114,14 @@ Buffer.byteLength = function(str, encoding) {
 
 // Buffer.concat(list)
 Buffer.concat = function(list) {
-  if (!util.isArray(list)) {
+  if (!Array.isArray(list)) {
     throw new TypeError('Bad arguments: Buffer.concat([Buffer])');
   }
 
   var length = 0;
   var i;
   for (i = 0; i < list.length; ++i) {
-    if (!util.isBuffer(list[i])) {
+    if (!Buffer.isBuffer(list[i])) {
       throw new TypeError('Bad arguments: Buffer.concat([Buffer])');
     }
     length += list[i].length;
@@ -141,12 +139,14 @@ Buffer.concat = function(list) {
 
 
 // Buffer.isBuffer(object)
-Buffer.isBuffer = util.isBuffer;
+Buffer.isBuffer = function(arg) {
+  return arg instanceof Buffer;
+};
 
 
 // buffer.equals(otherBuffer)
 Buffer.prototype.equals = function(otherBuffer) {
-  if (!util.isBuffer(otherBuffer)) {
+  if (!Buffer.isBuffer(otherBuffer)) {
     throw new TypeError('Bad arguments: buffer.equals(Buffer)');
   }
 
@@ -156,7 +156,7 @@ Buffer.prototype.equals = function(otherBuffer) {
 
 // buffer.compare(otherBuffer)
 Buffer.prototype.compare = function(otherBuffer) {
-  if (!util.isBuffer(otherBuffer)) {
+  if (!Buffer.isBuffer(otherBuffer)) {
     throw new TypeError('Bad arguments: buffer.compare(Buffer)');
   }
 
@@ -173,7 +173,7 @@ Buffer.prototype.compare = function(otherBuffer) {
 // * sourceStart - default to 0
 // * sourceEnd - default to buffer.length
 Buffer.prototype.copy = function(target, targetStart, sourceStart, sourceEnd) {
-  if (!util.isBuffer(target)) {
+  if (!Buffer.isBuffer(target)) {
     throw new TypeError('Bad arguments: buff.copy(Buffer)');
   }
 
@@ -196,7 +196,7 @@ Buffer.prototype.copy = function(target, targetStart, sourceStart, sourceEnd) {
 // * offset - default to 0
 // * length - default to buffer.length - offset
 Buffer.prototype.write = function(string, offset, length, encoding) {
-  if (!util.isString(string)) {
+  if (typeof string !== 'string') {
     throw new TypeError('Bad arguments: buff.write(string)');
   }
 
@@ -334,7 +334,7 @@ Buffer.prototype.readUInt16LE = function(offset, noAssert) {
 
 // buff.fill(value)
 Buffer.prototype.fill = function(value) {
-  if (util.isNumber(value)) {
+  if (typeof value === 'number') {
     value = value & 255;
     for (var i = 0; i < this.length; i++) {
       native.writeUInt8(this, value, i);
@@ -343,6 +343,11 @@ Buffer.prototype.fill = function(value) {
   return this;
 };
 
+/* Register the Buffer object back to the native C
+ * so the other side can get the prototype in a consistent
+ * and safe manner.
+ */
+native.Buffer = Buffer;
 
 module.exports = Buffer;
 module.exports.Buffer = Buffer;

--- a/src/js/util.js
+++ b/src/js/util.js
@@ -13,6 +13,8 @@
  * limitations under the License.
  */
 
+var Buffer = require('buffer');
+
 
 function isNull(arg) {
   return arg === null;
@@ -54,11 +56,6 @@ function isObject(arg) {
 
 function isFunction(arg) {
   return typeof arg === 'function';
-}
-
-
-function isBuffer(arg) {
-  return arg instanceof Buffer;
 }
 
 
@@ -231,7 +228,7 @@ exports.isString = isString;
 exports.isObject = isObject;
 exports.isFinite = isFinite;
 exports.isFunction = isFunction;
-exports.isBuffer = isBuffer;
+exports.isBuffer = Buffer.isBuffer;
 exports.isArray = Array.isArray;
 exports.exceptionWithHostPort = exceptionWithHostPort;
 exports.errnoException = errnoException;

--- a/src/modules/iotjs_module_buffer.c
+++ b/src/modules/iotjs_module_buffer.c
@@ -338,10 +338,9 @@ jerry_value_t iotjs_bufferwrap_create_buffer(size_t len) {
   iotjs_jval_set_property_number(jres_buffer, IOTJS_MAGIC_STRING_LENGTH, len);
 
   // Support for 'instanceof' operator
-  jerry_value_t jglobal = jerry_get_global_object();
+  jerry_value_t native_buffer = iotjs_module_get("buffer");
   jerry_value_t jbuffer =
-      iotjs_jval_get_property(jglobal, IOTJS_MAGIC_STRING_BUFFER);
-  jerry_release_value(jglobal);
+      iotjs_jval_get_property(native_buffer, IOTJS_MAGIC_STRING_BUFFER);
 
   if (!jerry_value_is_error(jbuffer) && jerry_value_is_object(jbuffer)) {
     jerry_value_t jbuffer_proto =

--- a/test/run_pass/test_buffer_inmutability_creation.js
+++ b/test/run_pass/test_buffer_inmutability_creation.js
@@ -1,0 +1,41 @@
+/* Copyright 2018-present Samsung Electronics Co., Ltd. and other contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/* Related issue: https://github.com/Samsung/iotjs/issues/1379 */
+
+var assert = require('assert');
+
+/* The global Buffer by default is a function */
+assert.strictEqual(typeof(Buffer), "function");
+
+var backup_buffer = Buffer;
+
+/* Modify the global Buffer */
+Buffer++;
+
+/**
+ * The ++ operation will change the value of the "Buffer" variable.
+ * Thus the type shouldn't be a function now.
+ */
+assert.notStrictEqual(typeof(Buffer), "function");
+
+/**
+ * Still the creation of buffer should work.
+ * Using an already saved buffer reference
+ */
+var new_buffer = backup_buffer("OK");
+
+assert.equal(new_buffer.length, 2);
+assert.equal(new_buffer.toString(), "OK");

--- a/test/testsets.json
+++ b/test/testsets.json
@@ -47,6 +47,9 @@
       "name": "test_buffer_str_conv.js"
     },
     {
+      "name": "test_buffer_inmutability_creation.js"
+    },
+    {
       "name": "test_console.js",
       "required-modules": [
         "console"


### PR DESCRIPTION
Main points of the change:
* The iotjs_bufferwrap_create_buffer method required
  the global object's Buffer property correctness.
  However by doing a "Buffer++" the global property
  will be changed and the new buffer's prototype will
  be set incorrect. This change exposes the JS side Buffer
  for the C side via the 'native.Buffer' property and as
  the native objects are not as accessible as global properties
  modifying the global buffer will not affect the C side.

* The util.isBuffer used the global's Buffer value, however
  it can also be changed via the "Buffer++" code.
  The isBuffer implementation is moved into the Buffer module.
  However, if the util module should not call require for the
  buffer module because that would cause a cyclical reference as
  the buffer module already requires the util module.

* Removed buffer module's dependency on the util module and
  the util module includes the buffer module to expose the isBuffer
  method.