### PR TITLE
Update the version of clang-format from 3.8 to 3.9

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -53,7 +53,7 @@ matrix:
       - RUN_DOCKER=yes
       addons:
         apt:
-          packages: [valgrind, clang-format-3.8]
+          packages: [valgrind, clang-format-3.9]
     - env:
       - JOBNAME="OSX/x86-64 Build & Correctness Tests"
       - OPTS="host-darwin"

--- a/docs/devs/Coding-Style-Guidelines.md
+++ b/docs/devs/Coding-Style-Guidelines.md
@@ -208,7 +208,7 @@ This tool helps you check your code style. You have to install `clang` and `esli
 
 ```bash
 $ sudo apt-get update
-$ sudo apt-get install clang-format-3.8
+$ sudo apt-get install clang-format-3.9
 $ cd iotjs
 $ npm install
 ```

--- a/src/modules/iotjs_module_constants.c
+++ b/src/modules/iotjs_module_constants.c
@@ -14,8 +14,8 @@
  */
 
 #include "iotjs_def.h"
-#include "iotjs_module.h"
 #include "iotjs_compatibility.h"
+#include "iotjs_module.h"
 
 #define SET_CONSTANT(object, constant)                           \
   do {                                                           \

--- a/tools/apt-get-install-deps.sh
+++ b/tools/apt-get-install-deps.sh
@@ -16,4 +16,4 @@
 
 sudo apt-get update -q
 sudo apt-get install -q -y \
-    cmake gcc valgrind clang-format-3.8
+    cmake gcc valgrind clang-format-3.9

--- a/tools/check_tidy.py
+++ b/tools/check_tidy.py
@@ -103,7 +103,7 @@ class ClangFormat(object):
         self._extensions = extensions
         self._skip_files = skip_files
         self._options = options
-        self._check_clang_format("clang-format-3.8")
+        self._check_clang_format("clang-format-3.9")
 
     def _check_clang_format(self, base):
         clang_format = spawn.find_executable(base)


### PR DESCRIPTION
clang-format-3.8 does not available on Ubuntu 18.04 (bionic),
but clang-format-3.9 is available on both Ubuntu 14.04 (trusty),
16.04 (xenial) and 18.04 (bionic).

IoT.js-DCO-1.0-Signed-off-by: László Langó llango.u-szeged@partner.samsung.com