### PR TITLE
Pass the extra JerryScript build parameters for the snapshot tool build

### DIFF
--- a/cmake/jerry.cmake
+++ b/cmake/jerry.cmake
@@ -32,6 +32,18 @@ ExternalProject_Add(hostjerry
     -DFEATURE_LOGGING=ON
     -DFEATURE_SNAPSHOT_SAVE=${ENABLE_SNAPSHOT}
     -DFEATURE_PROFILE=${FEATURE_PROFILE}
+    ${EXTRA_JERRY_CMAKE_PARAMS}
+
+    # The snapshot tool does not require the system allocator
+    # turn it off by default.
+    #
+    # Additionally this is required if one compiles on a
+    # 64bit system to a 32bit system with system allocator
+    # enabled. This is beacuse on 64bit the system allocator
+    # should not be used as it returns 64bit pointers which
+    # can not be represented correctly in the JerryScript engine
+    # currently.
+    -DFEATURE_SYSTEM_ALLOCATOR=OFF
 )
 set(JERRY_HOST_SNAPSHOT
     ${CMAKE_BINARY_DIR}/${DEPS_HOST_JERRY}/bin/jerry-snapshot)


### PR DESCRIPTION
When using `--jerry-cmake=..` argument for the build script
the arguments were not passed for the snapshot tool.
This could result in an generated incompatible snapshot for the
iotjs binary.

To fix this all `jerry-cmake` params should be passed for the
snapshot tool also.