### PR TITLE
Fixed debugger build on TizenRT.

### DIFF
--- a/cmake/iotjs.cmake
+++ b/cmake/iotjs.cmake
@@ -472,6 +472,9 @@ message(STATUS "TARGET_OS                ${TARGET_OS}")
 message(STATUS "TARGET_SYSTEMROOT        ${TARGET_SYSTEMROOT}")
 
 iotjs_add_compile_flags(${IOTJS_MODULE_DEFINES})
+if(FEATURE_DEBUGGER)
+  iotjs_add_compile_flags("-DJERRY_DEBUGGER")
+endif()
 
 # Configure the libiotjs.a
 set(TARGET_STATIC_IOTJS libiotjs)

--- a/cmake/jerry.cmake
+++ b/cmake/jerry.cmake
@@ -99,7 +99,7 @@ if("${CMAKE_BUILD_TYPE}" STREQUAL "Debug")
 endif()
 
 # NuttX is not using the default port implementation of JerryScript
-if("${TARGET_OS}" MATCHES "NUTTX")
+if("${TARGET_OS}" MATCHES "NUTTX|TIZENRT")
   list(APPEND DEPS_LIB_JERRY_ARGS -DJERRY_PORT_DEFAULT=OFF)
 else()
   list(APPEND DEPS_LIB_JERRY_ARGS -DJERRY_PORT_DEFAULT=ON)
@@ -171,7 +171,7 @@ add_dependencies(jerry-ext libjerry)
 set_property(TARGET jerry-ext PROPERTY
   IMPORTED_LOCATION ${CMAKE_BINARY_DIR}/lib/${JERRY_EXT_NAME})
 
-if(NOT "${TARGET_OS}" MATCHES "NUTTX")
+if(NOT "${TARGET_OS}" MATCHES "NUTTX|TIZENRT")
   build_lib_name(JERRY_PORT_NAME jerry-port)
   build_lib_name(JERRY_PORT_DEFAULT_NAME jerry-port-default)
   set_property(DIRECTORY APPEND PROPERTY

--- a/src/iotjs.c
+++ b/src/iotjs.c
@@ -20,7 +20,7 @@
 #include "iotjs_string_ext.h"
 
 #include "jerryscript-ext/debugger.h"
-#ifndef __NUTTX__
+#if !defined(__NUTTX__) && !defined(__TIZENRT__)
 #include "jerryscript-port-default.h"
 #endif
 #include "jerryscript-port.h"

--- a/src/platform/tizenrt/iotjs_main_tizenrt.c
+++ b/src/platform/tizenrt/iotjs_main_tizenrt.c
@@ -24,6 +24,9 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#ifdef JERRY_DEBUGGER
+#include <time.h>
+#endif /* JERRY_DEBUGGER */
 
 #include "jerryscript-port.h"
 #include "jerryscript.h"
@@ -84,6 +87,16 @@ void jerryx_port_handler_print_char(char c) { /**< the character to print */
   // printf("%c", c);
 } /* jerryx_port_handler_print_char */
 
+#ifdef JERRY_DEBUGGER
+void jerry_port_sleep(uint32_t sleep_time) {
+  nanosleep(
+      &(const struct timespec){
+          (time_t)sleep_time / 1000,
+          ((long int)sleep_time % 1000) * 1000000L /* Seconds, nanoseconds */
+      },
+      NULL);
+} /* jerry_port_sleep */
+#endif /* JERRY_DEBUGGER */
 
 int iotjs_entry(int argc, char **argv);
 int tuv_cleanup(void);


### PR DESCRIPTION
TizenRT should not build the default port implementation of the
JerryScript engine. TizenRT port defines its own port implementation
in the 'iotjs_main_tizenrt.c' file. Added missing 'jerry_port_sleep'
implementation if JerryScript debugger is enabled.

IoT.js-DCO-1.0-Signed-off-by: László Langó llango.u-szeged@partner.samsung.com