### PR TITLE
Fix not checking if debugger sent no remote source

### DIFF
--- a/src/js/module.js
+++ b/src/js/module.js
@@ -303,6 +303,12 @@ Module.prototype.compile = function(filename, source) {
 Module.runMain = function() {
   if (Builtin.debuggerWaitSource) {
     var sources = Builtin.debuggerGetSource();
+
+    if (sources.length == 0) {
+      var err = new Error('No remote source received!');
+      return process._onUncaughtException(err);
+    }
+
     sources.forEach(function(rModule) {
       Module.remoteCache[rModule[0]] = rModule[1];
     });


### PR DESCRIPTION
There was an assertion failure if IoT.js was started with `--start-debug-server --debugger-wait-source`, but the debugger client sent actually no source.
This patch fixes it.

IoT.js-DCO-1.0-Signed-off-by: Daniel Balla dballa@inf.u-szeged.hu