### PR TITLE
Improve JerryScript native object access

### DIFF
--- a/src/iotjs_binding.c
+++ b/src/iotjs_binding.c
@@ -341,12 +341,17 @@ jerry_value_t iotjs_jval_get_property(jerry_value_t jobj, const char* name) {
 }
 
 
-uintptr_t iotjs_jval_get_object_native_handle(jerry_value_t jobj) {
+void* iotjs_jval_get_object_native_handle(jerry_value_t jobj,
+                                          JNativeInfoType* required_info) {
   IOTJS_ASSERT(jerry_value_is_object(jobj));
 
-  uintptr_t ptr = 0x0;
+  void* ptr = NULL;
   JNativeInfoType* out_info;
-  jerry_get_object_native_pointer(jobj, (void**)&ptr, &out_info);
+  bool has_p = jerry_get_object_native_pointer(jobj, (void**)&ptr, &out_info);
+
+  if (!has_p || (required_info != NULL && out_info != required_info)) {
+    return NULL;
+  }
 
   return ptr;
 }

--- a/src/iotjs_handlewrap.c
+++ b/src/iotjs_handlewrap.c
@@ -50,7 +50,7 @@ iotjs_handlewrap_t* iotjs_handlewrap_from_handle(uv_handle_t* handle) {
 
 iotjs_handlewrap_t* iotjs_handlewrap_from_jobject(jerry_value_t jobject) {
   iotjs_handlewrap_t* handlewrap =
-      (iotjs_handlewrap_t*)(iotjs_jval_get_object_native_handle(jobject));
+      (iotjs_handlewrap_t*)(iotjs_jval_get_object_native_handle(jobject, NULL));
   iotjs_handlewrap_validate(handlewrap);
   return handlewrap;
 }
@@ -104,6 +104,6 @@ void iotjs_handlewrap_close(iotjs_handlewrap_t* handlewrap,
 void iotjs_handlewrap_validate(iotjs_handlewrap_t* handlewrap) {
   IOTJS_ASSERT(handlewrap);
   IOTJS_ASSERT((void*)handlewrap == handlewrap->handle->data);
-  IOTJS_ASSERT((uintptr_t)handlewrap ==
-               iotjs_jval_get_object_native_handle(handlewrap->jobject));
+  IOTJS_ASSERT((void*)handlewrap ==
+               iotjs_jval_get_object_native_handle(handlewrap->jobject, NULL));
 }

--- a/src/modules/iotjs_module_adc.c
+++ b/src/modules/iotjs_module_adc.c
@@ -55,8 +55,8 @@ JS_FUNCTION(AdcCons) {
   // Create ADC object
   const jerry_value_t jadc = JS_GET_THIS();
   iotjs_adc_t* adc = adc_create(jadc);
-  IOTJS_ASSERT(adc ==
-               (iotjs_adc_t*)(iotjs_jval_get_object_native_handle(jadc)));
+  IOTJS_ASSERT(adc == (iotjs_adc_t*)(iotjs_jval_get_object_native_handle(
+                          jadc, &this_module_native_info)));
 
   jerry_value_t jconfig;
   JS_GET_REQUIRED_ARG_VALUE(0, jconfig, IOTJS_MAGIC_STRING_CONFIG, object);

--- a/src/modules/iotjs_module_blehcisocket.c
+++ b/src/modules/iotjs_module_blehcisocket.c
@@ -167,9 +167,10 @@ JS_FUNCTION(BleHciSocketCons) {
   // Create object
   jerry_value_t jblehcisocket = JS_GET_THIS();
   iotjs_blehcisocket_t* blehcisocket = iotjs_blehcisocket_create(jblehcisocket);
-  IOTJS_ASSERT(blehcisocket ==
-               (iotjs_blehcisocket_t*)(iotjs_jval_get_object_native_handle(
-                   jblehcisocket)));
+  IOTJS_ASSERT(
+      blehcisocket ==
+      (iotjs_blehcisocket_t*)(iotjs_jval_get_object_native_handle(jblehcisocket,
+                                                                  NULL)));
   return jerry_create_undefined();
 }
 

--- a/src/modules/iotjs_module_bridge.c
+++ b/src/modules/iotjs_module_bridge.c
@@ -203,10 +203,11 @@ static void iotjs_bridge_call_destroy(iotjs_bridge_call_t* bridgecall) {
 }
 
 static iotjs_bridge_object_t* iotjs_bridge_get_object(jerry_value_t obj_val) {
-  iotjs_bridge_object_t* bridgeobj = NULL;
-  bool is_ok = false;
-  is_ok = jerry_get_object_native_pointer(obj_val, (void**)&bridgeobj, NULL);
-  if (!is_ok) {
+  iotjs_bridge_object_t* bridgeobj =
+      (iotjs_bridge_object_t*)iotjs_jval_get_object_native_handle(obj_val,
+                                                                  NULL);
+
+  if (bridgeobj == NULL) {
     bridgeobj = IOTJS_ALLOC(iotjs_bridge_object_t);
     bridgeobj->jobject = obj_val;
     bridgeobj->calls = NULL;

--- a/src/modules/iotjs_module_buffer.c
+++ b/src/modules/iotjs_module_buffer.c
@@ -42,7 +42,8 @@ iotjs_bufferwrap_t* iotjs_bufferwrap_create(const jerry_value_t jobject,
 
   IOTJS_ASSERT(
       bufferwrap ==
-      (iotjs_bufferwrap_t*)(iotjs_jval_get_object_native_handle(jobject)));
+      (iotjs_bufferwrap_t*)(iotjs_jval_get_object_native_handle(jobject,
+                                                                NULL)));
 
   return bufferwrap;
 }
@@ -55,8 +56,8 @@ static void iotjs_bufferwrap_destroy(iotjs_bufferwrap_t* bufferwrap) {
 
 iotjs_bufferwrap_t* iotjs_bufferwrap_from_jbuffer(const jerry_value_t jbuffer) {
   IOTJS_ASSERT(jerry_value_is_object(jbuffer));
-  iotjs_bufferwrap_t* buffer =
-      (iotjs_bufferwrap_t*)iotjs_jval_get_object_native_handle(jbuffer);
+  iotjs_bufferwrap_t* buffer = (iotjs_bufferwrap_t*)
+      iotjs_jval_get_object_native_handle(jbuffer, &this_module_native_info);
   IOTJS_ASSERT(buffer != NULL);
   return buffer;
 }
@@ -84,13 +85,10 @@ iotjs_bufferwrap_t* iotjs_jbuffer_get_bufferwrap_ptr(
     return NULL;
   }
 
-  void* native_p;
-  const jerry_object_native_info_t* type_p;
-  bool has_native_pointer =
-      jerry_get_object_native_pointer(jbuffer, &native_p, &type_p);
-
-  if (has_native_pointer && type_p == &this_module_native_info) {
-    return (iotjs_bufferwrap_t*)native_p;
+  iotjs_bufferwrap_t* buffer = (iotjs_bufferwrap_t*)
+      iotjs_jval_get_object_native_handle(jbuffer, &this_module_native_info);
+  if (buffer != NULL) {
+    return buffer;
   }
 
   return NULL;

--- a/src/modules/iotjs_module_mqtt.c
+++ b/src/modules/iotjs_module_mqtt.c
@@ -599,14 +599,11 @@ JS_FUNCTION(MqttReceive) {
 
   jerry_value_t jnat = JS_GET_ARG(0, object);
 
-  void *native_p;
-  JNativeInfoType *out_native_info;
-  bool has_p =
-      jerry_get_object_native_pointer(jnat, &native_p, &out_native_info);
-  if (!has_p || out_native_info != &mqttclient_native_info) {
+  iotjs_mqttclient_t *mqttclient = (iotjs_mqttclient_t *)
+      iotjs_jval_get_object_native_handle(jnat, &mqttclient_native_info);
+  if (mqttclient == NULL) {
     return JS_CREATE_ERROR(COMMON, "MQTT native pointer not available");
   }
-  iotjs_mqttclient_t *mqttclient = (iotjs_mqttclient_t *)native_p;
 
   jerry_value_t jbuffer = JS_GET_ARG(1, object);
   iotjs_bufferwrap_t *buff_recv = iotjs_bufferwrap_from_jbuffer(jbuffer);

--- a/src/modules/iotjs_module_tcp.c
+++ b/src/modules/iotjs_module_tcp.c
@@ -223,7 +223,8 @@ static void OnConnection(uv_stream_t* handle, int status) {
     IOTJS_ASSERT(jerry_value_is_object(jclient_tcp));
 
     iotjs_tcpwrap_t* tcp_wrap_client =
-        (iotjs_tcpwrap_t*)(iotjs_jval_get_object_native_handle(jclient_tcp));
+        (iotjs_tcpwrap_t*)(iotjs_jval_get_object_native_handle(
+            jclient_tcp, &this_module_native_info));
 
     uv_stream_t* client_handle =
         (uv_stream_t*)(iotjs_tcpwrap_tcp_handle(tcp_wrap_client));

--- a/src/modules/iotjs_module_timer.c
+++ b/src/modules/iotjs_module_timer.c
@@ -147,7 +147,7 @@ JS_FUNCTION(Timer) {
 
   jerry_value_t jobject = iotjs_timerwrap_jobject(timer_wrap);
   IOTJS_ASSERT(jerry_value_is_object(jobject));
-  IOTJS_ASSERT(iotjs_jval_get_object_native_handle(jtimer) != 0);
+  IOTJS_ASSERT(iotjs_jval_get_object_native_handle(jtimer, NULL) != NULL);
 
   return jerry_create_undefined();
 }

--- a/src/modules/iotjs_module_tls.c
+++ b/src/modules/iotjs_module_tls.c
@@ -293,17 +293,12 @@ JS_FUNCTION(TlsInit) {
 
   // Get context
   jerry_value_t jtls_context = JS_GET_ARG(2, object);
-
-  void *native_ptr;
-  const jerry_object_native_info_t *native_info;
-  bool tls_context_available =
-      jerry_get_object_native_pointer(jtls_context, &native_ptr, &native_info);
-
-  if (!tls_context_available || native_info != &tls_context_native_info) {
+  iotjs_tls_context_t *tls_context = (iotjs_tls_context_t *)
+      iotjs_jval_get_object_native_handle(jtls_context,
+                                          &tls_context_native_info);
+  if (tls_context == NULL) {
     return JS_CREATE_ERROR(COMMON, "secure context not available");
   }
-
-  iotjs_tls_context_t *tls_context = (iotjs_tls_context_t *)native_ptr;
 
   iotjs_tls_t *tls_data = iotjs_tls_create(jtls_socket, tls_context);
 

--- a/src/modules/iotjs_module_websocket.c
+++ b/src/modules/iotjs_module_websocket.c
@@ -111,14 +111,11 @@ static char *iotjs_ws_write_data(char *buff, void *data, size_t size) {
 
 
 static bool iotjs_check_handshake_key(char *server_key, jerry_value_t jsref) {
-  void *native_p;
-  JNativeInfoType *out_native_info;
-  bool has_p =
-      jerry_get_object_native_pointer(jsref, &native_p, &out_native_info);
-  if (!has_p || out_native_info != &wsclient_native_info) {
+  iotjs_wsclient_t *wsclient = (iotjs_wsclient_t *)
+      iotjs_jval_get_object_native_handle(jsref, &wsclient_native_info);
+  if (wsclient == NULL) {
     return false;
   }
-  iotjs_wsclient_t *wsclient = (iotjs_wsclient_t *)native_p;
 
   unsigned char *out_buff = NULL;
   size_t ws_guid_size = strlen(WS_GUID);
@@ -279,14 +276,11 @@ JS_FUNCTION(PrepareHandshakeRequest) {
     return JS_CREATE_ERROR(COMMON, "Invalid host and/or path arguments!");
   };
 
-  void *native_p;
-  JNativeInfoType *out_native_info;
-  bool has_p =
-      jerry_get_object_native_pointer(jsref, &native_p, &out_native_info);
-  if (!has_p || out_native_info != &wsclient_native_info) {
+  iotjs_wsclient_t *wsclient = (iotjs_wsclient_t *)
+      iotjs_jval_get_object_native_handle(jsref, &wsclient_native_info);
+  if (wsclient == NULL) {
     return iotjs_websocket_check_error(WS_ERR_NATIVE_POINTER_ERR);
   }
-  iotjs_wsclient_t *wsclient = (iotjs_wsclient_t *)native_p;
 
   size_t generated_key_len = 0;
   wsclient->generated_key = ws_generate_key(jsref, &generated_key_len);
@@ -502,14 +496,11 @@ JS_FUNCTION(WsReceive) {
 
   jerry_value_t jsref = JS_GET_ARG(0, object);
 
-  void *native_p;
-  JNativeInfoType *out_native_info;
-  bool has_p =
-      jerry_get_object_native_pointer(jsref, &native_p, &out_native_info);
-  if (!has_p || out_native_info != &wsclient_native_info) {
+  iotjs_wsclient_t *wsclient = (iotjs_wsclient_t *)
+      iotjs_jval_get_object_native_handle(jsref, &wsclient_native_info);
+  if (wsclient == NULL) {
     return iotjs_websocket_check_error(WS_ERR_NATIVE_POINTER_ERR);
   }
-  iotjs_wsclient_t *wsclient = (iotjs_wsclient_t *)native_p;
 
   jerry_value_t jbuffer = JS_GET_ARG(1, object);
   iotjs_bufferwrap_t *buffer_wrap = iotjs_bufferwrap_from_jbuffer(jbuffer);


### PR DESCRIPTION
Changes:
* Modified iotjs_jval_get_object_native_handle to accept an additional
  parameter specifying the native pointer's expected info.
  If no info is specified the native pointer is returned in all cases.
* __JS_DECLARE_PTR renamed to JS_DECLARE_PTR.
* From the JS_DECLARE_PTR the direct native pointer access code parts
  are removed and it now uses the modified iotjs_jval_get_object_native_handle.
* Updated modules to use the modified iotjs_jval_get_object_native_handle
  method.

The change reduces the binary code size a bit.