### PR TITLE
Add options argument for http createServer

### DIFF
--- a/docs/api/IoT.js-API-HTTP.md
+++ b/docs/api/IoT.js-API-HTTP.md
@@ -14,7 +14,14 @@
 
 IoT.js provides HTTP to support HTTP server and client enabling users to receive/send HTTP request easily.
 
-### http.createServer([requestListener])
+### http.createServer([options][, requestListener])
+* `options` {Object}
+  * `IncomingMessage` {Function} Specifies the `IncomingMessage` constructor to be used when creating an http incoming message object.
+    Useful when extending the original {http.IncommingMessge}.
+    Default: `http.IncommingMessage`.
+  * `ServerResponse` {Function} Specifies the `ServerResponse` constructor to be used when creating the server response object.
+    Useful when extending the original {http.ServerResponse}.
+    Default: 'http.ServerResponse`.
 * `requestListener` {Function}
   * request {http.IncomingMessage}
   * response {http.ServerResponse}

--- a/src/js/http.js
+++ b/src/js/http.js
@@ -15,6 +15,7 @@
 
 var net = require('net');
 var ClientRequest = require('http_client').ClientRequest;
+var IncomingMessage = require('http_incoming').IncomingMessage;
 var HTTPParser = require('http_parser').HTTPParser;
 var HTTPServer = require('http_server');
 var util = require('util');
@@ -30,15 +31,15 @@ exports.request = function(options, cb) {
   return new ClientRequest(options, cb, socket);
 };
 
-function Server(requestListener) {
+function Server(options, requestListener) {
   if (!(this instanceof Server)) {
-    return new Server(requestListener);
+    return new Server(options, requestListener);
   }
 
   net.Server.call(this, {allowHalfOpen: true},
                   HTTPServer.connectionListener);
 
-  HTTPServer.initServer.call(this, {}, requestListener);
+  HTTPServer.initServer.call(this, options, requestListener);
 }
 util.inherits(Server, net.Server);
 
@@ -51,8 +52,8 @@ Server.prototype.setTimeout = function(ms, cb) {
 
 exports.Server = Server;
 
-exports.createServer = function(requestListener) {
-  return new Server(requestListener);
+exports.createServer = function(options, requestListener) {
+  return new Server(options, requestListener);
 };
 
 
@@ -64,3 +65,6 @@ exports.get = function(options, cb) {
   req.end();
   return req;
 };
+
+exports.IncomingMessage = IncomingMessage;
+exports.ServerResponse = HTTPServer.ServerResponse;

--- a/src/js/http_common.js
+++ b/src/js/http_common.js
@@ -24,6 +24,7 @@ exports.createHTTPParser = function(type) {
   parser.OnHeadersComplete = parserOnHeadersComplete;
   parser.OnBody = parserOnBody;
   parser.OnMessageComplete = parserOnMessageComplete;
+  parser._IncomingMessage = IncomingMessage;
   return parser;
 };
 
@@ -58,7 +59,7 @@ function parserOnHeadersComplete(info) {
   }
 
 
-  this.incoming = new IncomingMessage(this.socket);
+  this.incoming = new this._IncomingMessage(this.socket);
   this.incoming.url = url;
   this.incoming.httpVersion = info.http_major + '.' + info.http_minor;
 

--- a/test/run_pass/test_net_http_modified_req_resp.js
+++ b/test/run_pass/test_net_http_modified_req_resp.js
@@ -1,0 +1,113 @@
+/* Copyright 2018-present Samsung Electronics Co., Ltd. and other contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+var assert = require('assert');
+var http = require('http');
+
+var response_message = 'DATA';
+var response_got = 'NOT THIS';
+
+/*
+ * Test if 'subclassing' the IncomingMessage
+ * and ServerResponse is correctly propagated.
+ */
+function newIncomingMessage() {
+  http.IncomingMessage.apply(this, arguments);
+};
+newIncomingMessage.prototype = Object.create(http.IncomingMessage.prototype);
+newIncomingMessage.prototype.extra_field = 'found';
+newIncomingMessage.prototype.waitForBody = function() {
+  var chunks = [];
+  this.on('data', function(chunk) {
+    chunks.push(chunk);
+  });
+  this.on('end', function() {
+    this.emit('full_body', Buffer.concat(chunks));
+  });
+};
+
+
+function newServerResponse() {
+  http.ServerResponse.apply(this, arguments);
+};
+newServerResponse.prototype = Object.create(http.ServerResponse.prototype);
+newServerResponse.prototype.sendJSON = function (obj) {
+  var message_body = JSON.stringify(obj);
+  this.setHeader('Content-Length', message_body.length);
+  this.setHeader('Content-Type', 'application/json');
+  this.writeHead(200);
+  this.end(message_body);
+};
+
+var serveropts = {
+  IncomingMessage: newIncomingMessage,
+  ServerResponse: newServerResponse,
+};
+
+var server = http.createServer(serveropts, function (req, res) {
+  assert.equal(req.method, 'POST', 'Incorrect request method detected');
+  assert.equal(req.url, '/put_msg', 'Incorrect request url detected');
+  assert.assert(req instanceof http.IncomingMessage,
+                'Request is not instance of http.IncomingMessage');
+  assert.assert(req instanceof newIncomingMessage,
+                'Request is not instance of the new Request object');
+  assert.equal(req.extra_field, 'found',
+               'No "extra_field" property on the request instance');
+
+  req.waitForBody();
+  req.on('full_body', function(body) {
+    assert.assert(body instanceof Buffer);
+    assert.equal(body.toString(), 'DEMO');
+
+    res.sendJSON({message: response_message});
+  });
+});
+
+server.listen(3001);
+
+var demo_msg = 'DEMO';
+var options = {
+  method : 'POST',
+  port : 3001,
+  path : '/put_msg',
+  headers: {
+    'Content-Length': demo_msg.length,
+  },
+};
+var req = http.request(options, function (response){
+  var content_type =
+    response.headers['Content-Type'] || response.headers['content-type']
+  assert.equal(content_type, 'application/json',
+               'Incorrect content type returned by the server');
+
+  var chunks = []
+  response.on('data', function(chunk) {
+    chunks.push(chunk);
+  });
+  response.on('end', function() {
+    var body = JSON.parse(Buffer.concat(chunks).toString());
+    assert.assert('message' in body, 'No "message" key in response JSON');
+    response_got = body.message;
+
+    server.close();
+  });
+});
+
+req.end(demo_msg);
+
+process.on('exit', function() {
+  assert.equal(response_got, response_message,
+               'Invalid response returned from the demo server');
+});

--- a/test/run_pass/test_net_http_modified_request.js
+++ b/test/run_pass/test_net_http_modified_request.js
@@ -1,0 +1,104 @@
+/* Copyright 2018-present Samsung Electronics Co., Ltd. and other contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+var assert = require('assert');
+var http = require('http');
+
+var response_message = 'DATA';
+var response_got = 'NOT THIS';
+
+/*
+ * Test if 'subclassing' the IncomingMessage
+ * and ServerResponse is propagated correctly.
+ */
+function newIncomingMessage() {
+  http.IncomingMessage.apply(this, arguments);
+};
+newIncomingMessage.prototype = Object.create(http.IncomingMessage.prototype);
+newIncomingMessage.prototype.extra_field = 'found';
+newIncomingMessage.prototype.waitForBody = function() {
+  var chunks = [];
+  this.on('data', function(chunk) {
+    chunks.push(chunk);
+  });
+  this.on('end', function() {
+    this.emit('full_body', Buffer.concat(chunks));
+  });
+};
+
+
+var serveropts = {
+  IncomingMessage: newIncomingMessage,
+};
+
+var server = http.createServer(serveropts, function (req, res) {
+  assert.equal(req.method, 'POST', 'Incorrect request method detected');
+  assert.equal(req.url, '/put_msg', 'Incorrect request url detected');
+  assert.assert(req instanceof http.IncomingMessage,
+                'Request is not instance of http.IncomingMessage');
+  assert.assert(req instanceof newIncomingMessage,
+                'Request is not instance of the new Request object');
+  assert.equal(req.extra_field, 'found',
+               'No "extra_field" property on the request instance');
+
+  req.waitForBody();
+  req.on('full_body', function(body) {
+    assert.assert(body instanceof Buffer);
+    assert.equal(body.toString(), 'DEMO');
+
+    var message_body = JSON.stringify({message: response_message});
+    res.setHeader('Content-Length', message_body.length);
+    res.setHeader('Content-Type', 'application/json');
+    res.writeHead(200);
+    res.end(message_body);
+  });
+});
+
+server.listen(3001);
+
+var demo_msg = 'DEMO';
+var options = {
+  method : 'POST',
+  port : 3001,
+  path : '/put_msg',
+  headers: {
+    'Content-Length': demo_msg.length,
+  },
+};
+var req = http.request(options, function (response){
+  var content_type =
+    response.headers['Content-Type'] || response.headers['content-type']
+  assert.equal(content_type, 'application/json',
+               'Incorrect content type returned by the server');
+
+  var chunks = []
+  response.on('data', function(chunk) {
+    chunks.push(chunk);
+  });
+  response.on('end', function() {
+    var body = JSON.parse(Buffer.concat(chunks).toString());
+    assert.assert('message' in body, 'No "message" key in response JSON');
+    response_got = body.message;
+
+    server.close();
+  });
+});
+
+req.end(demo_msg);
+
+process.on('exit', function() {
+  assert.equal(response_got, response_message,
+               'Invalid response returned from the demo server');
+});

--- a/test/run_pass/test_net_http_modified_response.js
+++ b/test/run_pass/test_net_http_modified_response.js
@@ -1,0 +1,94 @@
+/* Copyright 2018-present Samsung Electronics Co., Ltd. and other contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+var assert = require('assert');
+var http = require('http');
+
+var response_message = 'DATA';
+var response_got = 'NOT THIS';
+
+/*
+ * Test if 'subclassing' the ServerResponse is propagated correctly.
+ */
+function newServerResponse() {
+  http.ServerResponse.apply(this, arguments);
+};
+newServerResponse.prototype = Object.create(http.ServerResponse.prototype);
+newServerResponse.prototype.sendJSON = function (obj) {
+  var message_body = JSON.stringify(obj);
+  this.setHeader('Content-Length', message_body.length);
+  this.setHeader('Content-Type', 'application/json');
+  this.writeHead(200);
+  this.end(message_body);
+};
+
+var serveropts = {
+  ServerResponse: newServerResponse,
+};
+
+var server = http.createServer(serveropts, function (req, res) {
+  assert.equal(req.method, 'POST', 'Incorrect request method detected');
+  assert.equal(req.url, '/put_msg', 'Incorrect request url detected');
+  assert.assert(req instanceof http.IncomingMessage,
+                'Request is not instance of http.IncomingMessage');
+
+  var chunks = [];
+  req.on('data', function(chunk) {
+    chunks.push(chunk);
+  });
+  req.on('end', function() {
+    var body = Buffer.concat(chunks);
+    assert.equal(body.toString(), 'DEMO');
+
+    res.sendJSON({message: response_message});
+  });
+});
+
+server.listen(3001);
+
+var demo_msg = 'DEMO';
+var options = {
+  method : 'POST',
+  port : 3001,
+  path : '/put_msg',
+  headers: {
+    'Content-Length': demo_msg.length,
+  },
+};
+var req = http.request(options, function (response){
+  var content_type =
+    response.headers['Content-Type'] || response.headers['content-type']
+  assert.equal(content_type, 'application/json',
+               'Incorrect content type returned by the server');
+
+  var chunks = []
+  response.on('data', function(chunk) {
+    chunks.push(chunk);
+  });
+  response.on('end', function() {
+    var body = JSON.parse(Buffer.concat(chunks).toString());
+    assert.assert('message' in body, 'No "message" key in response JSON');
+    response_got = body.message;
+
+    server.close();
+  });
+});
+
+req.end(demo_msg);
+
+process.on('exit', function() {
+  assert.equal(response_got, response_message,
+               'Invalid response returned from the demo server');
+});

--- a/test/run_pass/test_net_https_modified_req_resp.js
+++ b/test/run_pass/test_net_https_modified_req_resp.js
@@ -1,0 +1,119 @@
+/* Copyright 2018-present Samsung Electronics Co., Ltd. and other contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+var assert = require('assert');
+var fs = require('fs');
+var http = require('http');
+var https = require('https');
+
+var response_message = 'DATA';
+var response_got = 'NOT THIS';
+
+/*
+ * Test if 'subclassing' the IncomingMessage
+ * and ServerResponse is correctly propagated.
+ */
+function newIncomingMessage() {
+  http.IncomingMessage.apply(this, arguments);
+};
+newIncomingMessage.prototype = Object.create(http.IncomingMessage.prototype);
+newIncomingMessage.prototype.extra_field = 'found';
+newIncomingMessage.prototype.waitForBody = function() {
+  var chunks = [];
+  this.on('data', function(chunk) {
+    chunks.push(chunk);
+  });
+  this.on('end', function() {
+    this.emit('full_body', Buffer.concat(chunks));
+  });
+};
+
+
+function newServerResponse() {
+  http.ServerResponse.apply(this, arguments);
+};
+newServerResponse.prototype = Object.create(http.ServerResponse.prototype);
+newServerResponse.prototype.sendJSON = function (obj) {
+  var message_body = JSON.stringify(obj);
+  this.setHeader('Content-Length', message_body.length);
+  this.setHeader('Content-Type', 'application/json');
+  this.writeHead(200);
+  this.end(message_body);
+};
+
+var serveropts = {
+  IncomingMessage: newIncomingMessage,
+  ServerResponse: newServerResponse,
+
+  key: fs.readFileSync(process.cwd() + '/resources/my_key.key'),
+  cert: fs.readFileSync(process.cwd() + '/resources/my_crt.crt')
+};
+
+var server = https.createServer(serveropts, function (req, res) {
+  assert.equal(req.method, 'POST', 'Incorrect request method detected');
+  assert.equal(req.url, '/put_msg', 'Incorrect request url detected');
+  assert.assert(req instanceof http.IncomingMessage,
+                'Request is not instance of http.IncomingMessage');
+  assert.assert(req instanceof newIncomingMessage,
+                'Request is not instance of the new Request object');
+  assert.equal(req.extra_field, 'found',
+               'No "extra_field" property on the request instance');
+
+  req.waitForBody();
+  req.on('full_body', function(body) {
+    assert.assert(body instanceof Buffer);
+    assert.equal(body.toString(), 'DEMO');
+
+    res.sendJSON({message: response_message});
+  });
+});
+
+server.listen(3001);
+
+var demo_msg = 'DEMO';
+var options = {
+  method : 'POST',
+  port : 3001,
+  path : '/put_msg',
+  headers: {
+    'Content-Length': demo_msg.length,
+  },
+  rejectUnauthorized: false
+};
+var req = https.request(options, function (response){
+  var content_type =
+    response.headers['Content-Type'] || response.headers['content-type']
+  assert.equal(content_type, 'application/json',
+               'Incorrect content type returned by the server');
+
+  var chunks = []
+  response.on('data', function(chunk) {
+    chunks.push(chunk);
+  });
+  response.on('end', function() {
+    var body = JSON.parse(Buffer.concat(chunks).toString());
+    assert.assert('message' in body, 'No "message" key in response JSON');
+    response_got = body.message;
+
+    server.close();
+  });
+});
+
+req.end(demo_msg);
+
+process.on('exit', function() {
+  assert.equal(response_got, response_message,
+               'Invalid response returned from the demo server');
+});

--- a/test/testsets.json
+++ b/test/testsets.json
@@ -582,6 +582,24 @@
       ]
     },
     {
+      "name": "test_net_http_modified_request.js",
+      "required-modules": [
+        "http"
+      ]
+    },
+    {
+      "name": "test_net_http_modified_response.js",
+      "required-modules": [
+        "http"
+      ]
+    },
+    {
+      "name": "test_net_http_modified_req_resp.js",
+      "required-modules": [
+        "http"
+      ]
+    },
+    {
       "name": "test_net_httpclient_error.js",
       "required-modules": [
         "http"
@@ -636,6 +654,14 @@
     {
       "name": "test_net_https_request_response.js",
       "timeout": 10,
+      "required-modules": [
+        "https",
+        "http",
+        "net"
+      ]
+    },
+    {
+      "name": "test_net_https_modified_req_resp.js",
       "required-modules": [
         "https",
         "http",


### PR DESCRIPTION
Improve compatibility with node.js by adding the `options`
argument for the createServer method in the http modules.

In addition allow "subclassing" the http.Incoming and httpServerResponse
objects. With this it is possible to augment the created request and
response objects passed for the `requestListener` method.