### PR TITLE
Modify test_fs_write_stream.js to use writable memory area on TizenRT.

### DIFF
--- a/test/run_pass/test_fs_write_stream.js
+++ b/test/run_pass/test_fs_write_stream.js
@@ -20,7 +20,8 @@ if (fs.createReadStream === undefined || fs.createWriteStream === undefined) {
   process.exit(0);
 }
 
-var outputFile = process.cwd() + '/tmp/test_fs5.txt';
+var dir = (process.platform === 'tizenrt') ? '/mnt/' : process.cwd() + '/tmp/';
+var outputFile = dir + 'test_fs5.txt';
 var testData = 'WriteStream test';
 
 var writableFileStream = fs.createWriteStream(outputFile);

--- a/test/testsets.json
+++ b/test/testsets.json
@@ -293,6 +293,10 @@
     },
     {
       "name": "test_fs_write_stream.js",
+      "skip": [
+        "nuttx"
+      ],
+      "reason": "depends on the type of the memory (testrunner uses Read Only Memory)",
       "required-modules": [
         "fs"
       ]


### PR DESCRIPTION
On TizenRT, only the `/mnt` folder is writable.