### PR TITLE
Move test_tls.js skip into iotjs

### DIFF
--- a/test/testsets.json
+++ b/test/testsets.json
@@ -780,6 +780,10 @@
     },
     {
       "name": "test_tls.js",
+      "skip": [
+        "tizenrt"
+      ],
+      "reason": "Error: SSL setup failed (no enough memory for the test)",
       "required-modules": [
         "tls",
         "fs"


### PR DESCRIPTION
The test was removed from js-remote-test, because it fails on all artik053 boards, and before it was locally skipped in the testsystem.

IoT.js-DCO-1.0-Signed-off-by: Bela Toth tbela@inf.u-szeged.hu