### PR TITLE
Simplify version key in AppVeyor configuration

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,6 +1,4 @@
-version: 1.0.{build}
-pull_requests:
-  do_not_increment_build_number: true
+version: "{build}"
 branches:
   except:
   - coverity_scan


### PR DESCRIPTION
The format `1.0.{build}` is artificial, the 1.0 prefix has no
meaning, `{build}` is enough.

IoT.js-DCO-1.0-Signed-off-by: Akos Kiss akiss@inf.u-szeged.hu