### PR TITLE
Fix http.METHODS property value

### DIFF
--- a/docs/api/IoT.js-API-HTTP.md
+++ b/docs/api/IoT.js-API-HTTP.md
@@ -82,7 +82,9 @@ http.get({
 
 
 ### http.METHODS
-A list of HTTP methods supported by the parser as `string` properties of an `Object`.
+* {string[]}
+
+A list of HTTP methods supported by the parser as a `string` array.
 
 ## Class: http.Server
 

--- a/src/js/http.js
+++ b/src/js/http.js
@@ -15,7 +15,7 @@
 
 var net = require('net');
 var ClientRequest = require('http_client').ClientRequest;
-var HTTPParser = require('http_parser');
+var HTTPParser = require('http_parser').HTTPParser;
 var HTTPServer = require('http_server');
 var util = require('util');
 

--- a/src/modules/iotjs_module_http_parser.c
+++ b/src/modules/iotjs_module_http_parser.c
@@ -452,6 +452,24 @@ JS_FUNCTION(HTTPParserCons) {
   return jerry_create_undefined();
 }
 
+static void http_parser_register_methods_object(jerry_value_t target) {
+  jerry_value_t methods = jerry_create_array(26);
+
+  jerry_value_t method_name;
+  uint32_t idx = 0;
+#define V(num, name, string)                                         \
+  do {                                                               \
+    method_name = jerry_create_string((const jerry_char_t*)#string); \
+    jerry_set_property_by_index(methods, idx++, method_name);        \
+    jerry_release_value(method_name);                                \
+  } while (0);
+
+  HTTP_METHOD_MAP(V)
+#undef V
+
+  iotjs_jval_set_property_jval(target, IOTJS_MAGIC_STRING_METHODS, methods);
+  jerry_release_value(methods);
+}
 
 jerry_value_t InitHttpParser() {
   jerry_value_t http_parser = jerry_create_object();
@@ -465,14 +483,7 @@ jerry_value_t InitHttpParser() {
   iotjs_jval_set_property_number(jParserCons, IOTJS_MAGIC_STRING_RESPONSE_U,
                                  HTTP_RESPONSE);
 
-  jerry_value_t methods = jerry_create_object();
-#define V(num, name, string) \
-  iotjs_jval_set_property_string_raw(methods, #num, #string);
-  HTTP_METHOD_MAP(V)
-#undef V
-
-  iotjs_jval_set_property_jval(jParserCons, IOTJS_MAGIC_STRING_METHODS,
-                               methods);
+  http_parser_register_methods_object(jParserCons);
 
   jerry_value_t prototype = jerry_create_object();
 
@@ -485,7 +496,6 @@ jerry_value_t InitHttpParser() {
                                prototype);
 
   jerry_release_value(jParserCons);
-  jerry_release_value(methods);
   jerry_release_value(prototype);
 
   return http_parser;

--- a/test/run_pass/test_net_http_methods.js
+++ b/test/run_pass/test_net_http_methods.js
@@ -1,0 +1,33 @@
+/* Copyright 2018-present Samsung Electronics Co., Ltd. and other contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+var assert = require('assert');
+var http = require('http');
+
+assert(http.METHODS instanceof Array, 'http.METHODS should be an array');
+
+for (var idx in http.METHODS) {
+  assert(typeof(http.METHODS[idx]) === 'string',
+         'Elements of the http.METHODS should be strings. ' +
+         'Found an invalid element, index: ' + idx);
+}
+
+/* Test if at least the basic HTTP methods should be supported */
+var main_methods = ['GET', 'POST', 'PUT', 'DELETE', 'HEAD'];
+for (var idx in main_methods) {
+  var method_name = main_methods[idx];
+  assert.notEqual(http.METHODS.indexOf(method_name), -1,
+                 'http.METHODS is missing the value: ' + method_name);
+}

--- a/test/testsets.json
+++ b/test/testsets.json
@@ -546,6 +546,12 @@
       ]
     },
     {
+      "name": "test_net_http_methods.js",
+      "required-modules": [
+        "http"
+      ]
+    },
+    {
       "name": "test_net_http_response_twice.js",
       "required-modules": [
         "http",


### PR DESCRIPTION
The http.METHODS property returned an "undefined" value
as it was incorrectly connected to the http_parser's methods property.

Changes made:
* The http.METHODS property correctly returns the list of methods
  processed by the http parser.
* Change the storage of the METHODS value. Now it returns a list of
  strings containing the methods.
* Updated the relevant documentation.
* Added test case for http.METHODS.

The structure of the previous METHODS object:
```js
{
  "0": "DELETE",
  "1": "GET",
  "2": "HEAD",
  // <snip>
  "25": "PURGE",
  "26": "MKCALENDAR"
}
```

The new structure of the METHODS property:
```js
[ "DELETE",
  "GET",
  "HEAD",
  // <snip>
  "PURGE",
  "MKCALENDAR"
]
```

This change aligns the http.METHODS value with node.js.
