### PR TITLE
tizenrt: Disable debugger code if not enabled

### DIFF
--- a/src/iotjs.c
+++ b/src/iotjs.c
@@ -53,6 +53,7 @@ static bool jerry_initialize(iotjs_environment_t* env) {
   // Initialize jerry.
   jerry_init(jerry_flags);
 
+#ifdef JERRY_DEBUGGER
   if (iotjs_environment_config(env)->debugger != NULL) {
     uint16_t port = iotjs_environment_config(env)->debugger->port;
     jerryx_debugger_after_connect(jerryx_debugger_tcp_create(port) &&
@@ -65,6 +66,7 @@ static bool jerry_initialize(iotjs_environment_t* env) {
 
     jerry_debugger_continue();
   }
+#endif
 
   // Set magic strings.
   iotjs_register_jerry_magic_string();


### PR DESCRIPTION
Observed build issue on TizenRT (2.0+):

    iotjs.c:58: undefined reference to `jerryx_debugger_tcp_create'
    iotjs.c:59: undefined reference to `jerryx_debugger_ws_create'
    iotjs.c:58: undefined reference to `jerryx_debugger_after_connect'

The whole part is disabled,
even if only jerry-ext functions are not linked.

This should not cause any issue on earlier versions of TizenRT

Change-Id: Id88c745c9712f6f620bbd200f493397572174ce6
Forwarded: https://github.com/Samsung/iotjs/pull/
Origin: https://github.com/Samsung/iotjs/pull/1749
IoT.js-DCO-1.0-Signed-off-by: Philippe Coval philippe.coval@osg.samsung.com