### PR TITLE
MQTT merge subscribe and unsubscribe methods

### DIFF
--- a/src/js/mqtt.js
+++ b/src/js/mqtt.js
@@ -340,8 +340,8 @@ MQTTClient.prototype.subscribe = function(topic, options, callback) {
 
   var packet_id = handle.getPacketId();
 
-  // header bits: | 16 bit packet id | 2 bit qos |
-  var header = (packet_id << 2);
+  // header bits: | 2 bit qos | 16 bit packet id |
+  var header = packet_id;
 
   var qos = 0;
 
@@ -352,7 +352,7 @@ MQTTClient.prototype.subscribe = function(topic, options, callback) {
       qos = 0;
     }
 
-    header |= qos;
+    header |= (qos << 16);
   }
 
   var buffer = native.subscribe(topic, header);

--- a/src/modules/iotjs_module_mqtt.h
+++ b/src/modules/iotjs_module_mqtt.h
@@ -25,7 +25,7 @@
  * The types of the control packet.
  * These values determine the aim of the message.
  */
-enum {
+typedef enum {
   CONNECT = 0x1,
   CONNACK = 0x2,
   PUBLISH = 0x3,


### PR DESCRIPTION
The native C subscribe and unsubscribe calls of the MQTT modules were quite
similar. The only differences was the packet type and the extra QoS byte in
case of the subscribe message. By merging the two methods into one a bit of
code size can be reduced.

Main points of changes:
* Created an `iotjs_mqtt_subscribe_handler` method to handle
  subscribe/unsubscribe calls on C side.
* Changed the QoS value encoding on the JS side when sending the value for
  the C native handler.
* Changed the `iotjs_mqtt_control_packet_type` enum variable to be a typedef
  just like the other enums in the `iotjs_module_mqtt.h` file.