### PR TITLE
Fix an issue with writable streams on nuttx platform

### DIFF
--- a/src/js/stream_writable.js
+++ b/src/js/stream_writable.js
@@ -111,10 +111,13 @@ Writable.prototype.end = function(chunk, callback) {
   // Because NuttX cannot poll 'EOF',so forcely raise EOF event.
   if (process.platform === 'nuttx') {
     if (!state.ending) {
+      var eof = '\\e\\n\\d';
       if (util.isNullOrUndefined(chunk)) {
-        chunk = '\\e\\n\\d';
+        chunk = eof;
+      } else if (Buffer.isBuffer(chunk)) {
+        chunk = Buffer.concat([chunk, new Buffer(eof)]);
       } else {
-        chunk += '\\e\\n\\d';
+        chunk += eof;
       }
     }
   }


### PR DESCRIPTION
There's an issue on nuttx systems causing a Buffer to be converted to a string everytime a `Writable stream` ends. This is obviously not a good practice, especially when working with binary buffers.
This patch fixes the issue by differentiating Buffers from strings.

IoT.js-DCO-1.0-Signed-off-by: Daniel Balla dballa@inf.u-szeged.hu