### PR TITLE
Throw a real error when a built-in module is not found

### DIFF
--- a/src/js/module.js
+++ b/src/js/module.js
@@ -16,7 +16,12 @@
 
 var Builtin = require('builtin');
 var fs = Builtin.require('fs');
-var dynamicloader = Builtin.require('dynamicloader');
+var dynamicloader;
+try {
+  dynamicloader = Builtin.require('dynamicloader');
+} catch (e) {
+  // the 'dynamicloader' module is not enabled, nothing to do.
+}
 
 function normalizePathString(path) {
   // Assume all path separators are '/'

--- a/src/modules/iotjs_module_process.c
+++ b/src/modules/iotjs_module_process.c
@@ -158,7 +158,7 @@ JS_FUNCTION(CompileModule) {
   } else if (!jerry_value_is_undefined(native_module_jval)) {
     iotjs_jval_set_property_jval(jmodule, "exports", native_module_jval);
   } else {
-    jres = iotjs_jval_create_error_without_error_flag("Unknown native module");
+    jres = JS_CREATE_ERROR(COMMON, "Unknown native module");
   }
 
   jerry_release_value(jexports);


### PR DESCRIPTION
In case of a built-in js module called require for another
module which does not exists at all, an error object was
returned but it was not thrown.
