### PR TITLE
Fixed style checker on TravisCI after #1755.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -50,7 +50,6 @@ matrix:
     - env:
       - JOBNAME="Misc checks (e.g. style checker)"
       - OPTS="misc"
-      - RUN_DOCKER=yes
       addons:
         apt:
           packages: [valgrind, clang-format-3.9]

--- a/src/iotjs.c
+++ b/src/iotjs.c
@@ -158,7 +158,7 @@ void iotjs_run(iotjs_environment_t* env) {
   if (jerry_value_is_abort(jmain)) {
     iotjs_restart(env, jmain);
   } else if (jerry_value_is_error(jmain) &&
-              !iotjs_environment_is_exiting(env)) {
+             !iotjs_environment_is_exiting(env)) {
     jerry_value_t errval = jerry_get_value_from_error(jmain, false);
     iotjs_uncaught_exception(errval);
     jerry_release_value(errval);

--- a/tools/travis_script.py
+++ b/tools/travis_script.py
@@ -196,8 +196,7 @@ if __name__ == '__main__':
 
     elif test == "misc":
         ex.check_run_cmd('tools/check_signed_off.sh', ['--travis'])
-
-        exec_docker(DOCKER_IOTJS_PATH, ['tools/check_tidy.py'])
+        ex.check_run_cmd('tools/check_tidy.py')
 
     elif test == "external-modules":
         for buildtype in BUILDTYPES:


### PR DESCRIPTION
The style checker job should not run in the docker image, because
it does not contain the 'clang-format-3.9'.

IoT.js-DCO-1.0-Signed-off-by: László Langó llango.u-szeged@partner.samsung.com