### PR TITLE
Fix converions errors in iotjs_module_websocket.c

### DIFF
--- a/src/modules/iotjs_module_websocket.c
+++ b/src/modules/iotjs_module_websocket.c
@@ -207,12 +207,12 @@ static jerry_value_t iotjs_websocket_encode_frame(uint8_t opcode, bool mask,
   if (extended_len_size) {
     if (extended_len_size == 2) {
       uint16_t len = payload_len;
-      *buff_ptr++ = *((int8_t *)&len + 1);
-      *buff_ptr++ = *((int8_t *)&len);
+      *buff_ptr++ = *((char *)&len + 1);
+      *buff_ptr++ = *((char *)&len);
     } else {
       uint64_t len = payload_len;
       for (int8_t i = sizeof(uint64_t) - 1; i >= 0; i--) {
-        *buff_ptr++ = *((int8_t *)&len + i);
+        *buff_ptr++ = *((char *)&len + i);
       }
     }
   }


### PR DESCRIPTION
There are conversion errors if websocket module is enabled in case of TizenRT:
```
iotjs/src/modules/iotjs_module_websocket.c:210:21: error: conversion to 'char' from 'int8_t' may change the sign of the result [-Werror=sign-conversion]
       *buff_ptr++ = *((int8_t *)&len + 1);
                     ^
iotjs/src/modules/iotjs_module_websocket.c:211:21: error: conversion to 'char' from 'int8_t' may change the sign of the result [-Werror=sign-conversion]
       *buff_ptr++ = *((int8_t *)&len);
                     ^
iotjs/src/modules/iotjs_module_websocket.c:215:23: error: conversion to 'char' from 'int8_t' may change the sign of the result [-Werror=sign-conversion]
         *buff_ptr++ = *((int8_t *)&len + i);
                       ^
cc1: all warnings being treated as errors
```
 This patch fixes these errors.