### PR TITLE
Fix unwanted error message, when using --help

### DIFF
--- a/src/iotjs.c
+++ b/src/iotjs.c
@@ -226,7 +226,6 @@ int iotjs_entry(int argc, char** argv) {
   iotjs_environment_t* env = iotjs_environment_get();
   if (!iotjs_environment_parse_command_line_arguments(env, (uint32_t)argc,
                                                       argv)) {
-    DLOG("iotjs_environment_parse_command_line_arguments failed");
     ret_code = 1;
     goto exit;
   }

--- a/src/platform/tizen/iotjs_tizen_service_app.c
+++ b/src/platform/tizen/iotjs_tizen_service_app.c
@@ -86,7 +86,6 @@ static void loop_method_init_cb(int argc, char** argv, void* data) {
 
   if (!iotjs_environment_parse_command_line_arguments(env, (uint32_t)iotjs_argc,
                                                       iotjs_argv)) {
-    DLOG("iotjs_environment_parse_command_line_arguments failed");
     service_app_exit();
     return;
   }


### PR DESCRIPTION
Using `/build/x86_64-linux/debug/bin/iotjs --help` resulted in an unwanted error message: `[ERR] iotjs_environment_parse_command_line_arguments failed`. This PR fixes the issue.

IoT.js-DCO-1.0-Signed-off-by: Bela Toth tbela@inf.u-szeged.hu