### PR TITLE
Remove exports from https which were duplicated from the http module

### DIFF
--- a/docs/api/IoT.js-API-HTTPS.md
+++ b/docs/api/IoT.js-API-HTTPS.md
@@ -53,8 +53,8 @@ var server = https.createServer(options, function(request, response) {
   * `key` {string} Optional file path to private keys for client cert in PEM format.
   * `rejectUnauthorized` {boolean} Optional Specify whether to verify the Server's certificate against CA certificates. WARNING - Making this `false` may be a security risk. **Default:** `true`
 * `callback` {Function}
-  * `response` {https.IncomingMessage}
-* Returns: {https.ClientRequest}
+  * `response` {http.IncomingMessage}
+* Returns: {http.ClientRequest}
 
 Example:
 ```javascript
@@ -87,8 +87,8 @@ Note that in the example `req.end()` was called. With `https.request()` one must
   * `key` {string} Optional file path to private keys for client cert in PEM format.
   * `rejectUnauthorized` {boolean} Optional Specify whether to verify the Server's certificate against CA certificates. WARNING - Making this `false` may be a security risk. **Default:** `true`
 * `callback` {Function}
-  * `response` {https.IncomingMessage}
-* Returns: {https.ClientRequest}
+  * `response` {http.IncomingMessage}
+* Returns: {http.ClientRequest}
 
 Same as `https.request` except that `https.get` automatically call `req.end()` at the end.
 
@@ -102,20 +102,3 @@ https.get({
 ...
 });
 ```
-
-
-### https.METHODS
-A list of HTTPS methods supported by the parser as `string` properties of an `Object`.
-
-
-## Class: https.ClientRequest
-
-This object is created internally and returned from https.request(). It represents an in-progress request whose header has already been queued.
-
-See also: [http.ClientRequest](IoT.js-API-HTTP.md#class-httpclientrequest)
-
-## Class: https.IncomingMessage
-
-This object is created internally and returned to the callback in https.request(). It represents the response sent by a server to a request.
-
-See also: [http.IncomingMessage](IoT.js-API-HTTP.md#class-httpincomingmessage)

--- a/src/js/https.js
+++ b/src/js/https.js
@@ -16,11 +16,8 @@
 var tls = require('tls');
 var net = require('net');
 var ClientRequest = require('http_client').ClientRequest;
-var HTTPParser = require('http_parser');
 var HTTPServer = require('http_server');
 var util = require('util');
-
-exports.ClientRequest = ClientRequest;
 
 exports.request = function(options, cb) {
   options.port = options.port || 443;
@@ -51,8 +48,6 @@ Server.prototype.setTimeout = function(ms, cb) {
 exports.createServer = function(options, requestListener) {
   return new Server(options, requestListener);
 };
-
-exports.METHODS = HTTPParser.methods;
 
 exports.get = function(options, cb) {
   var req = exports.request(options, cb);


### PR DESCRIPTION
Main parts of the change:
* Remove https.METHODS and https.ClientRequest exports.
  These two exports are already accessible via the http module if needed
  and they were already returning the same value.
  Improves node.js compatibility.
* Update documentation so it will refer to http.IncomingMessage
  and http.ClientResponse.
