### PR TITLE
Fix an issue in the http_outgoing module

### DIFF
--- a/src/js/http_outgoing.js
+++ b/src/js/http_outgoing.js
@@ -100,12 +100,8 @@ OutgoingMessage.prototype._send = function(chunk, encoding, callback) {
     callback = encoding;
   }
 
-  if (util.isBuffer(chunk)) {
-    chunk = chunk.toString();
-  }
-
   if (!this._sentHeader) {
-    chunk = this._header + '\r\n' + chunk;
+    this._chunks.push(this._header + '\r\n');
     this._sentHeader = true;
   }
 

--- a/test/run_pass/test_net_http_outgoing_buffer.js
+++ b/test/run_pass/test_net_http_outgoing_buffer.js
@@ -1,0 +1,60 @@
+/* Copyright 2018-present Samsung Electronics Co., Ltd. and other contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+var http = require('http');
+var assert = require('assert');
+
+var clientMessage = new Buffer([0xE6, 0x7F, 0x3, 0x6, 0x7]);
+var serverMessage = new Buffer([0x3, 0x7F, 0x6, 0x7, 0xE6]);
+var serverReceived;
+var clientReceived;
+
+var server = http.createServer(function(req, res) {
+  var received = [];
+  req.on('data', function(data) {
+    received.push(data);
+  });
+  req.on('end', function() {
+    serverReceived = Buffer.concat(received);
+    res.end(serverMessage);
+  });
+}).listen(8383, 5);
+
+var reqOpts = {
+  method: 'POST',
+  port: 8383,
+  path: '/',
+  headers: {'Content-Length': clientMessage.length},
+};
+
+var clientReq = http.request(reqOpts, function(res) {
+  var response = [];
+
+  res.on('data', function(data) {
+    response.push(data);
+  });
+
+  res.on('end', function() {
+    clientReceived = Buffer.concat(response);
+    server.close();
+  });
+});
+
+clientReq.end(clientMessage);
+
+process.on('exit', function() {
+  assert.equal(serverReceived.compare(clientMessage), 0);
+  assert.equal(clientReceived.compare(serverMessage), 0);
+});

--- a/test/testsets.json
+++ b/test/testsets.json
@@ -540,6 +540,12 @@
       ]
     },
     {
+      "name": "test_net_http_outgoing_buffer.js",
+      "required-modules": [
+        "http"
+      ]
+    },
+    {
       "name": "test_net_http_response_twice.js",
       "required-modules": [
         "http",


### PR DESCRIPTION
Giving a Buffer that can't be converted to string to an HTTP Request caused an error, since the implementation tried to convert it to a string.
This patch fixes this issue, allowing binary data to correctly pass through.

IoT.js-DCO-1.0-Signed-off-by: Daniel Balla dballa@inf.u-szeged.hu